### PR TITLE
add support for system properties in configuration

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -120,6 +120,12 @@
             <version>2.1.4</version>
         </dependency>
 
+        <dependency>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-lang3</artifactId>
+          <version>3.3.2</version>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/broker/src/main/java/org/eclipse/moquette/server/ConfigurationParser.java
+++ b/broker/src/main/java/org/eclipse/moquette/server/ConfigurationParser.java
@@ -25,6 +25,7 @@ import java.text.ParseException;
 import java.util.Map.Entry;
 import java.util.Properties;
 
+import org.apache.commons.lang3.text.StrSubstitutor;
 import org.eclipse.moquette.commons.Constants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -119,8 +120,9 @@ class ConfigurationParser {
                     
                     //split till the first space
                     int deilimiterIdx = line.indexOf(' ');
-                    String key = line.substring(0, deilimiterIdx).trim();
-                    String value = line.substring(deilimiterIdx).trim();
+                    final String key = line.substring(0, deilimiterIdx).trim();
+                    final String valueRaw = line.substring(deilimiterIdx).trim();
+                    final String value = StrSubstitutor.replaceSystemProperties(valueRaw);
                     
                     m_properties.put(key, value);
                 }


### PR DESCRIPTION
Change the configuration parser of the MQTT parser, so we could use
system properties in the value of a configuration key.
The configuration file that the OSGi bundle is using points normally to
${moquette.path}/config/moquette.conf.
So we could use a configuration file that contains an entry e.g.
persistent_store ${moquette.path}/storage/moquette_store.mapdb
So the real location of the configuration and the dabase storage could
be changed for different environments without touching anything else but
a system property.

Signed-off-by: Markus Rathgeb maggu2810@gmail.com
