### PR TITLE
PubRelEncoder to encode following MQTT specification

### DIFF
--- a/netty_parser/src/main/java/org/eclipse/moquette/parser/netty/PubRelEncoder.java
+++ b/netty_parser/src/main/java/org/eclipse/moquette/parser/netty/PubRelEncoder.java
@@ -28,7 +28,7 @@ class PubRelEncoder extends DemuxEncoder<PubRelMessage> {
 
     @Override
     protected void encode(ChannelHandlerContext chc, PubRelMessage msg, ByteBuf out) {
-        out.writeByte(AbstractMessage.PUBREL << 4);
+        out.writeByte(AbstractMessage.PUBREL << 4 | 0x02);
         out.writeBytes(Utils.encodeRemainingLength(2));
         out.writeShort(msg.getMessageID());
     }

--- a/netty_parser/src/test/java/org/eclipse/moquette/parser/netty/PubRelEncoderTest.java
+++ b/netty_parser/src/test/java/org/eclipse/moquette/parser/netty/PubRelEncoderTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2012-2015 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package org.eclipse.moquette.parser.netty;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import org.eclipse.moquette.proto.messages.PubRelMessage;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.eclipse.moquette.parser.netty.TestUtils.mockChannelHandler;
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ * @author kazvictor
+ */
+public class PubRelEncoderTest {
+    ChannelHandlerContext m_mockedContext;
+         
+    @Before
+    public void setUp() {
+        //mock the ChannelHandlerContext to return an UnpooledAllocator
+        m_mockedContext = mockChannelHandler();
+    }
+    
+    @Test
+    public void testHeaderEncode() throws Exception {
+        int messageID = 0xAABB;
+        PubRelEncoder encoder = new PubRelEncoder();
+        PubRelMessage msg = new PubRelMessage();
+        msg.setMessageID(messageID);
+        ByteBuf out = Unpooled.buffer();
+        
+        //Exercise
+        encoder.encode(m_mockedContext, msg, out);
+        
+        //Verify
+        assertEquals(0x62, out.readByte()); //1 byte. See MQTT-3.6.1-1
+        assertEquals(0x02, out.readByte()); //2 byte, length
+        assertEquals((byte)0xAA, out.readByte());
+        assertEquals((byte)0xBB, out.readByte());
+    }
+}


### PR DESCRIPTION
Fixing PubRelEncoder to encode PubRel message flag to match what is in the MQTT specification (both 3.1.1 and 3.1) 
http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718054

See Appendix B: MQTT-3.6.1-1
