### PR TITLE
Add test code for connection timeout. And fix Issue #101.

### DIFF
--- a/broker/src/main/java/org/eclipse/moquette/server/Server.java
+++ b/broker/src/main/java/org/eclipse/moquette/server/Server.java
@@ -93,15 +93,23 @@ public class Server {
             config.setProperty("intercept.handler", handlerProp);
         }
         LOG.info("Persistent store file: " + config.getProperty(PERSISTENT_STORE_PROPERTY_NAME));
-        messaging = SimpleMessaging.getInstance();
+        messaging = createSimpleMessaging();
         messaging.init(config);
 
-        m_acceptor = new NettyAcceptor();
+        m_acceptor = createNettyAcceptor();
         m_acceptor.initialize(messaging, config);
+    }
+
+    protected SimpleMessaging createSimpleMessaging() {
+        return SimpleMessaging.getInstance();
+    }
+
+    protected NettyAcceptor createNettyAcceptor() {
+        return new NettyAcceptor();
     }
     
     public void stopServer() {
-    	LOG.info("Server stopping...");
+        LOG.info("Server stopping...");
         m_acceptor.close();
         messaging.stop();
         LOG.info("Server stopped");

--- a/broker/src/main/java/org/eclipse/moquette/server/ServerChannel.java
+++ b/broker/src/main/java/org/eclipse/moquette/server/ServerChannel.java
@@ -32,4 +32,6 @@ public interface ServerChannel {
     void close(boolean immediately);
     
     void write(Object value);
+    
+    boolean isClosed();
 }

--- a/broker/src/main/java/org/eclipse/moquette/server/netty/NettyAcceptor.java
+++ b/broker/src/main/java/org/eclipse/moquette/server/netty/NettyAcceptor.java
@@ -43,6 +43,7 @@ import java.security.*;
 
 import java.security.cert.CertificateException;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
@@ -119,6 +120,10 @@ public class NettyAcceptor implements ServerAcceptor {
             initializeWSSTransport(messaging, props, sslHandlerFactory);
         }
     }
+    
+    protected long getConnectTimeout() {
+        return Constants.DEFAULT_CONNECT_TIMEOUT * 1000;
+    }
 
     private void initFactory(String host, int port, final PipelineInitializer pipeliner) {
         ServerBootstrap b = new ServerBootstrap();
@@ -158,7 +163,7 @@ public class NettyAcceptor implements ServerAcceptor {
         initFactory(host, port, new PipelineInitializer() {
             @Override
             void init(ChannelPipeline pipeline) {
-                pipeline.addFirst("idleStateHandler", new IdleStateHandler(0, 0, Constants.DEFAULT_CONNECT_TIMEOUT));
+                pipeline.addFirst("idleStateHandler", new IdleStateHandler(0L, 0L, getConnectTimeout(), TimeUnit.MILLISECONDS));
                 pipeline.addAfter("idleStateHandler", "idleEventHandler", new MoquetteIdleTimoutHandler());
                 //pipeline.addLast("logger", new LoggingHandler("Netty", LogLevel.ERROR));
                 pipeline.addFirst("bytemetrics", new BytesMetricsHandler(m_bytesMetricsCollector));
@@ -193,7 +198,7 @@ public class NettyAcceptor implements ServerAcceptor {
                 //pipeline.addLast("webSocketHandler", new WebSocketServerProtocolHandler(null, "mqtt"));
                 pipeline.addLast("ws2bytebufDecoder", new WebSocketFrameToByteBufDecoder());
                 pipeline.addLast("bytebuf2wsEncoder", new ByteBufToWebSocketFrameEncoder());
-                pipeline.addFirst("idleStateHandler", new IdleStateHandler(0, 0, Constants.DEFAULT_CONNECT_TIMEOUT));
+                pipeline.addFirst("idleStateHandler", new IdleStateHandler(0L, 0L, getConnectTimeout(), TimeUnit.MILLISECONDS));
                 pipeline.addAfter("idleStateHandler", "idleEventHandler", new MoquetteIdleTimoutHandler());
                 pipeline.addFirst("bytemetrics", new BytesMetricsHandler(m_bytesMetricsCollector));
                 pipeline.addLast("decoder", new MQTTDecoder());
@@ -222,7 +227,7 @@ public class NettyAcceptor implements ServerAcceptor {
             @Override
             void init(ChannelPipeline pipeline) throws Exception {
                 pipeline.addLast("ssl", sslHandlerFactory.create());
-                pipeline.addFirst("idleStateHandler", new IdleStateHandler(0, 0, Constants.DEFAULT_CONNECT_TIMEOUT));
+                pipeline.addFirst("idleStateHandler", new IdleStateHandler(0L, 0L, getConnectTimeout(), TimeUnit.MILLISECONDS));
                 pipeline.addAfter("idleStateHandler", "idleEventHandler", new MoquetteIdleTimoutHandler());
                 //pipeline.addLast("logger", new LoggingHandler("Netty", LogLevel.ERROR));
                 pipeline.addFirst("bytemetrics", new BytesMetricsHandler(m_bytesMetricsCollector));
@@ -255,7 +260,7 @@ public class NettyAcceptor implements ServerAcceptor {
                 pipeline.addLast("webSocketHandler", new WebSocketServerProtocolHandler("/mqtt", "mqtt mqttv3.1, mqttv3.1.1"));
                 pipeline.addLast("ws2bytebufDecoder", new WebSocketFrameToByteBufDecoder());
                 pipeline.addLast("bytebuf2wsEncoder", new ByteBufToWebSocketFrameEncoder());
-                pipeline.addFirst("idleStateHandler", new IdleStateHandler(0, 0, Constants.DEFAULT_CONNECT_TIMEOUT));
+                pipeline.addFirst("idleStateHandler", new IdleStateHandler(0L, 0L, getConnectTimeout(), TimeUnit.MILLISECONDS));
                 pipeline.addAfter("idleStateHandler", "idleEventHandler", new MoquetteIdleTimoutHandler());
                 pipeline.addFirst("bytemetrics", new BytesMetricsHandler(m_bytesMetricsCollector));
                 pipeline.addLast("decoder", new MQTTDecoder());

--- a/broker/src/main/java/org/eclipse/moquette/server/netty/NettyChannel.java
+++ b/broker/src/main/java/org/eclipse/moquette/server/netty/NettyChannel.java
@@ -70,6 +70,10 @@ public class NettyChannel implements ServerChannel {
         m_channel.writeAndFlush(value);
     }
 
+    public boolean isClosed() {
+        return !m_channel.channel().isActive();
+    }
+
     @Override
     public String toString() {
         String clientID = (String) getAttribute(ATTR_KEY_CLIENTID);

--- a/broker/src/main/java/org/eclipse/moquette/spi/impl/ProtocolProcessor.java
+++ b/broker/src/main/java/org/eclipse/moquette/spi/impl/ProtocolProcessor.java
@@ -158,6 +158,14 @@ class ProtocolProcessor implements EventHandler<ValueEvent> {
     @MQTTMessage(message = ConnectMessage.class)
     void processConnect(ServerChannel session, ConnectMessage msg) {
         LOG.debug("CONNECT for client <{}>", msg.getClientID());
+
+        if (session.isClosed()) {
+            LOG.warn("channel was closed. client <{}>", msg.getClientID());
+            session.close(false);
+            return;
+        }
+
+
         if (msg.getProtocolVersion() != VERSION_3_1 && msg.getProtocolVersion() != VERSION_3_1_1) {
             ConnAckMessage badProto = new ConnAckMessage();
             badProto.setReturnCode(ConnAckMessage.UNNACEPTABLE_PROTOCOL_VERSION);

--- a/broker/src/main/java/org/eclipse/moquette/spi/impl/SimpleMessaging.java
+++ b/broker/src/main/java/org/eclipse/moquette/spi/impl/SimpleMessaging.java
@@ -80,7 +80,8 @@ public class SimpleMessaging implements IMessaging, EventHandler<ValueEvent> {
 
     private static SimpleMessaging INSTANCE;
     
-    private final ProtocolProcessor m_processor = new ProtocolProcessor();
+    private final ProtocolProcessor m_processor = createProtocolProcessor();
+
     private final AnnotationSupport annotationSupport = new AnnotationSupport();
     private boolean benchmarkEnabled = false;
     
@@ -88,7 +89,7 @@ public class SimpleMessaging implements IMessaging, EventHandler<ValueEvent> {
 
     Histogram histogram = new Histogram(5);
     
-    private SimpleMessaging() {
+    SimpleMessaging() {
     }
 
     public static SimpleMessaging getInstance() {
@@ -112,6 +113,10 @@ public class SimpleMessaging implements IMessaging, EventHandler<ValueEvent> {
 
         annotationSupport.processAnnotations(m_processor);
         processInit(configProps);
+    }
+
+    protected ProtocolProcessor createProtocolProcessor() {
+        return new ProtocolProcessor();
     }
 
     private void disruptorPublish(MessagingEvent msgEvent) {
@@ -195,6 +200,7 @@ public class SimpleMessaging implements IMessaging, EventHandler<ValueEvent> {
         m_storageService.initStore();
 
         List<InterceptHandler> observers = new ArrayList<>();
+        initDefaultObservers(observers);
         String interceptorClassName = props.getProperty("intercept.handler");
         if (interceptorClassName != null && !interceptorClassName.isEmpty()) {
             try {
@@ -257,6 +263,9 @@ public class SimpleMessaging implements IMessaging, EventHandler<ValueEvent> {
         m_processor.init(subscriptions, m_storageService, m_sessionsStore, authenticator, allowAnonymous, authorizator, m_interceptor);
     }
     
+    protected void initDefaultObservers(List<InterceptHandler> observers) {
+    }
+
     private Object loadClass(String className, Class<?> cls) {
         Object instance = null;
         try {

--- a/broker/src/test/java/org/eclipse/moquette/server/ServerIntegrationConnectionTimeoutTest.java
+++ b/broker/src/test/java/org/eclipse/moquette/server/ServerIntegrationConnectionTimeoutTest.java
@@ -1,0 +1,164 @@
+package org.eclipse.moquette.server;
+
+import static org.eclipse.moquette.commons.Constants.PERSISTENT_STORE_PROPERTY_NAME;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+
+import org.eclipse.moquette.interception.InterceptHandler;
+import org.eclipse.moquette.interception.messages.InterceptConnectMessage;
+import org.eclipse.moquette.server.config.IConfig;
+import org.eclipse.moquette.server.config.MemoryConfig;
+import org.eclipse.moquette.server.netty.NettyAcceptor;
+import org.eclipse.moquette.spi.impl.DelayedConnectSimpleMessaging;
+import org.eclipse.moquette.spi.impl.SimpleMessaging;
+import org.eclipse.paho.client.mqttv3.IMqttAsyncClient;
+import org.eclipse.paho.client.mqttv3.IMqttToken;
+import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.junit.After;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ServerIntegrationConnectionTimeoutTest {
+    private static final Logger LOG = LoggerFactory.getLogger(ServerIntegrationConnectionTimeoutTest.class);
+
+    Server m_server;
+    IConfig m_config;
+    private InterceptHandler mockInterceptHandler;
+
+    @Test
+    public void shouldNotConnectedConnectionDelayLagerThanConnectionTimeout() throws MqttException, IOException {
+        long connectionDelay = 5L;
+        long connectionTimeout = 1L;
+        startServer(connectionDelay, connectionTimeout);
+        
+        IMqttToken token1 = connect("client1");
+        IMqttToken token2 = connect("client2");
+        IMqttToken token3 = connect("client3");
+        IMqttToken token4 = connect("client4");
+
+        sleep(200L);
+
+        waitForCompletion(token1);
+        waitForCompletion(token2);
+        waitForCompletion(token3);
+        waitForCompletion(token4);
+        
+        verify(mockInterceptHandler, never()).onConnect(any(InterceptConnectMessage.class));
+    }
+
+    @Test
+    public void shouldConnectedConnectionDelaySmallerThanConnectionTimeout() throws MqttException, IOException {
+        long connectionDelay = 1L;
+        long connectionTimeout = 500L;
+        
+        startServer(connectionDelay, connectionTimeout);
+        
+        IMqttToken token1 = connect("client1");
+        IMqttToken token2 = connect("client2");
+        IMqttToken token3 = connect("client3");
+        IMqttToken token4 = connect("client4");
+
+        sleep(200L);
+
+        waitForCompletion(token1);
+        waitForCompletion(token2);
+        waitForCompletion(token3);
+        waitForCompletion(token4);
+        
+        verify(mockInterceptHandler, times(4)).onConnect(any(InterceptConnectMessage.class));
+    }
+
+    private void waitForCompletion(IMqttToken token) throws MqttException {
+        if (token == null) {
+            return;
+        }
+        try {
+            token.waitForCompletion();
+        } catch (Throwable t) {
+            LOG.error("token.waitForCompletion() client[{}] {}", token.getClient(), t);
+            LOG.error("Throwable : ", t);
+        }
+    }
+
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+        }
+    }
+
+    private IMqttToken connect(String clinetId) throws MqttException {
+        IMqttAsyncClient client = new MqttAsyncClient("tcp://127.0.0.1:1883", clinetId, new MemoryPersistence());
+        try {
+            return client.connect();
+        } catch (Throwable t) {
+            LOG.error("client.connect() client[{}] {}", clinetId, t);
+            LOG.error("Throwable : ", t);
+            return null;
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        stopServer();
+    }
+
+    private void stopServer() {
+        if (m_server != null) { 
+            m_server.stopServer();
+        }
+        File dbFile = new File(m_config.getProperty(PERSISTENT_STORE_PROPERTY_NAME));
+        if (dbFile.exists()) {
+            dbFile.delete();
+        }
+    }
+
+    protected void startServer(long connectionDelay, long connectionTimeout) throws IOException {
+        mockInterceptHandler = mock(InterceptHandler.class);
+        m_server = new DelayedConnectionServer(connectionDelay, connectionTimeout);
+        final Properties configProps = IntegrationUtils.prepareTestPropeties();
+        m_config = new MemoryConfig(configProps);
+        m_server.startServer(m_config);
+    }
+
+    private class DelayedConnectionServer extends Server {
+        private final long connectionDelay;
+        private final long connectionTimeout;
+        public DelayedConnectionServer(long connectionDelay, long connectionTimeout) {
+            this.connectionDelay = connectionDelay;
+            this.connectionTimeout = connectionTimeout;
+        }
+        @Override
+        protected NettyAcceptor createNettyAcceptor() {
+            return new NettyAcceptor() {
+                @Override
+                protected long getConnectTimeout() {
+                    return connectionTimeout;
+                }
+            };
+        }
+        @Override
+        protected SimpleMessaging createSimpleMessaging() {
+            return new DelayedConnectSimpleMessaging(connectionDelay) {
+
+                @Override
+                protected void initDefaultObservers(List<InterceptHandler> observers) {
+                    super.initDefaultObservers(observers);
+                    observers.add(mockInterceptHandler);
+                }
+            };
+        }
+    }
+}

--- a/broker/src/test/java/org/eclipse/moquette/spi/impl/DelayedConnectSimpleMessaging.java
+++ b/broker/src/test/java/org/eclipse/moquette/spi/impl/DelayedConnectSimpleMessaging.java
@@ -1,0 +1,26 @@
+package org.eclipse.moquette.spi.impl;
+
+import org.eclipse.moquette.proto.messages.ConnectMessage;
+import org.eclipse.moquette.server.ServerChannel;
+
+public class DelayedConnectSimpleMessaging extends SimpleMessaging {
+    private final long connectDelayMilliseconds;
+    public DelayedConnectSimpleMessaging(long connectDelayMilliseconds) {
+        super();
+        this.connectDelayMilliseconds = connectDelayMilliseconds;
+    }
+    @Override
+    protected ProtocolProcessor createProtocolProcessor() {
+        return new ProtocolProcessor() {
+            @Override
+            @MQTTMessage(message = ConnectMessage.class)
+            void processConnect(ServerChannel session, ConnectMessage msg) {
+                try {
+                    Thread.sleep(connectDelayMilliseconds);
+                } catch (InterruptedException e) {
+                }
+                super.processConnect(session, msg);
+            }
+        };
+    }
+}

--- a/broker/src/test/java/org/eclipse/moquette/spi/impl/DummyChannel.java
+++ b/broker/src/test/java/org/eclipse/moquette/spi/impl/DummyChannel.java
@@ -52,7 +52,7 @@ public class DummyChannel implements ServerChannel {
         m_channelClosed = true;
     }
 
-    boolean isClosed() {
+    public boolean isClosed() {
         return this.m_channelClosed;
     }
 

--- a/broker/src/test/java/org/eclipse/moquette/spi/impl/MockReceiverChannel.java
+++ b/broker/src/test/java/org/eclipse/moquette/spi/impl/MockReceiverChannel.java
@@ -43,6 +43,10 @@ class MockReceiverChannel implements ServerChannel {
     public void close(boolean immediately) {
     }
 
+    public boolean isClosed() {
+        return false;
+    }
+
     public AbstractMessage getMessage() {
         return this.m_receivedMessage;
     }


### PR DESCRIPTION
For fixing Issue #101, refactored many classes. 

Please review following.
- Add factory method for testing.
  - Server.createSimpleMessaging()
  - Server.createNettyAcceptor()
  - SimpleMessaging.createProtocolProcessor()
- Add NettyAcceptor.getConnectTimeout() using IdleStateHandler instance creation for testing.
- Add SimpleMessaging.initDefaultObservers() for testing.
- Change access modifier of SimpleMessaging's default constructor for testing.
- Add test case for connection timeout before processed by ProtocolProcessor.processConnect()
- Add class DelayedConnectSimpleMessaging in src/test/java for emulating timeout in processing CONNECT message.

If you have other opinions in this changes, please comment.
