### PR TITLE
Set maven POM version as constant (fix issue #112)

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -7,7 +7,7 @@
         <!--<relativePath>../pom.xml</relativePath>-->
         <artifactId>moquette-parent</artifactId>
         <groupId>org.eclipse.moquette</groupId>
-        <version>${moquette.version}</version>
+        <version>0.8-SNAPSHOT</version>
     </parent>
 
     <artifactId>moquette-broker</artifactId>
@@ -24,13 +24,13 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>moquette-parser-commons</artifactId>
-            <version>${moquette.version}</version>
+            <version>0.8-SNAPSHOT</version>
         </dependency>
         
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>moquette-netty-parser</artifactId>
-            <version>${moquette.version}</version>
+            <version>0.8-SNAPSHOT</version>
         </dependency>
         
         <!--<dependency>-->

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -6,7 +6,7 @@
         <!--<relativePath>../pom.xml</relativePath>-->
         <artifactId>moquette-parent</artifactId>
         <groupId>org.eclipse.moquette</groupId>
-        <version>${moquette.version}</version>
+        <version>0.8-SNAPSHOT</version>
     </parent>
 
     <artifactId>distribution</artifactId>
@@ -18,19 +18,19 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>moquette-broker</artifactId>
-            <version>${moquette.version}</version>
+            <version>0.8-SNAPSHOT</version>
         </dependency>
 
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>moquette-parser-commons</artifactId>
-            <version>${moquette.version}</version>
+            <version>0.8-SNAPSHOT</version>
         </dependency>
         
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>moquette-netty-parser</artifactId>
-            <version>${moquette.version}</version>
+            <version>0.8-SNAPSHOT</version>
         </dependency>
 
          <dependency>

--- a/embedding_moquette/pom.xml
+++ b/embedding_moquette/pom.xml
@@ -7,7 +7,7 @@
         <!--<relativePath>../pom.xml</relativePath>-->
         <artifactId>moquette-parent</artifactId>
         <groupId>org.eclipse.moquette</groupId>
-        <version>${moquette.version}</version>
+        <version>0.8-SNAPSHOT</version>
     </parent>
 
     <artifactId>moquette-embedded-test</artifactId>

--- a/netty_parser/pom.xml
+++ b/netty_parser/pom.xml
@@ -7,7 +7,7 @@
         <!--<relativePath>../pom.xml</relativePath>-->
         <artifactId>moquette-parent</artifactId>
         <groupId>org.eclipse.moquette</groupId>
-        <version>${moquette.version}</version>
+        <version>0.8-SNAPSHOT</version>
     </parent>
 
     <artifactId>moquette-netty-parser</artifactId>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>moquette-parser-commons</artifactId>
-            <version>${moquette.version}</version>
+            <version>0.8-SNAPSHOT</version>
         </dependency>
         
         <dependency>

--- a/parser_commons/pom.xml
+++ b/parser_commons/pom.xml
@@ -7,7 +7,7 @@
         <!--<relativePath>../pom.xml</relativePath>-->
         <artifactId>moquette-parent</artifactId>
         <groupId>org.eclipse.moquette</groupId>
-        <version>${moquette.version}</version>
+        <version>0.8-SNAPSHOT</version>
     </parent>
 
     <artifactId>moquette-parser-commons</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,14 +9,13 @@
         <target.version>1.7</target.version>
         <bintray.repo>andsel/maven</bintray.repo>
         <bintray.parent.package>org.dna.mqtt.moquette-parent</bintray.parent.package>
-        <moquette.version>0.8-SNAPSHOT</moquette.version>
     </properties>
     
     <groupId>org.eclipse.moquette</groupId>
     <artifactId>moquette-parent</artifactId>
 
     <packaging>pom</packaging>
-    <version>${moquette.version}</version>
+    <version>0.8-SNAPSHOT</version>
     <name>Moquette MQTT parent</name>
     <url>https://github.com/andsel/moquette/</url>
 


### PR DESCRIPTION
This change makes possible to embed moquette-broker with maven.

Versioning can be done easily with maven by using `mvn versions:set` command,
