### PR TITLE
Unable to find org.eclipse.paho.client.mqttv3 dependency

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -147,7 +147,7 @@
         <dependency>
             <groupId>org.eclipse.paho</groupId>
             <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-            <version>1.0.1</version>
+            <version>1.0.2</version>
             <scope>test</scope>
         </dependency>
         


### PR DESCRIPTION
Somehow I cant find the org.eclipse.paho.client.mqttv3 1.0.1 artifact on
the net. If I updated to 1.0.2, then I could package everything.
