### PR TITLE
allow turn off of nonSSL MQTT,  and also accepts empty string to indicate turn off

### DIFF
--- a/broker/src/main/java/io/moquette/server/config/ClasspathConfig.java
+++ b/broker/src/main/java/io/moquette/server/config/ClasspathConfig.java
@@ -43,13 +43,13 @@ public class ClasspathConfig extends IConfig {
         }
         Reader configReader = new InputStreamReader(is);
         ConfigurationParser confParser = new ConfigurationParser();
+        m_properties = confParser.getProperties();
         assignDefaults();
         try {
             confParser.parse(configReader);
         } catch (ParseException pex) {
             LOG.warn("An error occurred in parsing configuration, fallback on default configuration", pex);
         }
-        m_properties = confParser.getProperties();
     }
 
     @Override

--- a/broker/src/main/java/io/moquette/server/config/FilesystemConfig.java
+++ b/broker/src/main/java/io/moquette/server/config/FilesystemConfig.java
@@ -34,13 +34,13 @@ public class FilesystemConfig extends IConfig {
 
     public FilesystemConfig(File file) {
         ConfigurationParser confParser = new ConfigurationParser();
+        m_properties = confParser.getProperties();
         assignDefaults();
         try {
             confParser.parse(file);
         } catch (ParseException pex) {
             LOG.warn("An error occurred in parsing configuration, fallback on default configuration", pex);
         }
-        m_properties = confParser.getProperties();
     }
 
     public FilesystemConfig() {

--- a/broker/src/main/java/io/moquette/server/netty/NettyAcceptor.java
+++ b/broker/src/main/java/io/moquette/server/netty/NettyAcceptor.java
@@ -146,7 +146,12 @@ public class NettyAcceptor implements ServerAcceptor {
     private void initializePlainTCPTransport(final NettyMQTTHandler handler, IConfig props) throws IOException {
         final MoquetteIdleTimeoutHandler timeoutHandler = new MoquetteIdleTimeoutHandler();
         String host = props.getProperty(BrokerConstants.HOST_PROPERTY_NAME);
-        int port = Integer.parseInt(props.getProperty(BrokerConstants.PORT_PROPERTY_NAME));
+        String tcpPortProp = props.getProperty(BrokerConstants.PORT_PROPERTY_NAME);
+        if (tcpPortProp == null || "".equals(tcpPortProp)) {
+            LOG.info("tcp MQTT is disabled because the value for the property with key BrokerConstants.PORT_PROPERTY_NAME is null");
+            return;
+        }
+        int port = Integer.parseInt(tcpPortProp);
         initFactory(host, port, new PipelineInitializer() {
             @Override
             void init(ChannelPipeline pipeline) {
@@ -164,7 +169,7 @@ public class NettyAcceptor implements ServerAcceptor {
     
     private void initializeWebSocketTransport(final NettyMQTTHandler handler, IConfig props) throws IOException {
         String webSocketPortProp = props.getProperty(BrokerConstants.WEB_SOCKET_PORT_PROPERTY_NAME);
-        if (webSocketPortProp == null) {
+        if (webSocketPortProp == null || "".equals(webSocketPortProp)) {
             //Do nothing no WebSocket configured
             LOG.info("WebSocket is disabled");
             return;
@@ -196,7 +201,7 @@ public class NettyAcceptor implements ServerAcceptor {
     
     private void initializeSSLTCPTransport(final NettyMQTTHandler handler, IConfig props, final SSLContext sslContext) throws IOException {
         String sslPortProp = props.getProperty(BrokerConstants.SSL_PORT_PROPERTY_NAME);
-        if (sslPortProp == null) {
+        if (sslPortProp == null || "".equals(sslPortProp)) {
             //Do nothing no SSL configured
             LOG.info("SSL MQTT is disabled because there is no value in properties for key BrokerConstants.SSL_PORT_PROPERTY_NAME");
             return;
@@ -227,7 +232,7 @@ public class NettyAcceptor implements ServerAcceptor {
 
     private void initializeWSSTransport(final NettyMQTTHandler handler, IConfig props, final SSLContext sslContext) throws IOException {
         String sslPortProp = props.getProperty(BrokerConstants.WSS_PORT_PROPERTY_NAME);
-        if (sslPortProp == null) {
+        if (sslPortProp == null || "".equals(sslPortProp)) {
             //Do nothing no SSL configured
             LOG.info("SSL websocket is disabled because there is no value in properties for key BrokerConstants.WSS_PORT_PROPERTY_NAME");
             return;

--- a/broker/src/test/java/io/moquette/server/config/ClasspathConfigTest.java
+++ b/broker/src/test/java/io/moquette/server/config/ClasspathConfigTest.java
@@ -1,0 +1,19 @@
+package io.moquette.server.config;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import io.moquette.BrokerConstants;
+
+public class ClasspathConfigTest {
+
+	@Test
+	public void testSetProperties() {
+		final IConfig classPathConfig = new ClasspathConfig();
+        assertEquals(""+BrokerConstants.PORT,classPathConfig.getProperty(BrokerConstants.PORT_PROPERTY_NAME));
+        classPathConfig.setProperty(BrokerConstants.PORT_PROPERTY_NAME, "9999");
+        assertEquals("9999",classPathConfig.getProperty(BrokerConstants.PORT_PROPERTY_NAME));
+	}
+
+}


### PR DESCRIPTION
I found I wanted to turn off non-SSL  MQTT

also I found that some properties systems didn't allow null as the value on a put(), so enabled use of the empty string as well.
