### PR TITLE
Add clientID to the IAuthenticator interface

### DIFF
--- a/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessor.java
+++ b/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessor.java
@@ -58,7 +58,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Class responsible to handle the logic of MQTT protocol it's the director of
- * the protocol execution. 
+ * the protocol execution.
  *
  * Used by the front facing class SimpleMessaging.
  *
@@ -167,7 +167,7 @@ public class ProtocolProcessor {
                 failedCredentials(channel);
                 return;
             }
-            if (!m_authenticator.checkValid(msg.getUsername(), pwd)) {
+            if (!m_authenticator.checkValid(msg.getClientID(), msg.getUsername(), pwd)) {
                 failedCredentials(channel);
                 channel.close();
                 return;

--- a/broker/src/main/java/io/moquette/spi/impl/security/AcceptAllAuthenticator.java
+++ b/broker/src/main/java/io/moquette/spi/impl/security/AcceptAllAuthenticator.java
@@ -6,7 +6,7 @@ import io.moquette.spi.security.IAuthenticator;
  * Created by andrea on 8/23/14.
  */
 public class AcceptAllAuthenticator implements IAuthenticator {
-    public boolean checkValid(String username, byte[] password) {
+    public boolean checkValid(String clientId, String username, byte[] password) {
         return true;
     }
 }

--- a/broker/src/main/java/io/moquette/spi/impl/security/DBAuthenticator.java
+++ b/broker/src/main/java/io/moquette/spi/impl/security/DBAuthenticator.java
@@ -63,7 +63,7 @@ public class DBAuthenticator implements IAuthenticator {
     }
 
     @Override
-    public synchronized boolean checkValid(String username, byte[] password) {
+    public synchronized boolean checkValid(String clientId, String username, byte[] password) {
         // Check Username / Password in DB using sqlQuery
         if (username == null || password == null) {
             LOG.info("username or password was null");

--- a/broker/src/main/java/io/moquette/spi/impl/security/FileAuthenticator.java
+++ b/broker/src/main/java/io/moquette/spi/impl/security/FileAuthenticator.java
@@ -106,8 +106,9 @@ public class FileAuthenticator implements IAuthenticator {
             throw new ParseException("Failed to read", 1);
         }
     }
-    
-    public boolean checkValid(String username, byte[] password) {
+
+    @Override
+    public boolean checkValid(String clientId, String username, byte[] password) {
         if (username == null || password == null) {
             LOG.info("username or password was null");
             return false;

--- a/broker/src/main/java/io/moquette/spi/security/IAuthenticator.java
+++ b/broker/src/main/java/io/moquette/spi/security/IAuthenticator.java
@@ -22,5 +22,5 @@ package io.moquette.spi.security;
  */
 public interface IAuthenticator {
 
-    boolean checkValid(String username, byte[] password);
+    boolean checkValid(String clientId, String username, byte[] password);
 }

--- a/broker/src/test/java/io/moquette/server/ConfigurationClassLoaderTest.java
+++ b/broker/src/test/java/io/moquette/server/ConfigurationClassLoaderTest.java
@@ -72,7 +72,7 @@ public class ConfigurationClassLoaderTest implements IAuthenticator, IAuthorizat
     }
 
     @Override
-    public boolean checkValid(String username, byte[] password) {
+    public boolean checkValid(String clientID, String username, byte[] password) {
         return true;
     }
 

--- a/broker/src/test/java/io/moquette/spi/impl/MockAuthenticator.java
+++ b/broker/src/test/java/io/moquette/spi/impl/MockAuthenticator.java
@@ -16,6 +16,7 @@
 package io.moquette.spi.impl;
 
 import java.util.Map;
+import java.util.Set;
 
 import io.moquette.spi.security.IAuthenticator;
 
@@ -25,14 +26,19 @@ import io.moquette.spi.security.IAuthenticator;
  * @author andrea
  */
 class MockAuthenticator implements IAuthenticator {
-    
+
+    private Set<String> m_clientIds;
     private Map<String, byte[]> m_userPwds;
     
-    MockAuthenticator(Map<String, byte[]> userPwds) {
+    MockAuthenticator(Set<String> clientIds, Map<String, byte[]> userPwds) {
+        m_clientIds = clientIds;
         m_userPwds = userPwds;
     }
 
-    public boolean checkValid(String username, byte[] password) {
+    public boolean checkValid(String clientId, String username, byte[] password) {
+        if (!m_clientIds.contains(clientId)) {
+            return false;
+        }
         if (!m_userPwds.containsKey(username)) {
             return false;
         }

--- a/broker/src/test/java/io/moquette/spi/impl/ProtocolProcessorTest.java
+++ b/broker/src/test/java/io/moquette/spi/impl/ProtocolProcessorTest.java
@@ -83,10 +83,13 @@ public class ProtocolProcessorTest {
         m_messagesStore = memStorage.messagesStore();
         m_sessionStore = memStorage.sessionsStore();
         //m_messagesStore.initStore();
-        
+
+        Set<String> clientIds = new HashSet<>();
+        clientIds.add(FAKE_CLIENT_ID);
+        clientIds.add(FAKE_CLIENT_ID2);
         Map<String, byte[]> users = new HashMap<>();
         users.put(TEST_USER, TEST_PWD);
-        m_mockAuthenticator = new MockAuthenticator(users);
+        m_mockAuthenticator = new MockAuthenticator(clientIds, users);
 
         subscriptions = new SubscriptionsStore();
         subscriptions.init(memStorage.sessionsStore());

--- a/broker/src/test/java/io/moquette/spi/impl/security/DBAuthenticatorTest.java
+++ b/broker/src/test/java/io/moquette/spi/impl/security/DBAuthenticatorTest.java
@@ -57,19 +57,19 @@ public class DBAuthenticatorTest {
     @Test
     public void Db_verifyValid() {
         final DBAuthenticator dbAuthenticator = new DBAuthenticator(ORG_H2_DRIVER, JDBC_H2_MEM_TEST, "SELECT PASSWORD FROM ACCOUNT WHERE LOGIN=?", SHA_256);
-        assertTrue(dbAuthenticator.checkValid("dbuser","password".getBytes()));
+        assertTrue(dbAuthenticator.checkValid(null, "dbuser","password".getBytes()));
     }
 
     @Test
     public void Db_verifyInvalidLogin(){
         final DBAuthenticator dbAuthenticator = new DBAuthenticator(ORG_H2_DRIVER, JDBC_H2_MEM_TEST, "SELECT PASSWORD FROM ACCOUNT WHERE LOGIN=?", SHA_256);
-        assertFalse(dbAuthenticator.checkValid("dbuser2","password".getBytes()));
+        assertFalse(dbAuthenticator.checkValid(null, "dbuser2","password".getBytes()));
     }
 
     @Test
     public void Db_verifyInvalidPassword(){
         final DBAuthenticator dbAuthenticator = new DBAuthenticator(ORG_H2_DRIVER, JDBC_H2_MEM_TEST, "SELECT PASSWORD FROM ACCOUNT WHERE LOGIN=?", SHA_256);
-        assertFalse(dbAuthenticator.checkValid("dbuser","wrongPassword".getBytes()));
+        assertFalse(dbAuthenticator.checkValid(null, "dbuser","wrongPassword".getBytes()));
     }
 
 

--- a/broker/src/test/java/io/moquette/spi/impl/security/FileAuthenticatorTest.java
+++ b/broker/src/test/java/io/moquette/spi/impl/security/FileAuthenticatorTest.java
@@ -32,7 +32,7 @@ public class FileAuthenticatorTest {
         String file = getClass().getResource("/password_file.conf").getPath();        
         IAuthenticator auth = new FileAuthenticator(null, file);
         
-        assertTrue(auth.checkValid("testuser", "passwd".getBytes()));
+        assertTrue(auth.checkValid(null, "testuser", "passwd".getBytes()));
     }
     
     @Test
@@ -40,14 +40,14 @@ public class FileAuthenticatorTest {
         String file = getClass().getResource("/password_file.conf").getPath();        
         IAuthenticator auth = new FileAuthenticator(null, file);
         
-        assertFalse(auth.checkValid("testuser2", "passwd".getBytes()));
+        assertFalse(auth.checkValid(null, "testuser2", "passwd".getBytes()));
     }
     
     @Test
     public void loadPasswordFile_verifyDirectoryRef() {
         IAuthenticator auth = new FileAuthenticator("", "");
         
-        assertFalse(auth.checkValid("testuser2", "passwd".getBytes()));
+        assertFalse(auth.checkValid(null, "testuser2", "passwd".getBytes()));
     }
 
 }


### PR DESCRIPTION
I have need for the clientID to be passed into my IAuthenticator implementation. The nodejs MQTT (mosca) supports this in their interface.

This is the "simple" fix which basically breaks compatibility for all IAuthenticator implementations. I updated all those included in this code base, however, of course external users will break upon upgrade.

I am happy to come at this again if you want a more backward compatible solution (I just figured maybe you're okay breaking compatibility at this point given it's still a minor release number... and it's not too hard for someone to update their code to become compatible again).

Let me know.
