### PR TITLE
add/remove InterceptHandlers with server running

### DIFF
--- a/broker/src/main/java/io/moquette/interception/Interceptor.java
+++ b/broker/src/main/java/io/moquette/interception/Interceptor.java
@@ -46,4 +46,8 @@ public interface Interceptor {
     void notifyTopicUnsubscribed(String topic, String clientID, final String username);
 
     void notifyMessageAcknowledged(InterceptAcknowledgedMessage msg);
+
+    boolean addInterceptHandler(InterceptHandler interceptHandler);
+
+    boolean removeInterceptHandler(InterceptHandler interceptHandler);
 }

--- a/broker/src/main/java/io/moquette/server/Server.java
+++ b/broker/src/main/java/io/moquette/server/Server.java
@@ -155,4 +155,19 @@ public class Server {
         m_initialized = false;
         LOG.info("Server stopped");
     }
+
+    public boolean addInterceptHandler(InterceptHandler interceptHandler) {
+        if (!m_initialized) {
+            throw new IllegalStateException("Can't register interceptors on a server that is not yet started");
+        }
+        return m_processor.addInterceptHandler(interceptHandler);
+    }
+
+    public boolean removeInterceptHandler(InterceptHandler interceptHandler) {
+        if (!m_initialized) {
+            throw new IllegalStateException("Can't deregister interceptors from a server that is not yet started");
+        }
+        return m_processor.removeInterceptHandler(interceptHandler);
+    }
+
 }

--- a/broker/src/main/java/io/moquette/spi/impl/BrokerInterceptor.java
+++ b/broker/src/main/java/io/moquette/spi/impl/BrokerInterceptor.java
@@ -23,6 +23,7 @@ import io.moquette.spi.impl.subscriptions.Subscription;
 import io.moquette.parser.proto.messages.PublishMessage;
 
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -36,7 +37,7 @@ final class BrokerInterceptor implements Interceptor {
     private final ExecutorService executor;
 
     BrokerInterceptor(List<InterceptHandler> handlers) {
-        this.handlers = handlers;
+        this.handlers = new CopyOnWriteArrayList<>(handlers);
         executor = Executors.newFixedThreadPool(1);
     }
 
@@ -117,5 +118,15 @@ final class BrokerInterceptor implements Interceptor {
                 }
             });
         }
+    }
+
+    @Override
+    public boolean addInterceptHandler(InterceptHandler interceptHandler) {
+        return this.handlers.add(interceptHandler);
+    }
+
+    @Override
+    public boolean removeInterceptHandler(InterceptHandler interceptHandler) {
+        return this.handlers.remove(interceptHandler);
     }
 }

--- a/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessor.java
+++ b/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessor.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
+import io.moquette.interception.InterceptHandler;
 import io.moquette.server.ConnectionDescriptor;
 import io.moquette.server.netty.AutoFlushHandler;
 import io.moquette.server.netty.NettyUtils;
@@ -774,5 +775,13 @@ public class ProtocolProcessor {
             }
         }
         channel.flush();
+    }
+
+    public boolean addInterceptHandler(InterceptHandler interceptHandler) {
+        return this.m_interceptor.addInterceptHandler(interceptHandler);
+    }
+
+    public boolean removeInterceptHandler(InterceptHandler interceptHandler) {
+        return this.m_interceptor.removeInterceptHandler(interceptHandler);
     }
 }


### PR DESCRIPTION
Proposal for changes to allow for InterceptHandlers to be added to and removed from a running server.

My use case relates to running Moquette in an OSGi container, and other bundles - with their own lifecycle - need to add InterceptHandlers.
