### PR TITLE
dropMessagesInSession for clientId

### DIFF
--- a/MapDBMessagesStore.java
+++ b/MapDBMessagesStore.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2012-2015 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.moquette.spi.persistence;
+
+import io.moquette.spi.IMatchingCondition;
+import io.moquette.spi.IMessagesStore;
+
+import org.mapdb.DB;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * IMessagesStore implementation backed by MapDB.
+ *
+ * @author andrea
+ */
+class MapDBMessagesStore implements IMessagesStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MapDBMessagesStore.class);
+
+    private DB m_db;
+
+    //maps clientID -> guid
+    private ConcurrentMap<String, String> m_retainedStore;
+    //maps guid to message, it's message store
+    private ConcurrentMap<String, IMessagesStore.StoredMessage> m_persistentMessageStore;
+
+
+    MapDBMessagesStore(DB db) {
+        m_db = db;
+    }
+
+    @Override
+    public void initStore() {
+        m_retainedStore = m_db.getHashMap("retained");
+        m_persistentMessageStore = m_db.getHashMap("persistedMessages");
+    }
+
+    @Override
+    public void storeRetained(String topic, String guid) {
+        m_retainedStore.put(topic, guid);
+    }
+
+    @Override
+    public Collection<StoredMessage> searchMatching(IMatchingCondition condition) {
+        LOG.debug("searchMatching scanning all retained messages, presents are {}", m_retainedStore.size());
+
+        List<StoredMessage> results = new ArrayList<>();
+        for (Map.Entry<String, String> entry : m_retainedStore.entrySet()) {
+            final String guid = entry.getValue();
+            StoredMessage storedMsg = m_persistentMessageStore.get(guid);
+            if (condition.match(entry.getKey())) {
+                results.add(storedMsg);
+            }
+        }
+
+        return results;
+    }
+
+    @Override
+    public String storePublishForFuture(StoredMessage evt) {
+        LOG.debug("storePublishForFuture store evt {}", evt);
+        if (evt.getClientID() == null) {
+            LOG.error("persisting a message without a clientID, bad programming error msg: {}", evt);
+            throw new IllegalArgumentException("\"persisting a message without a clientID, bad programming error");
+        }
+        String guid = UUID.randomUUID().toString();
+        evt.setGuid(guid);
+        LOG.debug("storePublishForFuture guid <{}>", guid);
+        m_persistentMessageStore.put(guid, evt);
+        ConcurrentMap<Integer, String> messageIdToGuid = m_db.getHashMap(MapDBSessionsStore.messageId2GuidsMapName(evt.getClientID()));
+        messageIdToGuid.put(evt.getMessageID(), guid);
+        return guid;
+    }
+
+    @Override
+    public List<StoredMessage> listMessagesInSession(Collection<String> guids) {
+        List<StoredMessage> ret = new ArrayList<>();
+        for (String guid : guids) {
+            ret.add(m_persistentMessageStore.get(guid));
+        }
+        return ret;
+    }
+
+    @Override
+    public void dropMessagesInSession(String clientID) {
+        ConcurrentMap<Integer, String> messageIdToGuid=m_db.getHashMap(MapDBSessionsStore.messageId2GuidsMapName(clientID));
+        for(Entry<Integer,String> entry:messageIdToGuid.entrySet()){
+        	String guid=entry.getValue();
+        	m_persistentMessageStore.remove(guid);
+        }
+        messageIdToGuid.clear();
+    }
+
+    @Override
+    public StoredMessage getMessageByGuid(String guid) {
+        return m_persistentMessageStore.get(guid);
+    }
+
+    @Override
+    public void cleanRetained(String topic) {
+        m_retainedStore.remove(topic);
+    }
+}

--- a/broker/src/main/java/io/moquette/spi/ClientSession.java
+++ b/broker/src/main/java/io/moquette/spi/ClientSession.java
@@ -108,7 +108,7 @@ public class ClientSession {
         //update the selected subscriptions if not present or if has a greater qos
         if (existingSub == null || existingSub.getRequestedQos().byteValue() < newSubscription.getRequestedQos().byteValue()) {
             if (existingSub != null) {
-                subscriptions.remove(newSubscription);
+                subscriptions.remove(existingSub);
             }
             subscriptions.add(newSubscription);
             m_sessionsStore.addNewSubscription(newSubscription);

--- a/broker/src/main/java/io/moquette/spi/persistence/MapDBMessagesStore.java
+++ b/broker/src/main/java/io/moquette/spi/persistence/MapDBMessagesStore.java
@@ -17,11 +17,13 @@ package io.moquette.spi.persistence;
 
 import io.moquette.spi.IMatchingCondition;
 import io.moquette.spi.IMessagesStore;
+
 import org.mapdb.DB;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
+import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentMap;
 
 /**
@@ -99,8 +101,14 @@ class MapDBMessagesStore implements IMessagesStore {
 
     @Override
     public void dropMessagesInSession(String clientID) {
-        m_db.getHashMap(MapDBSessionsStore.messageId2GuidsMapName(clientID)).clear();
-        m_persistentMessageStore.remove(clientID);
+        ConcurrentMap<Integer, String> messageIdToGuid=m_db.getHashMap(MapDBSessionsStore.messageId2GuidsMapName(clientID));
+        if(messageIdToGuid!=null&&!messageIdToGuid.isEmpty()){
+        	for(Entry<Integer,String> entry:messageIdToGuid.entrySet()){
+            	String guid=entry.getValue();
+            	m_persistentMessageStore.remove(guid);
+            }
+            messageIdToGuid.clear();
+        }
     }
 
     @Override

--- a/broker/src/main/java/io/moquette/spi/persistence/MapDBMessagesStore.java
+++ b/broker/src/main/java/io/moquette/spi/persistence/MapDBMessagesStore.java
@@ -37,7 +37,7 @@ class MapDBMessagesStore implements IMessagesStore {
 
     private DB m_db;
 
-    //maps clientID -> guid
+    //maps topic -> guid
     private ConcurrentMap<String, String> m_retainedStore;
     //maps guid to message, it's message store
     private ConcurrentMap<String, IMessagesStore.StoredMessage> m_persistentMessageStore;


### PR DESCRIPTION
 clear the m_persistentMessageStore should use message guid to clear the map,not use clientId to clear the map,because we put message in the map use guid for the key
