### PR TITLE
Bugfix for ServerRestartIntegrationTest - Persistence file could not be deleted under Windows

### DIFF
--- a/broker/src/test/java/io/moquette/server/ServerRestartIntegrationTest.java
+++ b/broker/src/test/java/io/moquette/server/ServerRestartIntegrationTest.java
@@ -63,9 +63,9 @@ public class ServerRestartIntegrationTest {
 
     @Before
     public void setUp() throws Exception {
-        startServer();
         String dbPath = IntegrationUtils.localMapDBPath();
         IntegrationUtils.cleanPersistenceFile(dbPath);
+        startServer();
 
         m_subscriber = new MqttClient("tcp://localhost:1883", "Subscriber", s_dataStore);
         m_messageCollector = new MessageCollector();


### PR DESCRIPTION
ServerRestartIntegrationTest failed because the the server was started before trying to delete the persistence files which works on Linux but fails on Windows because the files can't be deleted as they are opened by the server. 
This actually prevented building the broker on Windows because the test failed.
