### PR TITLE
Changing some private classes/methods to public

### DIFF
--- a/broker/src/main/java/io/moquette/server/DefaultMoquetteSslContextCreator.java
+++ b/broker/src/main/java/io/moquette/server/DefaultMoquetteSslContextCreator.java
@@ -37,7 +37,7 @@ import java.security.cert.CertificateException;
  *
  * Created by andrea on 13/12/15.
  */
-class DefaultMoquetteSslContextCreator implements ISslContextCreator {
+public class DefaultMoquetteSslContextCreator implements ISslContextCreator {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultMoquetteSslContextCreator.class);
 

--- a/broker/src/main/java/io/moquette/spi/impl/BrokerInterceptor.java
+++ b/broker/src/main/java/io/moquette/spi/impl/BrokerInterceptor.java
@@ -32,11 +32,11 @@ import java.util.concurrent.Executors;
  *
  * @author Wagner Macedo
  */
-final class BrokerInterceptor implements Interceptor {
+public final class BrokerInterceptor implements Interceptor {
     private final List<InterceptHandler> handlers;
     private final ExecutorService executor;
 
-    BrokerInterceptor(List<InterceptHandler> handlers) {
+    public BrokerInterceptor(List<InterceptHandler> handlers) {
         this.handlers = new CopyOnWriteArrayList<>(handlers);
         executor = Executors.newFixedThreadPool(1);
     }

--- a/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessor.java
+++ b/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessor.java
@@ -114,7 +114,7 @@ public class ProtocolProcessor {
     //maps clientID to Will testament, if specified on CONNECT
     private ConcurrentMap<String, WillMessage> m_willStore = new ConcurrentHashMap<>();
 
-    ProtocolProcessor() {}
+    public ProtocolProcessor() {}
 
 
     public void init(SubscriptionsStore subscriptions, IMessagesStore storageService,
@@ -132,7 +132,7 @@ public class ProtocolProcessor {
         init(subscriptions,storageService,sessionsStore,authenticator,allowAnonymous, allowZeroByteClientId, authorizator,interceptor,null);
     }
 
-    void init(SubscriptionsStore subscriptions, IMessagesStore storageService,
+    public void init(SubscriptionsStore subscriptions, IMessagesStore storageService,
               ISessionsStore sessionsStore,
               IAuthenticator authenticator,
               boolean allowAnonymous, IAuthorizator authorizator, BrokerInterceptor interceptor, String serverPort) {
@@ -152,7 +152,7 @@ public class ProtocolProcessor {
      * @param interceptor to notify events to an intercept handler
      * @param serverPort
      */
-    void init(SubscriptionsStore subscriptions, IMessagesStore storageService,
+    public void init(SubscriptionsStore subscriptions, IMessagesStore storageService,
               ISessionsStore sessionsStore,
               IAuthenticator authenticator,
               boolean allowAnonymous,


### PR DESCRIPTION
To embed moquette's MQTT protocol processor in an external program, some classes and methods are needed to be public. I hope this would be merged in the future release.
