### PR TITLE
Remove compile-time dependency on log4j

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -38,13 +38,6 @@
         </dependency>
         
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.5</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
             <version>${netty.version}</version>
@@ -112,6 +105,13 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.8.2</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.5</version>
             <scope>test</scope>
         </dependency>
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -32,6 +32,13 @@
             <artifactId>slf4j-api</artifactId>
             <version>1.7.5</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.5</version>
+            <scope>runtime</scope>
+        </dependency>
     </dependencies>
 
 

--- a/netty_parser/pom.xml
+++ b/netty_parser/pom.xml
@@ -45,8 +45,15 @@
         
         <dependency>
             <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.6.4</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.6.4</version>
+            <scope>test</scope>
         </dependency>
         
         <dependency>

--- a/osgi_test/pom.xml
+++ b/osgi_test/pom.xml
@@ -60,13 +60,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <version>0.9.20</version>
-            <scope>test</scope>
-        </dependency>
-
        <dependency>
            <groupId>javax.inject</groupId>
            <artifactId>javax.inject</artifactId>


### PR DESCRIPTION
Move log4j dependency from broker to dist - otherwise it is propagate transitively to projects using Moquette as a library.

Also removed redundant logback-core dependency from OSGi tests (it already has logback-classic).