### PR TITLE
The subscriptions tree must be pruned in order to prevent severe performance issues

### DIFF
--- a/broker/src/main/java/io/moquette/connections/IConnectionsManager.java
+++ b/broker/src/main/java/io/moquette/connections/IConnectionsManager.java
@@ -10,12 +10,6 @@ import java.util.Collection;
  *
  */
 public interface IConnectionsManager {
-	/**
-	 * Returns the number of physical connections
-	 * 
-	 * @return
-	 */
-	public int getActiveConnectionsNo();
 
 	/**
 	 * Determines wether a MQTT client is connected to the broker.

--- a/broker/src/main/java/io/moquette/server/ConnectionDescriptorStore.java
+++ b/broker/src/main/java/io/moquette/server/ConnectionDescriptorStore.java
@@ -97,11 +97,6 @@ public class ConnectionDescriptorStore implements IConnectionsManager {
     }
 
     @Override
-    public int getActiveConnectionsNo() {
-        return connectionDescriptors.size();
-    }
-
-    @Override
     public Collection<String> getConnectedClientIds() {
         return connectionDescriptors.keySet();
     }

--- a/broker/src/main/java/io/moquette/server/Server.java
+++ b/broker/src/main/java/io/moquette/server/Server.java
@@ -304,5 +304,12 @@ public class Server {
     public IConnectionsManager getConnectionsManager() {
         return m_processorBootstrapper.getConnectionDescriptors();
     }
+    
+    public int getActiveConnectionsNo() {
+    	if (m_acceptor == null)
+    		return 0;
+    	else
+    		return m_acceptor.getActiveConnectionsNo();
+    }
 
 }

--- a/broker/src/main/java/io/moquette/server/ServerAcceptor.java
+++ b/broker/src/main/java/io/moquette/server/ServerAcceptor.java
@@ -30,4 +30,6 @@ public interface ServerAcceptor {
     void initialize(ProtocolProcessor processor, IConfig props, ISslContextCreator sslCtxCreator) throws IOException;
     
     void close();
+    
+	int getActiveConnectionsNo();
 }

--- a/broker/src/main/java/io/moquette/server/netty/NettyAcceptor.java
+++ b/broker/src/main/java/io/moquette/server/netty/NettyAcceptor.java
@@ -344,6 +344,7 @@ public class NettyAcceptor implements ServerAcceptor {
         return new SslHandler(sslEngine);
     }
     
+    @Override
 	public int getActiveConnectionsNo() {
 		if (handler == null)
 			return 0;

--- a/broker/src/main/java/io/moquette/spi/impl/subscriptions/SubscriptionsStore.java
+++ b/broker/src/main/java/io/moquette/spi/impl/subscriptions/SubscriptionsStore.java
@@ -199,7 +199,7 @@ public class SubscriptionsStore {
         TreeNode newRoot;
         do {
             oldRoot = subscriptions.get();
-            newRoot = oldRoot.removeClientSubscriptions(clientID);
+            newRoot = oldRoot.removeClientSubscriptions(clientID).getNode();
             //spin lock repeating till we can, swap root, if can't swap just re-do the operation
         } while(!subscriptions.compareAndSet(oldRoot, newRoot));
     }


### PR DESCRIPTION
We have detected a severe performance issue in the following scenario:
- clients connect with the cleanSession flag setted to true.
- after establishing a new connection against the broker, clients subscribe to a different MQTT topic of their own. These topics are not shared among clients.

Each time a client disconnects, its subscriptions are removed from the subscription tree. But the nodes remain on the tree with an empty subscriptions list.

When the broker processes a publish message, it traverses the whole subscription tree. The number of empty nodes grows each time a client disconnects, and this increments the time the broker takes to handle a PUBLISH message (from less than 20 ms after starting up the broker to 200 ms after several hours).

This issue also makes the broker vulnerable to very simple DDoS attacks, an can be easily fixed by modifying the SubscriptionsStore and TreeNode classes.