### PR TITLE
Prevent usage of MsgId 0 when wrapping around

### DIFF
--- a/broker/src/main/java/io/moquette/spi/persistence/MapDBSessionsStore.java
+++ b/broker/src/main/java/io/moquette/spi/persistence/MapDBSessionsStore.java
@@ -212,7 +212,7 @@ class MapDBSessionsStore implements ISessionsStore {
         }
 
         int maxId = inFlightForClient.isEmpty() ? 0 : Collections.max(inFlightForClient);
-        int nextPacketId = (maxId + 1) % 0xFFFF;
+        int nextPacketId = (maxId % 0xFFFF) + 1;
         inFlightForClient.add(nextPacketId);
         if (LOG.isDebugEnabled()) {
             LOG.debug("The next packet ID has been generated. CId= {}, result = {}.", clientID, nextPacketId);


### PR DESCRIPTION
The spec says that the message ID has to be non-zero which is not the case in the original code when the counter wraps around. First taking the modulo and then incrementing lets the next id be between 1 and 0xFFFF instead of 0 and 0xFFFF-1