### PR TITLE
IMessagesStore#storeRetained: this method should decide to store QOS0 messages

### DIFF
--- a/broker/src/main/java/io/moquette/interception/messages/InterceptAcknowledgedMessage.java
+++ b/broker/src/main/java/io/moquette/interception/messages/InterceptAcknowledgedMessage.java
@@ -17,15 +17,16 @@
 package io.moquette.interception.messages;
 
 import static io.moquette.spi.IMessagesStore.StoredMessage;
+import io.moquette.spi.impl.subscriptions.Topic;
 
 public class InterceptAcknowledgedMessage implements InterceptMessage {
 
     private final StoredMessage msg;
     private final String username;
-    private final String topic;
+    private final Topic topic;
     private final int packetID;
 
-    public InterceptAcknowledgedMessage(StoredMessage msg, String topic, String username, int packetID) {
+    public InterceptAcknowledgedMessage(StoredMessage msg, Topic topic, String username, int packetID) {
         this.msg = msg;
         this.username = username;
         this.topic = topic;
@@ -40,7 +41,7 @@ public class InterceptAcknowledgedMessage implements InterceptMessage {
         return username;
     }
 
-    public String getTopic() {
+    public Topic getTopic() {
         return topic;
     }
 

--- a/broker/src/main/java/io/moquette/persistence/MemoryMessagesStore.java
+++ b/broker/src/main/java/io/moquette/persistence/MemoryMessagesStore.java
@@ -39,15 +39,15 @@ public class MemoryMessagesStore implements IMessagesStore {
     }
 
     @Override
-    public void storeRetained(Topic topic, StoredMessage msg) {
-        LOG.debug("Store retained message for topic={}, CId={}", topic, msg.getClientID());
+    public void storeRetained(StoredMessage msg) {
+        LOG.debug("Store retained message for topic={}, CId={}", msg.getTopic(), msg.getClientID());
         if (msg.getClientID() == null) {
             throw new IllegalArgumentException("Message to be persisted must have a not null client ID");
         }
         if (msg.getQos() != MqttQoS.AT_MOST_ONCE && msg.getPayloadArray().length > 0)
-            m_retainedStore.put(topic, msg);
+            m_retainedStore.put(msg.getTopic(), msg);
         else
-            cleanRetained(topic);
+            cleanRetained(msg.getTopic());
     }
 
     @Override

--- a/broker/src/main/java/io/moquette/persistence/MemoryMessagesStore.java
+++ b/broker/src/main/java/io/moquette/persistence/MemoryMessagesStore.java
@@ -19,6 +19,7 @@ package io.moquette.persistence;
 import io.moquette.spi.IMatchingCondition;
 import io.moquette.spi.IMessagesStore;
 import io.moquette.spi.impl.subscriptions.Topic;
+import io.netty.handler.codec.mqtt.MqttQoS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,12 +39,15 @@ public class MemoryMessagesStore implements IMessagesStore {
     }
 
     @Override
-    public void storeRetained(Topic topic, StoredMessage storedMessage) {
-        LOG.debug("Store retained message for topic={}, CId={}", topic, storedMessage.getClientID());
-        if (storedMessage.getClientID() == null) {
-            throw new IllegalArgumentException( "Message to be persisted must have a not null client ID");
+    public void storeRetained(Topic topic, StoredMessage msg) {
+        LOG.debug("Store retained message for topic={}, CId={}", topic, msg.getClientID());
+        if (msg.getClientID() == null) {
+            throw new IllegalArgumentException("Message to be persisted must have a not null client ID");
         }
-        m_retainedStore.put(topic, storedMessage);
+        if (msg.getQos() != MqttQoS.AT_MOST_ONCE && msg.getPayloadArray().length > 0)
+            m_retainedStore.put(topic, msg);
+        else
+            cleanRetained(topic);
     }
 
     @Override

--- a/broker/src/main/java/io/moquette/spi/IMessagesStore.java
+++ b/broker/src/main/java/io/moquette/spi/IMessagesStore.java
@@ -33,12 +33,12 @@ public interface IMessagesStore {
         private static final long serialVersionUID = 1755296138639817304L;
         final MqttQoS m_qos;
         final byte[] m_payload;
-        final String m_topic;
+        final Topic m_topic;
         private boolean m_retained;
         private String m_clientID;
         private MessageGUID m_guid;
 
-        public StoredMessage(byte[] message, MqttQoS qos, String topic) {
+        public StoredMessage(byte[] message, MqttQoS qos, Topic topic) {
             m_qos = qos;
             m_payload = message;
             m_topic = topic;
@@ -48,7 +48,7 @@ public interface IMessagesStore {
             return m_qos;
         }
 
-        public String getTopic() {
+        public Topic getTopic() {
             return m_topic;
         }
 

--- a/broker/src/main/java/io/moquette/spi/IMessagesStore.java
+++ b/broker/src/main/java/io/moquette/spi/IMessagesStore.java
@@ -107,5 +107,5 @@ public interface IMessagesStore {
 
     void cleanRetained(Topic topic);
 
-    void storeRetained(Topic topic, StoredMessage msg);
+    void storeRetained(StoredMessage msg);
 }

--- a/broker/src/main/java/io/moquette/spi/IMessagesStore.java
+++ b/broker/src/main/java/io/moquette/spi/IMessagesStore.java
@@ -21,7 +21,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import java.io.Serializable;
-import java.nio.ByteBuffer;
 import java.util.Collection;
 
 /**
@@ -73,6 +72,10 @@ public interface IMessagesStore {
             return Unpooled.copiedBuffer(m_payload);
         }
 
+        public byte[] getPayloadArray() {
+            return m_payload;
+        }
+
         public void setRetained(boolean retained) {
             this.m_retained = retained;
         }
@@ -104,5 +107,5 @@ public interface IMessagesStore {
 
     void cleanRetained(Topic topic);
 
-    void storeRetained(Topic topic, StoredMessage storedMessage);
+    void storeRetained(Topic topic, StoredMessage msg);
 }

--- a/broker/src/main/java/io/moquette/spi/impl/InternalRepublisher.java
+++ b/broker/src/main/java/io/moquette/spi/impl/InternalRepublisher.java
@@ -18,6 +18,7 @@ package io.moquette.spi.impl;
 
 import io.moquette.spi.ClientSession;
 import io.moquette.spi.IMessagesStore;
+import io.moquette.spi.impl.subscriptions.Topic;
 import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.mqtt.*;
 import org.slf4j.Logger;
@@ -89,10 +90,10 @@ class InternalRepublisher {
             packetID);
     }
 
-    public static MqttPublishMessage createPublishForQos(String topic, MqttQoS qos, ByteBuf message, boolean retained,
+    public static MqttPublishMessage createPublishForQos(Topic topic, MqttQoS qos, ByteBuf message, boolean retained,
             int messageId) {
         MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.PUBLISH, false, qos, retained, 0);
-        MqttPublishVariableHeader varHeader = new MqttPublishVariableHeader(topic, messageId);
+        MqttPublishVariableHeader varHeader = new MqttPublishVariableHeader(topic.toString(), messageId);
         return new MqttPublishMessage(fixedHeader, varHeader, message);
     }
 }

--- a/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessor.java
+++ b/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessor.java
@@ -59,19 +59,19 @@ public class ProtocolProcessor {
 
     static final class WillMessage {
 
-        private final String topic;
+        private final Topic topic;
         private final ByteBuffer payload;
         private final boolean retained;
         private final MqttQoS qos;
 
-        WillMessage(String topic, ByteBuffer payload, boolean retained, MqttQoS qos) {
+        WillMessage(Topic topic, ByteBuffer payload, boolean retained, MqttQoS qos) {
             this.topic = topic;
             this.payload = payload;
             this.retained = retained;
             this.qos = qos;
         }
 
-        public String getTopic() {
+        public Topic getTopic() {
             return topic;
         }
 
@@ -394,8 +394,8 @@ public class ProtocolProcessor {
             byte[] willPayload = msg.payload().willMessage().getBytes();
             ByteBuffer bb = (ByteBuffer) ByteBuffer.allocate(willPayload.length).put(willPayload).flip();
             // save the will testament in the clientID store
-            WillMessage will = new WillMessage(msg.payload().willTopic(), bb, msg.variableHeader().isWillRetain(),
-                    willQos);
+            WillMessage will = new WillMessage(new Topic(msg.payload().willTopic()), bb,
+                    msg.variableHeader().isWillRetain(), willQos);
             m_willStore.put(clientId, will);
             LOG.info("MQTT last will and testament has been configured. CId={}", clientId);
         }
@@ -470,7 +470,7 @@ public class ProtocolProcessor {
         ClientSession targetSession = m_sessionsStore.sessionForClient(clientID);
         StoredMessage inflightMsg = targetSession.inFlightAcknowledged(messageID);
 
-        String topic = inflightMsg.getTopic();
+        Topic topic = inflightMsg.getTopic();
         InterceptAcknowledgedMessage wrapped = new InterceptAcknowledgedMessage(inflightMsg, topic, username, messageID);
         m_interceptor.notifyMessageAcknowledged(wrapped);
     }
@@ -481,7 +481,7 @@ public class ProtocolProcessor {
         byte[] payloadContent = readBytesAndRewind(payload);
 
         IMessagesStore.StoredMessage stored = new IMessagesStore.StoredMessage(payloadContent,
-                msg.fixedHeader().qosLevel(), msg.variableHeader().topicName());
+                msg.fixedHeader().qosLevel(), new Topic(msg.variableHeader().topicName()));
         stored.setRetained(msg.fixedHeader().isRetain());
         return stored;
     }
@@ -528,34 +528,20 @@ public class ProtocolProcessor {
      */
     public void internalPublish(MqttPublishMessage msg, final String clientId) {
         final MqttQoS qos = msg.fixedHeader().qosLevel();
-        final Topic topic = new Topic(msg.variableHeader().topicName());
-        LOG.info("Sending PUBLISH message. Topic={}, qos={}", topic, qos);
 
-        MessageGUID guid = null;
         IMessagesStore.StoredMessage toStoreMsg = asStoredMessage(msg);
+        LOG.info("Sending PUBLISH message. Topic={}, qos={}", toStoreMsg.getTopic(), qos);
         if (clientId == null || clientId.isEmpty()) {
             toStoreMsg.setClientID("BROKER_SELF");
         } else {
             toStoreMsg.setClientID(clientId);
         }
-//        if (qos == EXACTLY_ONCE) { // QoS2
-//            guid = m_messagesStore.storePublishForFuture(toStoreMsg);
-//        }
-        this.messagesPublisher.publish2Subscribers(toStoreMsg, topic);
+        this.messagesPublisher.publish2Subscribers(toStoreMsg);
 
         if (!msg.fixedHeader().isRetain()) {
             return;
         }
-        if (qos == AT_MOST_ONCE || msg.payload().readableBytes() == 0) {
-            // QoS == 0 && retain => clean old retained
-            m_messagesStore.cleanRetained(topic);
-            return;
-        }
-//        if (guid == null) {
-//            // before wasn't stored
-//            guid = m_messagesStore.storePublishForFuture(toStoreMsg);
-//        }
-        m_messagesStore.storeRetained(topic, toStoreMsg);
+        m_messagesStore.storeRetained(toStoreMsg.getTopic(), toStoreMsg);
     }
 
     /**
@@ -567,13 +553,12 @@ public class ProtocolProcessor {
          // NB it's a will publish, it needs a PacketIdentifier for this conn, default to 1
          IMessagesStore.StoredMessage tobeStored = asStoredMessage(will);
          tobeStored.setClientID(clientID);
-         Topic topic = new Topic(tobeStored.getTopic());
-         this.messagesPublisher.publish2Subscribers(tobeStored, topic);
+         this.messagesPublisher.publish2Subscribers(tobeStored);
 
          //Stores retained message to the topic
- 	    if(will.isRetained()) {
- 	    	m_messagesStore.storeRetained(topic, tobeStored);
- 	    }
+         if(will.isRetained()) {
+             m_messagesStore.storeRetained(tobeStored.getTopic(), tobeStored);
+         }
      }
 
     static MqttQoS lowerQosToTheSubscriptionDesired(Subscription sub, MqttQoS qos) {
@@ -619,7 +604,7 @@ public class ProtocolProcessor {
         ClientSession targetSession = m_sessionsStore.sessionForClient(clientID);
         StoredMessage inflightMsg = targetSession.secondPhaseAcknowledged(messageID);
         String username = NettyUtils.userName(channel);
-        String topic = inflightMsg.getTopic();
+        Topic topic = inflightMsg.getTopic();
         m_interceptor
                 .notifyMessageAcknowledged(new InterceptAcknowledgedMessage(inflightMsg, topic, username, messageID));
     }

--- a/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessor.java
+++ b/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessor.java
@@ -541,7 +541,7 @@ public class ProtocolProcessor {
         if (!msg.fixedHeader().isRetain()) {
             return;
         }
-        m_messagesStore.storeRetained(toStoreMsg.getTopic(), toStoreMsg);
+        m_messagesStore.storeRetained(toStoreMsg);
     }
 
     /**
@@ -556,9 +556,8 @@ public class ProtocolProcessor {
          this.messagesPublisher.publish2Subscribers(tobeStored);
 
          //Stores retained message to the topic
-         if(will.isRetained()) {
-             m_messagesStore.storeRetained(tobeStored.getTopic(), tobeStored);
-         }
+         if(will.isRetained())
+             m_messagesStore.storeRetained(tobeStored);
      }
 
     static MqttQoS lowerQosToTheSubscriptionDesired(Subscription sub, MqttQoS qos) {

--- a/broker/src/main/java/io/moquette/spi/impl/Qos0PublishHandler.java
+++ b/broker/src/main/java/io/moquette/spi/impl/Qos0PublishHandler.java
@@ -58,10 +58,8 @@ class Qos0PublishHandler extends QosPublishHandler {
 
         this.publisher.publish2Subscribers(toStoreMsg, topic);
 
-        if (msg.fixedHeader().isRetain()) {
-            // QoS == 0 && retain => clean old retained
-            m_messagesStore.cleanRetained(topic);
-        }
+        if (msg.fixedHeader().isRetain())
+            m_messagesStore.storeRetained(topic, toStoreMsg);
 
         m_interceptor.notifyTopicPublished(msg, clientID, username);
     }

--- a/broker/src/main/java/io/moquette/spi/impl/Qos0PublishHandler.java
+++ b/broker/src/main/java/io/moquette/spi/impl/Qos0PublishHandler.java
@@ -57,7 +57,7 @@ class Qos0PublishHandler extends QosPublishHandler {
         this.publisher.publish2Subscribers(toStoreMsg);
 
         if (msg.fixedHeader().isRetain())
-            m_messagesStore.storeRetained(toStoreMsg.getTopic(), toStoreMsg);
+            m_messagesStore.storeRetained(toStoreMsg);
 
         m_interceptor.notifyTopicPublished(msg, clientID, username);
     }

--- a/broker/src/main/java/io/moquette/spi/impl/Qos1PublishHandler.java
+++ b/broker/src/main/java/io/moquette/spi/impl/Qos1PublishHandler.java
@@ -70,7 +70,7 @@ class Qos1PublishHandler extends QosPublishHandler {
         sendPubAck(clientID, messageID);
 
         if (msg.fixedHeader().isRetain())
-            m_messagesStore.storeRetained(toStoreMsg.getTopic(), toStoreMsg);
+            m_messagesStore.storeRetained(toStoreMsg);
 
         m_interceptor.notifyTopicPublished(msg, clientID, username);
     }

--- a/broker/src/main/java/io/moquette/spi/impl/Qos1PublishHandler.java
+++ b/broker/src/main/java/io/moquette/spi/impl/Qos1PublishHandler.java
@@ -19,7 +19,6 @@ package io.moquette.spi.impl;
 import io.moquette.server.ConnectionDescriptorStore;
 import io.moquette.server.netty.NettyUtils;
 import io.moquette.spi.IMessagesStore;
-import io.moquette.spi.impl.subscriptions.Topic;
 import io.moquette.spi.security.IAuthorizator;
 import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttFixedHeader;
@@ -53,26 +52,25 @@ class Qos1PublishHandler extends QosPublishHandler {
 
     void receivedPublishQos1(Channel channel, MqttPublishMessage msg) {
         // verify if topic can be write
-        final Topic topic = new Topic(msg.variableHeader().topicName());
+        // route message to subscribers
+        IMessagesStore.StoredMessage toStoreMsg = asStoredMessage(msg);
         String clientID = NettyUtils.clientID(channel);
+        toStoreMsg.setClientID(clientID);
         String username = NettyUtils.userName(channel);
-        if (!m_authorizator.canWrite(topic, username, clientID)) {
-            LOG.error("MQTT client is not authorized to publish on topic. CId={}, topic={}", clientID, topic);
+        if (!m_authorizator.canWrite(toStoreMsg.getTopic(), username, clientID)) {
+            LOG.error("MQTT client is not authorized to publish on topic. CId={}, topic={}", clientID,
+                    toStoreMsg.getTopic());
             return;
         }
 
         final int messageID = msg.variableHeader().messageId();
 
-        // route message to subscribers
-        IMessagesStore.StoredMessage toStoreMsg = asStoredMessage(msg);
-        toStoreMsg.setClientID(clientID);
-
-        this.publisher.publish2Subscribers(toStoreMsg, topic, messageID);
+        this.publisher.publish2Subscribers(toStoreMsg, messageID);
 
         sendPubAck(clientID, messageID);
 
         if (msg.fixedHeader().isRetain())
-            m_messagesStore.storeRetained(topic, toStoreMsg);
+            m_messagesStore.storeRetained(toStoreMsg.getTopic(), toStoreMsg);
 
         m_interceptor.notifyTopicPublished(msg, clientID, username);
     }

--- a/broker/src/main/java/io/moquette/spi/impl/Qos1PublishHandler.java
+++ b/broker/src/main/java/io/moquette/spi/impl/Qos1PublishHandler.java
@@ -42,7 +42,7 @@ class Qos1PublishHandler extends QosPublishHandler {
     private final ConnectionDescriptorStore connectionDescriptors;
     private final MessagesPublisher publisher;
 
-    public Qos1PublishHandler(IAuthorizator authorizator, IMessagesStore messagesStore, BrokerInterceptor interceptor,
+    Qos1PublishHandler(IAuthorizator authorizator, IMessagesStore messagesStore, BrokerInterceptor interceptor,
                               ConnectionDescriptorStore connectionDescriptors, MessagesPublisher messagesPublisher) {
         super(authorizator);
         this.m_messagesStore = messagesStore;
@@ -71,14 +71,8 @@ class Qos1PublishHandler extends QosPublishHandler {
 
         sendPubAck(clientID, messageID);
 
-        if (msg.fixedHeader().isRetain()) {
-            if (!msg.payload().isReadable()) {
-                m_messagesStore.cleanRetained(topic);
-            } else {
-                // before wasn't stored
-                m_messagesStore.storeRetained(topic, toStoreMsg);
-            }
-        }
+        if (msg.fixedHeader().isRetain())
+            m_messagesStore.storeRetained(topic, toStoreMsg);
 
         m_interceptor.notifyTopicPublished(msg, clientID, username);
     }

--- a/broker/src/main/java/io/moquette/spi/impl/Qos2PublishHandler.java
+++ b/broker/src/main/java/io/moquette/spi/impl/Qos2PublishHandler.java
@@ -115,13 +115,8 @@ class Qos2PublishHandler extends QosPublishHandler {
 
         this.publisher.publish2Subscribers(evt, topic, messageID);
 
-        if (evt.isRetained()) {
-            if (evt.getPayload().readableBytes() == 0) {
-                m_messagesStore.cleanRetained(topic);
-            } else {
-                m_messagesStore.storeRetained(topic, evt);
-            }
-        }
+        if (evt.isRetained())
+            m_messagesStore.storeRetained(topic, evt);
 
         //TODO here we should notify to the listeners
         //m_interceptor.notifyTopicPublished(msg, clientID, username);

--- a/broker/src/main/java/io/moquette/spi/impl/Qos2PublishHandler.java
+++ b/broker/src/main/java/io/moquette/spi/impl/Qos2PublishHandler.java
@@ -111,9 +111,9 @@ class Qos2PublishHandler extends QosPublishHandler {
             LOG.warn("Can't find inbound inflight message for CId={}, messageId={}", clientID, messageID);
             throw new IllegalArgumentException("Can't find inbound inflight message");
         }
-        final Topic topic = new Topic(evt.getTopic());
+        final Topic topic = evt.getTopic();
 
-        this.publisher.publish2Subscribers(evt, topic, messageID);
+        this.publisher.publish2Subscribers(evt, messageID);
 
         if (evt.isRetained())
             m_messagesStore.storeRetained(topic, evt);

--- a/broker/src/main/java/io/moquette/spi/impl/Qos2PublishHandler.java
+++ b/broker/src/main/java/io/moquette/spi/impl/Qos2PublishHandler.java
@@ -86,13 +86,6 @@ class Qos2PublishHandler extends QosPublishHandler {
         // Next the client will send us a pub rel
         // NB publish to subscribers for QoS 2 happen upon PUBREL from publisher
 
-//        if (msg.fixedHeader().isRetain()) {
-//            if (msg.payload().readableBytes() == 0) {
-//                m_messagesStore.cleanRetained(topic);
-//            } else {
-//                m_messagesStore.storeRetained(topic, toStoreMsg);
-//            }
-//        }
         //TODO this should happen on PUB_REL, else we notify false positive
         m_interceptor.notifyTopicPublished(msg, clientID, username);
     }
@@ -111,12 +104,10 @@ class Qos2PublishHandler extends QosPublishHandler {
             LOG.warn("Can't find inbound inflight message for CId={}, messageId={}", clientID, messageID);
             throw new IllegalArgumentException("Can't find inbound inflight message");
         }
-        final Topic topic = evt.getTopic();
-
         this.publisher.publish2Subscribers(evt, messageID);
 
         if (evt.isRetained())
-            m_messagesStore.storeRetained(topic, evt);
+            m_messagesStore.storeRetained(evt);
 
         //TODO here we should notify to the listeners
         //m_interceptor.notifyTopicPublished(msg, clientID, username);

--- a/broker/src/test/java/io/moquette/persistence/MessageStoreTCK.java
+++ b/broker/src/test/java/io/moquette/persistence/MessageStoreTCK.java
@@ -29,10 +29,11 @@ public abstract class MessageStoreTCK {
     @Test
     public void testDropMessagesInSessionDoesntCleanAnyRetainedStoredMessages() {
         final ClientSession session = sessionsStore.createNewSession(TEST_CLIENT, true);
-        StoredMessage publishToStore = new StoredMessage("Hello".getBytes(), EXACTLY_ONCE, "/topic");
+
+        StoredMessage publishToStore = new StoredMessage("Hello".getBytes(), EXACTLY_ONCE, new Topic("/topic"));
         publishToStore.setClientID(TEST_CLIENT);
         publishToStore.setRetained(true);
-        messagesStore.storeRetained(new Topic("/topic"), publishToStore);
+        messagesStore.storeRetained(publishToStore);
 
         // Exercise
         session.cleanSession();
@@ -50,10 +51,10 @@ public abstract class MessageStoreTCK {
 
     @Test
     public void testStoreRetained() {
-        StoredMessage msgStored = new StoredMessage("Hello".getBytes(), MqttQoS.AT_LEAST_ONCE, "/topic");
+        StoredMessage msgStored = new StoredMessage("Hello".getBytes(), MqttQoS.AT_LEAST_ONCE, asTopic("/topic"));
         msgStored.setClientID(TEST_CLIENT);
 
-        messagesStore.storeRetained(asTopic("/topic"), msgStored);
+        messagesStore.storeRetained(msgStored);
 
         //Verify the message is in the store
         StoredMessage msgRetrieved = messagesStore.searchMatching(new IMatchingCondition() {

--- a/broker/src/test/java/io/moquette/spi/impl/ProtocolProcessorTest.java
+++ b/broker/src/test/java/io/moquette/spi/impl/ProtocolProcessorTest.java
@@ -267,7 +267,7 @@ public class ProtocolProcessorTest extends AbstractProtocolProcessorCommonUtils 
                 new Topic("/topic"));
         retainedMessage.setRetained(true);
         retainedMessage.setClientID(FAKE_PUBLISHER_ID);
-        m_messagesStore.storeRetained(new Topic("/topic"), retainedMessage);
+        m_messagesStore.storeRetained(retainedMessage);
 
         m_processor.init(subs, m_messagesStore, m_sessionStore, null, true, new PermitAllAuthorizator(),
                 NO_OBSERVERS_INTERCEPTOR);

--- a/broker/src/test/java/io/moquette/spi/impl/ProtocolProcessorTest.java
+++ b/broker/src/test/java/io/moquette/spi/impl/ProtocolProcessorTest.java
@@ -263,7 +263,8 @@ public class ProtocolProcessorTest extends AbstractProtocolProcessorCommonUtils 
         List<Subscription> emptySubs = Collections.emptyList();
         when(subs.matches(any(Topic.class))).thenReturn(emptySubs);
 
-        StoredMessage retainedMessage = new StoredMessage("Hello".getBytes(), MqttQoS.EXACTLY_ONCE, "/topic");
+        StoredMessage retainedMessage = new StoredMessage("Hello".getBytes(), MqttQoS.EXACTLY_ONCE,
+                new Topic("/topic"));
         retainedMessage.setRetained(true);
         retainedMessage.setClientID(FAKE_PUBLISHER_ID);
         m_messagesStore.storeRetained(new Topic("/topic"), retainedMessage);

--- a/h2_storage/src/main/java/io/moquette/persistence/h2/H2MessagesStore.java
+++ b/h2_storage/src/main/java/io/moquette/persistence/h2/H2MessagesStore.java
@@ -19,6 +19,7 @@ package io.moquette.persistence.h2;
 import io.moquette.spi.IMatchingCondition;
 import io.moquette.spi.IMessagesStore;
 import io.moquette.spi.impl.subscriptions.Topic;
+import io.netty.handler.codec.mqtt.MqttQoS;
 import org.h2.mvstore.Cursor;
 import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
@@ -50,7 +51,10 @@ class H2MessagesStore implements IMessagesStore {
         if (storedMessage.getClientID() == null) {
             throw new IllegalArgumentException("Message to be persisted must have a not null client ID");
         }
-        retainedStore.put(topic, storedMessage);
+        if (storedMessage.getQos() != MqttQoS.AT_MOST_ONCE && storedMessage.getPayloadArray().length > 0)
+            retainedStore.put(topic, storedMessage);
+        else
+            cleanRetained(topic);
     }
 
     @Override

--- a/h2_storage/src/main/java/io/moquette/persistence/h2/H2MessagesStore.java
+++ b/h2_storage/src/main/java/io/moquette/persistence/h2/H2MessagesStore.java
@@ -46,15 +46,15 @@ class H2MessagesStore implements IMessagesStore {
     }
 
     @Override
-    public void storeRetained(Topic topic, StoredMessage storedMessage) {
-        LOG.debug("Store retained message for topic={}, CId={}", topic, storedMessage.getClientID());
-        if (storedMessage.getClientID() == null) {
+    public void storeRetained(StoredMessage storedMessage) {
+        LOG.debug("Store retained message for topic={}, CId={}", storedMessage.getTopic(), storedMessage.getClientID());
+        if (storedMessage.getClientID() == null)
             throw new IllegalArgumentException("Message to be persisted must have a not null client ID");
-        }
+
         if (storedMessage.getQos() != MqttQoS.AT_MOST_ONCE && storedMessage.getPayloadArray().length > 0)
-            retainedStore.put(topic, storedMessage);
+            retainedStore.put(storedMessage.getTopic(), storedMessage);
         else
-            cleanRetained(topic);
+            cleanRetained(storedMessage.getTopic());
     }
 
     @Override

--- a/mapdb_storage/src/main/java/io/moquette/persistence/mapdb/MapDBMessagesStore.java
+++ b/mapdb_storage/src/main/java/io/moquette/persistence/mapdb/MapDBMessagesStore.java
@@ -76,14 +76,14 @@ class MapDBMessagesStore implements IMessagesStore {
     }
 
     @Override
-    public void storeRetained(Topic topic, StoredMessage msg) {
-        LOG.debug("Store retained message for topic={}, CId={}", topic, msg.getClientID());
+    public void storeRetained(StoredMessage msg) {
+        LOG.debug("Store retained message for topic={}, CId={}", msg.getTopic(), msg.getClientID());
         if (msg.getClientID() == null) {
             throw new IllegalArgumentException("Message to be persisted must have a not null client ID");
         }
         if (msg.getQos() != MqttQoS.AT_MOST_ONCE && msg.getPayloadArray().length > 0)
-            m_retainedStore.put(topic, msg);
+            m_retainedStore.put(msg.getTopic(), msg);
         else
-            cleanRetained(topic);
+            cleanRetained(msg.getTopic());
     }
 }

--- a/mapdb_storage/src/main/java/io/moquette/persistence/mapdb/MapDBMessagesStore.java
+++ b/mapdb_storage/src/main/java/io/moquette/persistence/mapdb/MapDBMessagesStore.java
@@ -19,6 +19,7 @@ package io.moquette.persistence.mapdb;
 import io.moquette.spi.IMatchingCondition;
 import io.moquette.spi.IMessagesStore;
 import io.moquette.spi.impl.subscriptions.Topic;
+import io.netty.handler.codec.mqtt.MqttQoS;
 import org.mapdb.DB;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,11 +76,14 @@ class MapDBMessagesStore implements IMessagesStore {
     }
 
     @Override
-    public void storeRetained(Topic topic, StoredMessage storedMessage) {
-        LOG.debug("Store retained message for topic={}, CId={}", topic, storedMessage.getClientID());
-        if (storedMessage.getClientID() == null) {
-            throw new IllegalArgumentException( "Message to be persisted must have a not null client ID");
+    public void storeRetained(Topic topic, StoredMessage msg) {
+        LOG.debug("Store retained message for topic={}, CId={}", topic, msg.getClientID());
+        if (msg.getClientID() == null) {
+            throw new IllegalArgumentException("Message to be persisted must have a not null client ID");
         }
-        m_retainedStore.put(topic, storedMessage);
+        if (msg.getQos() != MqttQoS.AT_MOST_ONCE && msg.getPayloadArray().length > 0)
+            m_retainedStore.put(topic, msg);
+        else
+            cleanRetained(topic);
     }
 }

--- a/mapdb_storage/src/test/java/io/moquette/persistence/mapdb/MapDBPersistentStoreTest.java
+++ b/mapdb_storage/src/test/java/io/moquette/persistence/mapdb/MapDBPersistentStoreTest.java
@@ -21,6 +21,7 @@ import io.moquette.persistence.MessageStoreTCK;
 import io.moquette.server.config.IConfig;
 import io.moquette.server.config.MemoryConfig;
 import io.moquette.spi.IMessagesStore.StoredMessage;
+import io.moquette.spi.impl.subscriptions.Topic;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import org.junit.After;
 import org.junit.Before;
@@ -97,7 +98,7 @@ public class MapDBPersistentStoreTest extends MessageStoreTCK {
 
     @Test
     public void testNextPacketID() {
-        StoredMessage msgStored = new StoredMessage("Hello".getBytes(), MqttQoS.AT_LEAST_ONCE, "/topic");
+        StoredMessage msgStored = new StoredMessage("Hello".getBytes(), MqttQoS.AT_LEAST_ONCE, new Topic("/topic"));
         msgStored.setClientID(TEST_CLIENT);
 
         // request a first ID


### PR DESCRIPTION
Motivation:
The storage implementation gets the possibility to choose how the different QOS levels for retained messages are handled.
The current implementation suppresses QOS 0 retained messages, the MessagesStore won't get them.
 
My storage implementation has different levels of reliability and speed. 
For example:
QOS 0 : persistent, fast and non reliable
QOS 1 : persistent, fast and reliable
QOS 2 : persistent, back pressure and reliable

This PR is reducing the Topic class creation.
