### PR TITLE
Protocol processor added db type field

### DIFF
--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -62,6 +62,7 @@ public final class BrokerConstants {
     public static final String METRICS_LIBRATO_TOKEN_PROPERTY_NAME = "metrics.librato.token";
     public static final String METRICS_LIBRATO_SOURCE_PROPERTY_NAME = "metrics.librato.source";
     public static final String STORAGE_CLASS_NAME = "storage_class";
+    public static final String STORAGE_CLASS_TYPE = "storage_type_global";
 
     private BrokerConstants() {
     }

--- a/broker/src/main/java/io/moquette/server/Server.java
+++ b/broker/src/main/java/io/moquette/server/Server.java
@@ -250,7 +250,7 @@ public class Server {
             throw new IllegalStateException("Can't publish on a server is not yet started");
         }
         LOG.debug("Publishing message. CId={}, messageId={}", clientId, messageID);
-        m_processor.internalPublish(msg, clientId);
+        m_processor.internalPublish(msg, clientId, isGlobalDatabase());
     }
 
     public void stopServer() {

--- a/broker/src/main/java/io/moquette/server/Server.java
+++ b/broker/src/main/java/io/moquette/server/Server.java
@@ -71,6 +71,8 @@ public class Server {
 
     private ScheduledExecutorService scheduler;
 
+    private boolean globalDatabase;
+
     public static void main(String[] args) throws IOException {
         final Server server = new Server();
         server.startServer();
@@ -331,5 +333,19 @@ public class Server {
 
     public ScheduledExecutorService getScheduler() {
         return scheduler;
+    }
+
+    /**
+     * true if you use a global database for retain messages
+     */
+    public boolean isGlobalDatabase() {
+        return globalDatabase;
+    }
+
+    /**
+     * Set this to true if you use a global database for retain messages
+     */
+    public void setGlobalDatabase(boolean globalDatabase) {
+        this.globalDatabase = globalDatabase;
     }
 }

--- a/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessor.java
+++ b/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessor.java
@@ -526,7 +526,7 @@ public class ProtocolProcessor {
      * @param clientId
      *            the clientID
      */
-    public void internalPublish(MqttPublishMessage msg, final String clientId) {
+    public void internalPublish(MqttPublishMessage msg, final String clientId, boolean globalDatabase) {
         final MqttQoS qos = msg.fixedHeader().qosLevel();
         final Topic topic = new Topic(msg.variableHeader().topicName());
         LOG.info("Sending PUBLISH message. Topic={}, qos={}", topic, qos);
@@ -542,6 +542,9 @@ public class ProtocolProcessor {
 //            guid = m_messagesStore.storePublishForFuture(toStoreMsg);
 //        }
         this.messagesPublisher.publish2Subscribers(toStoreMsg, topic);
+
+        if (globalDatabase) // The retain message is already stored in the global database
+            return;
 
         if (!msg.fixedHeader().isRetain()) {
             return;

--- a/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessorBootstrapper.java
+++ b/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessorBootstrapper.java
@@ -104,6 +104,7 @@ public class ProtocolProcessorBootstrapper {
                 store.close();
             }
         };
+        server.setGlobalDatabase(Boolean.parseBoolean(props.getProperty(BrokerConstants.STORAGE_CLASS_TYPE, "false")));
 
         LOG.info("Configuring message interceptors...");
 


### PR DESCRIPTION
If a global database is used which store retain messages, doesn't need to restore them in ProtocolProcessor#internalPublish .