### PR TITLE
Terminate interceptor on shutdown.

### DIFF
--- a/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessorBootstrapper.java
+++ b/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessorBootstrapper.java
@@ -268,6 +268,8 @@ public class ProtocolProcessorBootstrapper {
     public void shutdown() {
         if (storeShutdown != null)
             storeShutdown.run();
+        if (m_interceptor != null)
+            m_interceptor.stop();
     }
 
     public ConnectionDescriptorStore getConnectionDescriptors() {


### PR DESCRIPTION
While running moquette as part of a web-app in Tomcat I noticed Tomcat had issues shutting down. I tracked it down to the ProtocolProcessorBootstrapper not shutting down its BrokerInterceptor, which has a ThreadPool. Simple fix.