### PR TITLE
Terminate processor on shutdown.

### DIFF
--- a/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessor.java
+++ b/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessor.java
@@ -938,4 +938,9 @@ public class ProtocolProcessor {
     public ISessionsStore getSessionsStore() {
         return m_sessionsStore;
     }
+
+    public void shutdown() {
+        if (m_interceptor != null)
+            m_interceptor.stop();
+    }
 }

--- a/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessorBootstrapper.java
+++ b/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessorBootstrapper.java
@@ -254,8 +254,8 @@ public class ProtocolProcessorBootstrapper {
     public void shutdown() {
         if (storeShutdown != null)
             storeShutdown.run();
-//        if (m_interceptor != null)
-//            m_interceptor.stop();
+        if (m_processor != null)
+            m_processor.shutdown();
     }
 
     public ConnectionDescriptorStore getConnectionDescriptors() {


### PR DESCRIPTION
Essentially the same as the previous #314.
The interceptor was moved from the ProtocolProcessorBootstrapper to the Processor class, but the cleanup code was not moved with it. As a result, threads are no longer terminated on shutdown. This PR adds the cleanup back.