### PR TITLE
MemorySessionStore configurable Cache for Session added

### DIFF
--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -67,6 +67,9 @@ public final class BrokerConstants {
 
     public static final String STORAGE_CLASS_NAME = "storage_class";
 
+    public static final String STORAGE_CLASS_MAX_SESSIONS = "storage_class.max_sessions";
+    public static final String STORAGE_CLASS_SESSION_EXPIRE = "storage_class.session_expire";
+
     private BrokerConstants() {
     }
 }

--- a/broker/src/main/java/io/moquette/persistence/MemorySessionStore.java
+++ b/broker/src/main/java/io/moquette/persistence/MemorySessionStore.java
@@ -16,7 +16,9 @@
 
 package io.moquette.persistence;
 
+import io.moquette.BrokerConstants;
 import io.moquette.server.Constants;
+import io.moquette.server.config.IConfig;
 import io.moquette.spi.ClientSession;
 import io.moquette.spi.IMessagesStore.StoredMessage;
 import io.moquette.spi.ISessionsStore;
@@ -25,11 +27,13 @@ import io.moquette.spi.impl.subscriptions.Subscription;
 import io.moquette.spi.impl.subscriptions.Topic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import java.util.*;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class MemorySessionStore implements ISessionsStore, ISubscriptionsStore {
@@ -51,15 +55,38 @@ public class MemorySessionStore implements ISessionsStore, ISubscriptionsStore {
             this.clientID = clientID;
             this.clientSession = clientSession;
         }
+
+        public void clean() {
+            LOG.info("Cleaning Session. ClientId={}", clientID);
+
+            secondPhaseStore.clear();
+            outboundFlightMessages.clear();
+            inboundFlightMessages.clear();
+            subscriptions.clear();
+            queue.clear();
+        }
     }
 
-    private final Map<String, Session> sessions = new ConcurrentHashMap<>();
+    private Cache<String, Session> sessions;
 
-    public MemorySessionStore() {
+    public MemorySessionStore(IConfig config) {
+        int expireInDays = Integer.parseInt(config.getProperty(BrokerConstants.STORAGE_CLASS_SESSION_EXPIRE, "28"));
+        int maxSessions = Integer.parseInt(config.getProperty(BrokerConstants.STORAGE_CLASS_MAX_SESSIONS, "5000"));
+
+        sessions = CacheBuilder
+                .newBuilder()
+                .expireAfterAccess(expireInDays, TimeUnit.DAYS)
+                .removalListener(k -> {
+                    LOG.error("Session for CID: {} removed Cause: {}", k.getKey(), k.getCause());
+                    ((Session) k.getValue()).clean();
+                })
+                .maximumSize(maxSessions)
+                .build();
+
     }
 
     private Session getSession(String clientID) {
-        Session session = sessions.get(clientID);
+        Session session = sessions.getIfPresent(clientID);
         if (session == null) {
             LOG.error("Can't find the session for client <{}>", clientID);
             throw new RuntimeException("Can't find the session for client <" + clientID + ">");
@@ -85,7 +112,7 @@ public class MemorySessionStore implements ISessionsStore, ISubscriptionsStore {
     @Override
     public void addNewSubscription(Subscription newSubscription) {
         final String clientID = newSubscription.getClientId();
-        Session session = sessions.get(clientID);
+        Session session = sessions.getIfPresent(clientID);
         if (session == null) {
             LOG.error("Can't find the session for client <{}>", clientID);
             return;
@@ -96,23 +123,24 @@ public class MemorySessionStore implements ISessionsStore, ISubscriptionsStore {
 
     @Override
     public void wipeSubscriptions(String clientID) {
-        if (!sessions.containsKey(clientID)) {
+        Session session = sessions.getIfPresent(clientID);
+        if (session == null) {
             LOG.error("Can't find the session for client <{}>", clientID);
             return;
         }
 
-        sessions.get(clientID).subscriptions.clear();
+        session.subscriptions.clear();
     }
 
     @Override
     public boolean contains(String clientID) {
-        return sessions.containsKey(clientID);
+        return sessions.getIfPresent(clientID) != null;
     }
 
     @Override
     public ClientSession createNewSession(String clientID, boolean cleanSession) {
         LOG.debug("createNewSession for client <{}>", clientID);
-        Session session = sessions.get(clientID);
+        Session session = sessions.getIfPresent(clientID);
         if (session != null) {
             LOG.error("already exists a session for client <{}>, bad condition", clientID);
             throw new IllegalArgumentException("Can't create a session with the ID of an already existing" + clientID);
@@ -126,19 +154,20 @@ public class MemorySessionStore implements ISessionsStore, ISubscriptionsStore {
 
     @Override
     public ClientSession sessionForClient(String clientID) {
-        if (!sessions.containsKey(clientID)) {
+        Session session = sessions.getIfPresent(clientID);
+        if (session == null) {
             LOG.error("Can't find the session for client <{}>", clientID);
             return null;
         }
 
-        PersistentSession storedSession = sessions.get(clientID).persistentSession.get();
+        PersistentSession storedSession = session.persistentSession.get();
         return new ClientSession(clientID, this, this, storedSession.cleanSession);
     }
 
     @Override
     public Collection<ClientSession> getAllSessions() {
         Collection<ClientSession> result = new ArrayList<>();
-        for (Session entry : sessions.values()) {
+        for (Session entry : sessions.asMap().values()) {
             result.add(new ClientSession(entry.clientID, this, this, entry.persistentSession.get().cleanSession));
         }
         return result;
@@ -146,18 +175,19 @@ public class MemorySessionStore implements ISessionsStore, ISubscriptionsStore {
 
     @Override
     public void updateCleanStatus(String clientID, boolean cleanSession) {
-        if (!sessions.containsKey(clientID)) {
+        Session session = sessions.getIfPresent(clientID);
+        if (session == null) {
             LOG.error("Can't find the session for client <{}>", clientID);
             return;
         }
 
-        sessions.get(clientID).persistentSession.set(new PersistentSession(cleanSession));
+        session.persistentSession.set(new PersistentSession(cleanSession));
     }
 
     @Override
     public List<ClientTopicCouple> listAllSubscriptions() {
         List<ClientTopicCouple> allSubscriptions = new ArrayList<>();
-        for (Session entry : sessions.values()) {
+        for (Session entry : sessions.asMap().values()) {
             for (Subscription sub : entry.subscriptions.values()) {
                 allSubscriptions.add(sub.asClientTopicCouple());
             }
@@ -168,12 +198,13 @@ public class MemorySessionStore implements ISessionsStore, ISubscriptionsStore {
     @Override
     public Subscription getSubscription(ClientTopicCouple couple) {
         String clientID = couple.clientID;
-        if (!sessions.containsKey(clientID)) {
+        Session session = sessions.getIfPresent(clientID);
+        if (session == null) {
             LOG.error("Can't find the session for client <{}>", clientID);
             return null;
         }
 
-        Map<Topic, Subscription> subscriptions = sessions.get(clientID).subscriptions;
+        Map<Topic, Subscription> subscriptions = session.subscriptions;
         if (subscriptions == null || subscriptions.isEmpty()) {
             return null;
         }
@@ -183,7 +214,7 @@ public class MemorySessionStore implements ISessionsStore, ISubscriptionsStore {
     @Override
     public List<Subscription> getSubscriptions() {
         List<Subscription> subscriptions = new ArrayList<>();
-        for (Session entry : sessions.values()) {
+        for (Session entry : sessions.asMap().values()) {
             subscriptions.addAll(entry.subscriptions.values());
         }
         return subscriptions;
@@ -196,7 +227,7 @@ public class MemorySessionStore implements ISessionsStore, ISubscriptionsStore {
 
     @Override
     public void inFlight(String clientID, int messageID, StoredMessage msg) {
-        Session session = sessions.get(clientID);
+        Session session = sessions.getIfPresent(clientID);
         if (session == null) {
             LOG.error("Can't find the session for client <{}>", clientID);
             return;
@@ -210,12 +241,13 @@ public class MemorySessionStore implements ISessionsStore, ISubscriptionsStore {
      */
     @Override
     public int nextPacketID(String clientID) {
-        if (!sessions.containsKey(clientID)) {
+        Session session = sessions.getIfPresent(clientID);
+        if (session == null) {
             LOG.error("Can't find the session for client <{}>", clientID);
             return -1;
         }
 
-        Map<Integer, StoredMessage> m = sessions.get(clientID).outboundFlightMessages;
+        Map<Integer, StoredMessage> m = session.outboundFlightMessages;
         int maxId = m.keySet().isEmpty() ? 0 : Collections.max(m.keySet());
         int nextPacketId = (maxId + 1) % 0xFFFF;
         m.put(nextPacketId, null);
@@ -224,23 +256,30 @@ public class MemorySessionStore implements ISessionsStore, ISubscriptionsStore {
 
     @Override
     public BlockingQueue<StoredMessage> queue(String clientID) {
-        if (!sessions.containsKey(clientID)) {
+        Session session = sessions.getIfPresent(clientID);
+        if (session == null) {
             LOG.error("Can't find the session for client <{}>", clientID);
             return null;
         }
 
-        return sessions.get(clientID).queue;
+        return session.queue;
     }
 
     @Override
     public void dropQueue(String clientID) {
-        sessions.get(clientID).queue.clear();
+        Session session = sessions.getIfPresent(clientID);
+        if (session == null) {
+            LOG.error("Can't find the session for client <{}>", clientID);
+            return;
+        }
+
+        session.queue.clear();
     }
 
     @Override
     public void moveInFlightToSecondPhaseAckWaiting(String clientID, int messageID, StoredMessage msg) {
         LOG.info("Moving msg inflight second phase store, clientID <{}> messageID {}", clientID, messageID);
-        Session session = sessions.get(clientID);
+        Session session = sessions.getIfPresent(clientID);
         if (session == null) {
             LOG.error("Can't find the session for client <{}>", clientID);
             return;
@@ -258,7 +297,7 @@ public class MemorySessionStore implements ISessionsStore, ISubscriptionsStore {
 
     @Override
     public int getInflightMessagesNo(String clientID) {
-        Session session = sessions.get(clientID);
+        Session session = sessions.getIfPresent(clientID);
         if (session == null) {
             LOG.error("Can't find the session for client <{}>", clientID);
             return 0;
@@ -275,60 +314,50 @@ public class MemorySessionStore implements ISessionsStore, ISubscriptionsStore {
 
     @Override
     public void markAsInboundInflight(String clientID, int messageID, StoredMessage msg) {
-        if (!sessions.containsKey(clientID))
+        Session session = sessions.getIfPresent(clientID);
+        if (session == null) {
             LOG.error("Can't find the session for client <{}>", clientID);
-
-        sessions.get(clientID).inboundFlightMessages.put(messageID, msg);
+            return;
+        }
+        session.inboundFlightMessages.put(messageID, msg);
     }
 
     @Override
     public int getPendingPublishMessagesNo(String clientID) {
-        if (!sessions.containsKey(clientID)) {
+        Session session = sessions.getIfPresent(clientID);
+        if (session == null) {
             LOG.error("Can't find the session for client <{}>", clientID);
             return 0;
         }
 
-        return sessions.get(clientID).queue.size();
+        return session.queue.size();
     }
 
     @Override
     public int getSecondPhaseAckPendingMessages(String clientID) {
-        if (!sessions.containsKey(clientID)) {
-            LOG.error("Can't find the session for client <{}>", clientID);
+        Session session = sessions.getIfPresent(clientID);
+        if (session == null) {
             return 0;
         }
 
-        return sessions.get(clientID).secondPhaseStore.size();
+        return session.secondPhaseStore.size();
     }
 
     @Override
     public void cleanSession(String clientID) {
         LOG.debug("Session cleanup for client <{}>", clientID);
 
-        Session session = sessions.get(clientID);
+        Session session = sessions.getIfPresent(clientID);
         if (session == null) {
             LOG.error("Can't find the session for client <{}>", clientID);
             return;
         }
 
-        // remove also the messages stored of type QoS1/2
-        LOG.info("Removing stored messages with QoS 1 and 2. ClientId={}", clientID);
-
-        session.secondPhaseStore.clear();
-        session.outboundFlightMessages.clear();
-        session.inboundFlightMessages.clear();
-
-        LOG.info("Wiping existing subscriptions. ClientId={}", clientID);
-        wipeSubscriptions(clientID);
-
-        //remove also the enqueued messages
-        dropQueue(clientID);
-
-        // TODO this missing last step breaks the junit test
-        //sessions.remove(clientID);
+        session.clean();
     }
 
     @Override
     public void heartBeat(String clientID) {
+        sessions.getIfPresent(clientID);
     }
 }

--- a/broker/src/main/java/io/moquette/persistence/MemorySessionStore.java
+++ b/broker/src/main/java/io/moquette/persistence/MemorySessionStore.java
@@ -327,4 +327,8 @@ public class MemorySessionStore implements ISessionsStore, ISubscriptionsStore {
         // TODO this missing last step breaks the junit test
         //sessions.remove(clientID);
     }
+
+    @Override
+    public void heartBeat(String clientID) {
+    }
 }

--- a/broker/src/main/java/io/moquette/persistence/MemoryStorageService.java
+++ b/broker/src/main/java/io/moquette/persistence/MemoryStorageService.java
@@ -30,7 +30,7 @@ public class MemoryStorageService implements IStore {
 
     public MemoryStorageService(IConfig props, ScheduledExecutorService scheduler) {
         m_messagesStore = new MemoryMessagesStore();
-        m_sessionsStore = new MemorySessionStore();
+        m_sessionsStore = new MemorySessionStore(props);
         m_messagesStore.initStore();
         m_sessionsStore.initStore();
     }

--- a/broker/src/main/java/io/moquette/server/netty/NettyMQTTHandler.java
+++ b/broker/src/main/java/io/moquette/server/netty/NettyMQTTHandler.java
@@ -41,8 +41,10 @@ public class NettyMQTTHandler extends ChannelInboundHandlerAdapter {
         MqttMessage msg = (MqttMessage) message;
         MqttMessageType messageType = msg.fixedHeader().messageType();
         LOG.debug("Processing MQTT message, type={}", messageType);
-        m_processor.getSessionsStore().heartBeat(NettyUtils.clientID(ctx.channel()));
         try {
+            String clientId = NettyUtils.clientID(ctx.channel());
+            if (clientId != null)
+                m_processor.getSessionsStore().heartBeat(clientId);
             switch (messageType) {
                 case CONNECT:
                     m_processor.processConnect(ctx.channel(), (MqttConnectMessage) msg);

--- a/broker/src/main/java/io/moquette/server/netty/NettyMQTTHandler.java
+++ b/broker/src/main/java/io/moquette/server/netty/NettyMQTTHandler.java
@@ -41,6 +41,7 @@ public class NettyMQTTHandler extends ChannelInboundHandlerAdapter {
         MqttMessage msg = (MqttMessage) message;
         MqttMessageType messageType = msg.fixedHeader().messageType();
         LOG.debug("Processing MQTT message, type={}", messageType);
+        m_processor.getSessionsStore().heartBeat(NettyUtils.clientID(ctx.channel()));
         try {
             switch (messageType) {
                 case CONNECT:

--- a/broker/src/main/java/io/moquette/spi/ISessionsStore.java
+++ b/broker/src/main/java/io/moquette/spi/ISessionsStore.java
@@ -132,4 +132,9 @@ public interface ISessionsStore {
     int getSecondPhaseAckPendingMessages(String clientID);
 
     void cleanSession(String clientID);
+
+    /**
+     * Call this method if there is a life sign from the client
+     */
+    void heartBeat(String clientID);
 }

--- a/broker/src/main/java/io/moquette/spi/impl/MessagesPublisher.java
+++ b/broker/src/main/java/io/moquette/spi/impl/MessagesPublisher.java
@@ -82,6 +82,7 @@ class MessagesPublisher {
             boolean targetIsActive = this.connectionDescriptors.isConnected(sub.getClientId());
 //TODO move all this logic into messageSender, which puts into the flightZone only the messages that pull out of the queue.
             if (targetIsActive) {
+                m_sessionsStore.heartBeat(sub.getClientId());
                 LOG.debug("Sending PUBLISH message to active subscriber. CId={}, topicFilter={}, qos={}",
                     sub.getClientId(), sub.getTopicFilter(), qos);
                 // we need to retain because duplicate only copy r/w indexes and don't retain() causing

--- a/broker/src/test/java/io/moquette/persistence/MemoryStorageTest.java
+++ b/broker/src/test/java/io/moquette/persistence/MemoryStorageTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2012-2017 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.moquette.persistence;
+
+import io.moquette.persistence.MessageStoreTCK;
+import io.moquette.server.config.IConfig;
+import io.moquette.server.config.MemoryConfig;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Properties;
+
+public class MemoryStorageTest extends MessageStoreTCK {
+
+    MemoryStorageService storageService;
+
+    @Before
+    public void setUp() throws Exception {
+        Properties props = new Properties();
+        IConfig conf = new MemoryConfig(props);
+        storageService = new  MemoryStorageService(conf, null);
+        messagesStore = storageService.messagesStore();
+        sessionsStore = storageService.sessionsStore();
+    }
+
+    @After
+    public void tearDown() {
+        if (storageService != null) {
+            storageService.close();
+        }
+    }
+}

--- a/broker/src/test/java/io/moquette/spi/ClientSessionTest.java
+++ b/broker/src/test/java/io/moquette/spi/ClientSessionTest.java
@@ -17,12 +17,12 @@
 package io.moquette.spi;
 
 import io.moquette.persistence.MemoryStorageService;
+import io.moquette.server.config.IConfig;
+import io.moquette.server.config.MemoryConfig;
 import io.moquette.spi.impl.subscriptions.*;
 import org.junit.Before;
 import org.junit.Test;
-
 import java.util.List;
-
 import static io.netty.handler.codec.mqtt.MqttQoS.AT_MOST_ONCE;
 import static io.netty.handler.codec.mqtt.MqttQoS.EXACTLY_ONCE;
 import static org.junit.Assert.assertEquals;
@@ -37,7 +37,9 @@ public class ClientSessionTest {
     @Before
     public void setUp() {
         store = new CTrieSubscriptionDirectory();
-        MemoryStorageService storageService = new MemoryStorageService(null, null);
+        IConfig config = new MemoryConfig(System.getProperties());
+        MemoryStorageService storageService = new MemoryStorageService(config, null);
+        storageService.initStore();
         this.sessionsStore = storageService.sessionsStore();
         store.init(sessionsStore);
 

--- a/broker/src/test/java/io/moquette/spi/impl/AbstractProtocolProcessorCommonUtils.java
+++ b/broker/src/test/java/io/moquette/spi/impl/AbstractProtocolProcessorCommonUtils.java
@@ -17,6 +17,8 @@ package io.moquette.spi.impl;
 
 import io.moquette.interception.InterceptHandler;
 import io.moquette.persistence.MemoryStorageService;
+import io.moquette.server.config.IConfig;
+import io.moquette.server.config.MemoryConfig;
 import io.moquette.server.netty.NettyUtils;
 import io.moquette.spi.IMessagesStore;
 import io.moquette.spi.ISessionsStore;
@@ -62,11 +64,13 @@ abstract class AbstractProtocolProcessorCommonUtils {
         NettyUtils.clientID(m_channel, FAKE_CLIENT_ID);
         NettyUtils.cleanSession(m_channel, false);
 
+        IConfig config = new MemoryConfig(System.getProperties());
+
         // sleep to let the messaging batch processor to process the initEvent
-        MemoryStorageService memStorage = new MemoryStorageService(null, null);
+        MemoryStorageService memStorage = new MemoryStorageService(config, null);
         m_messagesStore = memStorage.messagesStore();
         m_sessionStore = memStorage.sessionsStore();
-        // m_messagesStore.initStore();
+        m_messagesStore.initStore();
 
         Set<String> clientIds = new HashSet<>();
         clientIds.add(FAKE_CLIENT_ID);

--- a/broker/src/test/java/io/moquette/spi/impl/ProtocolProcessorTest.java
+++ b/broker/src/test/java/io/moquette/spi/impl/ProtocolProcessorTest.java
@@ -18,6 +18,8 @@ package io.moquette.spi.impl;
 
 import io.moquette.interception.InterceptHandler;
 import io.moquette.persistence.MemoryStorageService;
+import io.moquette.server.config.IConfig;
+import io.moquette.server.config.MemoryConfig;
 import io.moquette.server.netty.NettyUtils;
 import io.moquette.spi.IMessagesStore;
 import io.moquette.spi.IMessagesStore.StoredMessage;
@@ -82,7 +84,9 @@ public class ProtocolProcessorTest extends AbstractProtocolProcessorCommonUtils 
         };
 
         // simulate a connect that register a clientID to an IoSession
-        MemoryStorageService storageService = new MemoryStorageService(null, null);
+        IConfig config = new MemoryConfig(System.getProperties());
+        MemoryStorageService storageService = new MemoryStorageService(config, null);
+        storageService.initStore();
         subs.init(storageService.sessionsStore());
         m_processor.init(subs, m_messagesStore, m_sessionStore, null, true, new PermitAllAuthorizator(),
                 NO_OBSERVERS_INTERCEPTOR);
@@ -118,7 +122,9 @@ public class ProtocolProcessorTest extends AbstractProtocolProcessorCommonUtils 
         };
 
         // simulate a connect that register a clientID to an IoSession
-        MemoryStorageService storageService = new MemoryStorageService(null, null);
+        IConfig config = new MemoryConfig(System.getProperties());
+        MemoryStorageService storageService = new MemoryStorageService(config, null);
+        storageService.initStore();
         subs.init(storageService.sessionsStore());
         m_processor.init(subs, m_messagesStore, m_sessionStore, null, true, new PermitAllAuthorizator(),
                 NO_OBSERVERS_INTERCEPTOR);
@@ -240,7 +246,9 @@ public class ProtocolProcessorTest extends AbstractProtocolProcessorCommonUtils 
                 }
             }
         };
-        MemoryStorageService storageService = new MemoryStorageService(null, null);
+        IConfig config = new MemoryConfig(System.getProperties());
+        MemoryStorageService storageService = new MemoryStorageService(config, null);
+        storageService.initStore();
         subs.init(storageService.sessionsStore());
 
         // simulate a connect that register a clientID to an IoSession

--- a/broker/src/test/java/io/moquette/spi/impl/ProtocolProcessor_CONNECT_Test.java
+++ b/broker/src/test/java/io/moquette/spi/impl/ProtocolProcessor_CONNECT_Test.java
@@ -17,6 +17,8 @@
 package io.moquette.spi.impl;
 
 import io.moquette.persistence.MemoryStorageService;
+import io.moquette.server.config.IConfig;
+import io.moquette.server.config.MemoryConfig;
 import io.moquette.server.netty.NettyUtils;
 import io.moquette.spi.ClientSession;
 import io.moquette.spi.IMessagesStore;
@@ -54,10 +56,11 @@ public class ProtocolProcessor_CONNECT_Test {
 
         m_session = new EmbeddedChannel();
 
-        MemoryStorageService memStorage = new MemoryStorageService(null, null);
+        IConfig config = new MemoryConfig(System.getProperties());
+        MemoryStorageService memStorage = new MemoryStorageService(config, null);
         m_messagesStore = memStorage.messagesStore();
         m_sessionStore = memStorage.sessionsStore();
-        // m_messagesStore.initStore();
+        m_messagesStore.initStore();
 
         m_mockAuthenticator = new MockAuthenticator(singleton(FAKE_CLIENT_ID), singletonMap(TEST_USER, TEST_PWD));
 

--- a/broker/src/test/java/io/moquette/spi/impl/subscriptions/CTrieSubscriptionDirectoryMatchingTest.java
+++ b/broker/src/test/java/io/moquette/spi/impl/subscriptions/CTrieSubscriptionDirectoryMatchingTest.java
@@ -15,16 +15,16 @@
  */package io.moquette.spi.impl.subscriptions;
 
 import io.moquette.persistence.MemoryStorageService;
+import io.moquette.server.config.IConfig;
+import io.moquette.server.config.MemoryConfig;
 import io.moquette.spi.ClientSession;
 import io.moquette.spi.ISessionsStore;
 import io.moquette.spi.ISubscriptionsStore;
 import io.moquette.spi.ISubscriptionsStore.ClientTopicCouple;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -45,8 +45,10 @@ public class CTrieSubscriptionDirectoryMatchingTest {
     public void setUp() {
         sut = new CTrieSubscriptionDirectory();
 
-        this.storageService = new MemoryStorageService(null, null);
+        IConfig config = new MemoryConfig(System.getProperties());
+        this.storageService = new MemoryStorageService(config, null);
         this.sessionsStore = storageService.sessionsStore();
+        storageService.initStore();
         sut.init(sessionsStore);
 
         this.subscriptionsStore = this.sessionsStore.subscriptionStore();
@@ -179,7 +181,9 @@ public class CTrieSubscriptionDirectoryMatchingTest {
 
     private void assertMatch(String s, String t) {
         sut = new CTrieSubscriptionDirectory();
-        MemoryStorageService memStore = new MemoryStorageService(null, null);
+        IConfig config = new MemoryConfig(System.getProperties());
+        MemoryStorageService memStore = new MemoryStorageService(config, null);
+        memStore.initStore();
         ISessionsStore aSessionsStore = memStore.sessionsStore();
         sut.init(aSessionsStore);
 
@@ -191,7 +195,9 @@ public class CTrieSubscriptionDirectoryMatchingTest {
 
     private void assertNotMatch(String subscription, String topic) {
         sut = new CTrieSubscriptionDirectory();
-        MemoryStorageService memStore = new MemoryStorageService(null, null);
+        IConfig config = new MemoryConfig(System.getProperties());
+        MemoryStorageService memStore = new MemoryStorageService(config, null);
+        memStore.initStore();
         ISessionsStore aSessionsStore = memStore.sessionsStore();
         sut.init(aSessionsStore);
 

--- a/broker/src/test/java/io/moquette/spi/impl/subscriptions/CTrieSubscriptionDirectoryTest.java
+++ b/broker/src/test/java/io/moquette/spi/impl/subscriptions/CTrieSubscriptionDirectoryTest.java
@@ -15,6 +15,8 @@
  */package io.moquette.spi.impl.subscriptions;
 
 import io.moquette.persistence.MemoryStorageService;
+import io.moquette.server.config.IConfig;
+import io.moquette.server.config.MemoryConfig;
 import io.moquette.spi.ISessionsStore;
 import io.moquette.spi.ISubscriptionsStore.ClientTopicCouple;
 import org.junit.Before;
@@ -34,7 +36,9 @@ public class CTrieSubscriptionDirectoryTest {
     @Before
     public void setUp() {
         sut = new CTrieSubscriptionDirectory();
-        MemoryStorageService memStore = new MemoryStorageService(null, null);
+        IConfig config = new MemoryConfig(System.getProperties());
+        MemoryStorageService memStore = new MemoryStorageService(config, null);
+        memStore.initStore();
         ISessionsStore aSessionsStore = memStore.sessionsStore();
         sut.init(aSessionsStore);
     }

--- a/broker/src/test/java/io/moquette/spi/impl/subscriptions/SubscriptionsDirectoryTest.java
+++ b/broker/src/test/java/io/moquette/spi/impl/subscriptions/SubscriptionsDirectoryTest.java
@@ -17,6 +17,8 @@
 package io.moquette.spi.impl.subscriptions;
 
 import io.moquette.persistence.MemoryStorageService;
+import io.moquette.server.config.IConfig;
+import io.moquette.server.config.MemoryConfig;
 import io.moquette.spi.ClientSession;
 import io.moquette.spi.ISessionsStore;
 import io.moquette.spi.ISubscriptionsStore;
@@ -42,8 +44,10 @@ public class SubscriptionsDirectoryTest {
     @Before
     public void setUp() throws IOException {
         store = new SubscriptionsDirectory();
-        MemoryStorageService storageService = new MemoryStorageService(null, null);
+        IConfig config = new MemoryConfig(System.getProperties());
+        MemoryStorageService storageService = new MemoryStorageService(config, null);
         this.sessionsStore = storageService.sessionsStore();
+        storageService.initStore();
         store.init(sessionsStore);
 
         this.subscriptionsStore = this.sessionsStore.subscriptionStore();
@@ -212,7 +216,9 @@ public class SubscriptionsDirectoryTest {
         Topic subscription = new Topic(s);
         Topic topic = new Topic(t);
         store = new SubscriptionsDirectory();
-        MemoryStorageService memStore = new MemoryStorageService(null, null);
+        IConfig config = new MemoryConfig(System.getProperties());
+        MemoryStorageService memStore = new MemoryStorageService(config, null);
+        memStore.initStore();
         ISessionsStore aSessionsStore = memStore.sessionsStore();
         aSessionsStore.createNewSession("FAKE_CLI_ID_1", false);
         store.init(aSessionsStore);
@@ -226,7 +232,9 @@ public class SubscriptionsDirectoryTest {
         Topic subscription = new Topic(s);
         Topic topic = new Topic(t);
         store = new SubscriptionsDirectory();
-        MemoryStorageService memStore = new MemoryStorageService(null, null);
+        IConfig config = new MemoryConfig(System.getProperties());
+        MemoryStorageService memStore = new MemoryStorageService(config, null);
+        memStore.initStore();
         store.init(memStore.sessionsStore());
         Subscription sub = new Subscription("FAKE_CLI_ID_1", subscription, MqttQoS.AT_MOST_ONCE);
         this.subscriptionsStore.addNewSubscription(sub);
@@ -250,7 +258,9 @@ public class SubscriptionsDirectoryTest {
     @Test
     public void removeSubscription_withDifferentClients_subscribedSameTopic() {
         ISubscriptionsDirectory aStore = new SubscriptionsDirectory();
-        MemoryStorageService memStore = new MemoryStorageService(null, null);
+        IConfig config = new MemoryConfig(System.getProperties());
+        MemoryStorageService memStore = new MemoryStorageService(config, null);
+        memStore.initStore();
         ISessionsStore sessionsStore = memStore.sessionsStore();
         aStore.init(sessionsStore);
         // subscribe a not active clientID1 to /topic

--- a/broker/src/test/resources/log4j.properties
+++ b/broker/src/test/resources/log4j.properties
@@ -1,7 +1,7 @@
 # Set root logger level to DEBUG and its only appender to A1.
 log4j.rootLogger=ERROR, stdout, file
 
-log4j.logger.io.moquette=WARN
+log4j.logger.io.moquette=DEBUG
 
 log4j.logger.io.moquette.spi.impl.ProtocolProcessor=WARN
 

--- a/distribution/src/main/resources/moquette.conf
+++ b/distribution/src/main/resources/moquette.conf
@@ -44,6 +44,12 @@ host 0.0.0.0
 #storage_class io.moquette.persistence.h2.H2PersistentStore
 #storage_class io.moquette.persistence.mapdb.MapDBPersistentStore
 
+# The limit of sessions. If the limit is reached old session will be dropped
+#storage_class.max_sessions 1024
+
+# The time in days when a session will be dropped
+#storage_class.session_expire 14
+
 #*********************************************************************
 # acl_file:
 #    defines the path to the ACL file relative to moquette home dir

--- a/h2_storage/src/main/java/io/moquette/persistence/h2/H2SessionsStore.java
+++ b/h2_storage/src/main/java/io/moquette/persistence/h2/H2SessionsStore.java
@@ -336,4 +336,7 @@ public class H2SessionsStore implements ISessionsStore, ISubscriptionsStore {
         dropQueue(clientID);
     }
 
+    @Override
+    public void heartBeat(String clientID) {
+    }
 }

--- a/mapdb_storage/src/main/java/io/moquette/persistence/mapdb/MapDBSessionsStore.java
+++ b/mapdb_storage/src/main/java/io/moquette/persistence/mapdb/MapDBSessionsStore.java
@@ -23,6 +23,8 @@ import io.moquette.spi.ISessionsStore;
 import io.moquette.spi.ISubscriptionsStore;
 import io.moquette.spi.impl.subscriptions.Subscription;
 import io.moquette.spi.impl.subscriptions.Topic;
+import src.main.java.io.moquette.persistence.h2.Override;
+import src.main.java.io.moquette.persistence.h2.String;
 import org.mapdb.DB;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -338,5 +340,9 @@ class MapDBSessionsStore implements ISessionsStore, ISubscriptionsStore {
 
     static String inboundMessageId2MessagesMapName(String clientID) {
         return "inboundInflight_" + clientID;
+    }
+
+    @Override
+    public void heartBeat(String clientID) {
     }
 }

--- a/mapdb_storage/src/main/java/io/moquette/persistence/mapdb/MapDBSessionsStore.java
+++ b/mapdb_storage/src/main/java/io/moquette/persistence/mapdb/MapDBSessionsStore.java
@@ -23,8 +23,6 @@ import io.moquette.spi.ISessionsStore;
 import io.moquette.spi.ISubscriptionsStore;
 import io.moquette.spi.impl.subscriptions.Subscription;
 import io.moquette.spi.impl.subscriptions.Topic;
-import src.main.java.io.moquette.persistence.h2.Override;
-import src.main.java.io.moquette.persistence.h2.String;
 import org.mapdb.DB;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
In the `MemorySessionStore` the sessions doesn't get deleted. 
If clients uses for each connection a random ClientID the memory leaks away.

This PR contains Guava Cache that will start to drop old Session. 
The eviction happens by time and size

It adds 2 new configuration properties:
`storage_class.max_sessions` The default value is 5000 session
If 5000 session is reached the old session will get dropped

`storage_class.session_expire` The default value is 28 days
If a session isn't used for 28 days it will become dropped

Fixes: #347