### PR TITLE
Test setup improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ broker/runner
 /perf/target/
 /mapdb_storage/target/
 *~
-*log*
+*.log*
 .DS_Store
 .settings/
 .project

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -101,6 +101,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.librato.metrics</groupId>
+            <artifactId>librato-java</artifactId>
+            <version>2.1.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.bugsnag</groupId>
             <artifactId>bugsnag</artifactId>
             <version>[3.0,4.0)</version>
@@ -177,6 +183,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>3.0.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>1.4.191</version>
@@ -241,6 +254,21 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>
+                            io.moquette.persistence,
+                            io.moquette.server.config,
+                            io.moquette.spi,
+                            io.moquette.spi.impl.subscriptions,
+                        </Export-Package>
+                        <Embed-Dependency>
+                            com.bugsnag;bugsnag,
+                            com.librato.metrics;metrics-librato,
+                            com.librato.metrics;librato-java,
+                        </Embed-Dependency>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/broker/src/test/java/io/moquette/server/ServerIntegrationSSLClientAuthTest.java
+++ b/broker/src/test/java/io/moquette/server/ServerIntegrationSSLClientAuthTest.java
@@ -40,6 +40,7 @@ import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -113,11 +114,21 @@ public class ServerIntegrationSSLClientAuthTest {
 
     IMqttClient m_client;
     MessageCollector m_callback;
+    static String backup;
 
     @BeforeClass
     public static void beforeTests() {
         String tmpDir = System.getProperty("java.io.tmpdir");
         s_dataStore = new MqttDefaultFilePersistence(tmpDir);
+        backup = System.getProperty("moquette.path");
+    }
+
+    @AfterClass
+    public static void afterTests() {
+        if (backup == null)
+            System.clearProperty("moquette.path");
+        else
+            System.setProperty("moquette.path", backup);
     }
 
     protected void startServer() throws IOException {

--- a/broker/src/test/java/io/moquette/server/ServerIntegrationSSLTest.java
+++ b/broker/src/test/java/io/moquette/server/ServerIntegrationSSLTest.java
@@ -41,6 +41,7 @@ import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -60,10 +61,21 @@ public class ServerIntegrationSSLTest {
     IMqttClient m_client;
     MessageCollector m_callback;
 
+    static String backup;
+
     @BeforeClass
     public static void beforeTests() {
         String tmpDir = System.getProperty("java.io.tmpdir");
         s_dataStore = new MqttDefaultFilePersistence(tmpDir);
+        backup = System.getProperty("moquette.path");
+    }
+
+    @AfterClass
+    public static void afterTests() {
+        if (backup == null)
+            System.clearProperty("moquette.path");
+        else
+            System.setProperty("moquette.path", backup);
     }
 
     protected void startServer() throws IOException {

--- a/osgi_test/README.md
+++ b/osgi_test/README.md
@@ -1,0 +1,5 @@
+# Development
+
+to run the osgi tests use:
+
+    mvn clean && mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V && mvn -B test -pl osgi_test

--- a/osgi_test/pom.xml
+++ b/osgi_test/pom.xml
@@ -22,6 +22,37 @@
             <groupId>io.moquette</groupId>
             <artifactId>moquette-broker</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.moquette</groupId>
+            <artifactId>moquette-h2-storage</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.moquette</groupId>
+            <artifactId>moquette-mapdb-storage</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.5</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>1.7.5</version>
             <scope>test</scope>
         </dependency>
 

--- a/osgi_test/src/test/resources/log4j.properties
+++ b/osgi_test/src/test/resources/log4j.properties
@@ -1,0 +1,12 @@
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=ERROR, stdout
+
+log4j.logger.io.moquette=DEBUG
+
+# stdout appender is set to be a ConsoleAppender.
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Threshold=DEBUG
+# for debug trace
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+#log4j.appender.stdout.layout.ConversionPattern=%-4r [%t] %-5p %c{1} %x - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{dd/MM/yyyy HH:mm:ss,SSS} [%t] %-5p %c{1} %M %L %x - %m%n


### PR DESCRIPTION
ServerIntegrationSSLClientAuthTest and ServerLowlevelMessagesIntegrationTests change the System.properties this has side effects for following test. It makes some test runs flaky.

ServerLowlevelMessagesIntegrationTests: the test result is flacky on different system performances.

Osgi: The old test implementation ignored errors and the state of osgi packages

This pr is need for #345 