### PR TITLE
Added try/catch blocks around calls to canRead and canWrite to protect subscription state.

### DIFF
--- a/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessor.java
+++ b/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessor.java
@@ -813,7 +813,15 @@ public class ProtocolProcessor {
         final int messageId = messageId(msg);
         for (MqttTopicSubscription req : msg.payload().topicSubscriptions()) {
             Topic topic = new Topic(req.topicName());
-            if (!m_authorizator.canRead(topic, username, clientSession.clientID)) {
+            boolean canRead = false;
+            try {
+                canRead = m_authorizator.canRead(topic, username, clientSession.clientID);
+            } catch (Exception e) {
+                LOG.error("Caught exception calling canRead, please wrap and return false instead of throwing an excecption", e);
+                canRead = false;
+            }
+
+            if (!canRead) {
                 // send SUBACK with 0x80, the user hasn't credentials to read the topic
                 LOG.error("Client does not have read permissions on the topic CId={}, username={}, messageId={}, " +
                     "topic={}", clientID, username, messageId, topic);

--- a/broker/src/main/java/io/moquette/spi/impl/Qos0PublishHandler.java
+++ b/broker/src/main/java/io/moquette/spi/impl/Qos0PublishHandler.java
@@ -47,7 +47,16 @@ class Qos0PublishHandler extends QosPublishHandler {
         final Topic topic = new Topic(msg.variableHeader().topicName());
         String clientID = NettyUtils.clientID(channel);
         String username = NettyUtils.userName(channel);
-        if (!m_authorizator.canWrite(topic, username, clientID)) {
+
+        boolean canWrite = false;
+
+        try {
+            canWrite = m_authorizator.canWrite(topic, username, clientID);
+        } catch (Exception e)  {
+            LOG.error("Caught exception from canWrite, please wrap and return false instead throwing", e);
+        }
+
+        if (!canWrite) {
             LOG.error("MQTT client is not authorized to publish on topic. CId={}, topic={}", clientID, topic);
             return;
         }

--- a/broker/src/main/java/io/moquette/spi/impl/Qos1PublishHandler.java
+++ b/broker/src/main/java/io/moquette/spi/impl/Qos1PublishHandler.java
@@ -56,7 +56,16 @@ class Qos1PublishHandler extends QosPublishHandler {
         final Topic topic = new Topic(msg.variableHeader().topicName());
         String clientID = NettyUtils.clientID(channel);
         String username = NettyUtils.userName(channel);
-        if (!m_authorizator.canWrite(topic, username, clientID)) {
+
+        boolean canWrite = false;
+
+        try {
+            canWrite = m_authorizator.canWrite(topic, username, clientID);
+        } catch (Exception e)  {
+            LOG.error("Caught exception from canWrite, please wrap and return false instead throwing", e);
+        }
+
+        if (!canWrite) {
             LOG.error("MQTT client is not authorized to publish on topic. CId={}, topic={}", clientID, topic);
             return;
         }

--- a/broker/src/main/java/io/moquette/spi/impl/Qos2PublishHandler.java
+++ b/broker/src/main/java/io/moquette/spi/impl/Qos2PublishHandler.java
@@ -64,7 +64,16 @@ class Qos2PublishHandler extends QosPublishHandler {
         // check if the topic can be wrote
         String clientID = NettyUtils.clientID(channel);
         String username = NettyUtils.userName(channel);
-        if (!m_authorizator.canWrite(topic, username, clientID)) {
+
+        boolean canWrite = false;
+
+        try {
+            canWrite = m_authorizator.canWrite(topic, username, clientID);
+        } catch (Exception e)  {
+            LOG.error("Caught exception from canWrite, please wrap and return false instead throwing", e);
+        }
+
+        if (!canWrite) {
             LOG.error("MQTT client is not authorized to publish on topic. CId={}, topic={}", clientID, topic);
             return;
         }

--- a/broker/src/main/java/io/moquette/spi/impl/QosPublishHandler.java
+++ b/broker/src/main/java/io/moquette/spi/impl/QosPublishHandler.java
@@ -36,10 +36,19 @@ abstract class QosPublishHandler {
     public boolean checkWriteOnTopic(Topic topic, Channel channel) {
         String clientID = NettyUtils.clientID(channel);
         String username = NettyUtils.userName(channel);
-        if (!m_authorizator.canWrite(topic, username, clientID)) {
-            LOG.error("MQTT client is not authorized to publish on topic. CId={}, topic={}", clientID, topic);
-            return true;
+
+        boolean canWrite = false;
+
+        try {
+            canWrite = m_authorizator.canWrite(topic, username, clientID);
+        } catch (Exception e)  {
+            LOG.error("Caught exception from canWrite, please wrap and return false instead throwing", e);
         }
-        return false;
+
+        if (!canWrite) {
+            LOG.error("MQTT client is not authorized to publish on topic. CId={}, topic={}", clientID, topic);
+            return false;
+        }
+        return true;
     }
 }


### PR DESCRIPTION
Addresses issue #316  

Wrap canRead and canWrite, assume false if any uncaught exceptions occur.  This prevents a situation where a client_id can never subscribe again, even on new connections.