### PR TITLE
feature: upgrade the test case of EmbeddedLauncher.

### DIFF
--- a/broker/src/main/java/io/moquette/spi/impl/DebugUtils.java
+++ b/broker/src/main/java/io/moquette/spi/impl/DebugUtils.java
@@ -21,7 +21,10 @@ import io.netty.buffer.ByteBuf;
 final class DebugUtils {
 
     static String payload2Str(ByteBuf content) {
-        return new String(content.copy().array());
+        int size = content.readableBytes();
+        byte[] rawBytes = new byte[size];
+        content.getBytes(content.readerIndex(), rawBytes);
+        return new String(rawBytes);
     }
 
     private DebugUtils() {

--- a/broker/src/test/java/io/moquette/spi/impl/AbstractProtocolProcessorCommonUtils.java
+++ b/broker/src/test/java/io/moquette/spi/impl/AbstractProtocolProcessorCommonUtils.java
@@ -21,13 +21,33 @@ import io.moquette.server.netty.NettyUtils;
 import io.moquette.spi.IMessagesStore;
 import io.moquette.spi.ISessionsStore;
 import io.moquette.spi.impl.security.PermitAllAuthorizator;
-import io.moquette.spi.impl.subscriptions.*;
+import io.moquette.spi.impl.subscriptions.CTrieSubscriptionDirectory;
+import io.moquette.spi.impl.subscriptions.ISubscriptionsDirectory;
+import io.moquette.spi.impl.subscriptions.Subscription;
+import io.moquette.spi.impl.subscriptions.Topic;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.codec.mqtt.*;
+import io.netty.handler.codec.mqtt.MqttConnAckMessage;
+import io.netty.handler.codec.mqtt.MqttConnectMessage;
+import io.netty.handler.codec.mqtt.MqttFixedHeader;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.netty.handler.codec.mqtt.MqttMessageType;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttSubAckMessage;
+import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
+import io.netty.handler.codec.mqtt.MqttUnsubAckMessage;
+import io.netty.handler.codec.mqtt.MqttUnsubscribeMessage;
+import io.netty.handler.codec.mqtt.MqttVersion;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_ACCEPTED;
 import static io.netty.handler.codec.mqtt.MqttMessageIdVariableHeader.from;
@@ -307,7 +327,7 @@ abstract class AbstractProtocolProcessorCommonUtils {
 
     protected void verifyPublishIsReceived(EmbeddedChannel channel) {
         final MqttPublishMessage publishReceived = channel.readOutbound();
-        String payloadMessage = new String(publishReceived.payload().array());
+        String payloadMessage = DebugUtils.payload2Str(publishReceived.payload());
         assertEquals("Sent and received payload must be identical", HELLO_WORLD_MQTT, payloadMessage);
     }
 
@@ -321,7 +341,7 @@ abstract class AbstractProtocolProcessorCommonUtils {
 
     protected void verifyPublishIsReceived(EmbeddedChannel channel, String expectedPayload, MqttQoS expectedQoS) {
         final MqttPublishMessage publishReceived = channel.readOutbound();
-        String payloadMessage = new String(publishReceived.payload().array());
+        String payloadMessage = DebugUtils.payload2Str(publishReceived.payload());
         assertEquals("Sent and received payload must be identical", expectedPayload, payloadMessage);
         assertEquals("Expected QoS don't match", expectedQoS, publishReceived.fixedHeader().qosLevel());
     }

--- a/embedding_moquette/src/main/java/io/moquette/testembedded/EmbeddedLauncher.java
+++ b/embedding_moquette/src/main/java/io/moquette/testembedded/EmbeddedLauncher.java
@@ -23,7 +23,9 @@ import io.moquette.server.config.ClasspathResourceLoader;
 import io.moquette.server.config.IConfig;
 import io.moquette.server.config.IResourceLoader;
 import io.moquette.server.config.ResourceLoaderConfig;
+import io.moquette.server.netty.NettyUtils;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.mqtt.MqttMessageBuilders;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.handler.codec.mqtt.MqttQoS;
@@ -44,8 +46,9 @@ final class EmbeddedLauncher {
 
         @Override
         public void onPublish(InterceptPublishMessage msg) {
-            System.out.println(
-                    "Received on topic: " + msg.getTopicName() + " content: " + new String(msg.getPayload().array()));
+            byte[] bytes = new byte[msg.getPayload().readableBytes()];
+            msg.getPayload().getBytes(msg.getPayload().readerIndex(), bytes);
+            System.out.println("Received on topic: " + msg.getTopicName() + " content: " + new String(bytes));
         }
     }
 
@@ -53,31 +56,41 @@ final class EmbeddedLauncher {
         IResourceLoader classpathLoader = new ClasspathResourceLoader();
         final IConfig classPathConfig = new ResourceLoaderConfig(classpathLoader);
 
+        // 1. Start a broker.
         final Server mqttBroker = new Server();
         List<? extends InterceptHandler> userHandlers = Collections.singletonList(new PublisherListener());
         mqttBroker.startServer(classPathConfig, userHandlers);
 
         System.out.println("Broker started press [CTRL+C] to stop");
-        //Bind  a shutdown hook
+        // 2. Bind a shutdown hook
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             System.out.println("Stopping broker");
             mqttBroker.stopServer();
             System.out.println("Broker stopped");
         }));
 
-        Thread.sleep(20000);
+        // 3. construct publish message.
+        Thread.sleep(10000);
         System.out.println("Before self publish");
         MqttPublishMessage message = MqttMessageBuilders.publish()
             .topicName("/exit")
             .retained(true)
-//        qos(MqttQoS.AT_MOST_ONCE);
-//        qQos(MqttQoS.AT_LEAST_ONCE);
-            .qos(MqttQoS.EXACTLY_ONCE)
+            .qos(MqttQoS.AT_MOST_ONCE)
             .payload(Unpooled.copiedBuffer("Hello World!!".getBytes()))
             .build();
 
-        mqttBroker.internalPublish(message, "INTRLPUB");
+        // 4. construct local channel: fake channel.
+        EmbeddedChannel m_channel = new EmbeddedChannel();
+        NettyUtils.clientID(m_channel, "fake channel");
+        NettyUtils.cleanSession(m_channel, false);
+
+        // 5. publish the message.
+        mqttBroker.getProcessor().processPublish(m_channel, message);
+
         System.out.println("After self publish");
+
+        // 6. Note: the below usage won't call the PublisherListener InterceptHandler
+        // mqttBroker.internalPublish(message, "INTRLPUB");
     }
 
     private EmbeddedLauncher() {

--- a/perf/src/main/java/io/moquette/parser/netty/performance/NettyPublishReceiverHandler.java
+++ b/perf/src/main/java/io/moquette/parser/netty/performance/NettyPublishReceiverHandler.java
@@ -68,14 +68,9 @@ class NettyPublishReceiverHandler extends ChannelInboundHandlerAdapter {
     }
 
     static String payload2Str(ByteBuf content) {
-        byte[] rawBytes;
-        if (content.hasArray()) {
-            rawBytes = content.array();
-        } else {
-            int size = content.readableBytes();
-            rawBytes = new byte[size];
-            content.getBytes(content.readerIndex(), rawBytes);
-        }
+        int size = content.readableBytes();
+        byte[] rawBytes = new byte[size];
+        content.getBytes(content.readerIndex(), rawBytes);
         return new String(rawBytes);
     }
 


### PR DESCRIPTION
Fixes https://github.com/andsel/moquette/issues/341

* feature: use `ByteBuf.getBytes()` instead of `ByteBuf.array()`, because `ByteBuf.array()` will append multi blanks to the tail.
* feature: upgrade the test case of EmbeddedLauncher.