### PR TITLE
enable the usage of Netty OpenSSL provider implementation and PKCS12 key stores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ broker/runner
 .settings/
 .project
 .classpath
+/*/bin/
 *.swp
 
 *.class

--- a/broker/build.gradle
+++ b/broker/build.gradle
@@ -34,4 +34,5 @@ dependencies {
     testCompile group: 'org.eclipse.jetty.websocket', name: 'websocket-client', version:'9.2.0.M1'
 
     testCompile group: 'com.h2database', name: 'h2', version:'1.4.191'
+	testRuntime group: 'io.netty', name: 'netty-tcnative', version: '2.0.10.Final', classifier: 'linux-x86_64'
 }

--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -32,8 +32,17 @@ public final class BrokerConstants {
             + DEFAULT_MOQUETTE_STORE_MAP_DB_FILENAME;
     public static final String WEB_SOCKET_PORT_PROPERTY_NAME = "websocket_port";
     public static final String WSS_PORT_PROPERTY_NAME = "secure_websocket_port";
+
+    /**
+     * Defines the SSL implementation to use, default to "JDK".
+     * @see io.netty.handler.ssl.SslProvider#name()
+     */
+    public static final String SSL_PROVIDER = "ssl_provider";
     public static final String SSL_PORT_PROPERTY_NAME = "ssl_port";
     public static final String JKS_PATH_PROPERTY_NAME = "jks_path";
+
+    /** @see java.security.KeyStore#getInstance(String) for allowed types, default to "jks" */
+    public static final String KEY_STORE_TYPE = "key_store_type";
     public static final String KEY_STORE_PASSWORD_PROPERTY_NAME = "key_store_password";
     public static final String KEY_MANAGER_PASSWORD_PROPERTY_NAME = "key_manager_password";
     public static final String ALLOW_ANONYMOUS_PROPERTY_NAME = "allow_anonymous";

--- a/broker/src/main/java/io/moquette/server/DefaultMoquetteSslContextCreator.java
+++ b/broker/src/main/java/io/moquette/server/DefaultMoquetteSslContextCreator.java
@@ -16,19 +16,34 @@
 
 package io.moquette.server;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.security.GeneralSecurityException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.Objects;
+
 import io.moquette.BrokerConstants;
 import io.moquette.server.config.IConfig;
 import io.moquette.spi.security.ISslContextCreator;
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import java.io.*;
-import java.net.URL;
-import java.security.*;
-import java.security.cert.CertificateException;
 
 /**
  * Moquette server implementation to load SSL certificate from local filesystem path configured in
@@ -38,77 +53,120 @@ class DefaultMoquetteSslContextCreator implements ISslContextCreator {
 
     private static final Logger LOG = LoggerFactory.getLogger(DefaultMoquetteSslContextCreator.class);
 
-    private IConfig props;
+    private final IConfig props;
 
     DefaultMoquetteSslContextCreator(IConfig props) {
-        this.props = props;
+        this.props = Objects.requireNonNull(props);
     }
 
     @Override
-    public SSLContext initSSLContext() {
+    public SslContext initSSLContext() {
         LOG.info("Checking SSL configuration properties...");
-        final String jksPath = props.getProperty(BrokerConstants.JKS_PATH_PROPERTY_NAME);
-        LOG.info("Initializing SSL context. KeystorePath = {}.", jksPath);
-        if (jksPath == null || jksPath.isEmpty()) {
-            // key_store_password or key_manager_password are empty
-            LOG.warn("The keystore path is null or empty. The SSL context won't be initialized.");
-            return null;
-        }
 
-        // if we have the port also the jks then keyStorePassword and keyManagerPassword
-        // has to be defined
-        final String keyStorePassword = props.getProperty(BrokerConstants.KEY_STORE_PASSWORD_PROPERTY_NAME);
-        final String keyManagerPassword = props.getProperty(BrokerConstants.KEY_MANAGER_PASSWORD_PROPERTY_NAME);
-        if (keyStorePassword == null || keyStorePassword.isEmpty()) {
-            // key_store_password or key_manager_password are empty
-            LOG.warn("The keystore password is null or empty. The SSL context won't be initialized.");
-            return null;
-        }
-        if (keyManagerPassword == null || keyManagerPassword.isEmpty()) {
-            // key_manager_password or key_manager_password are empty
+        final String keyPassword = props.getProperty(BrokerConstants.KEY_MANAGER_PASSWORD_PROPERTY_NAME);
+        if (keyPassword == null || keyPassword.isEmpty()) {
             LOG.warn("The key manager password is null or empty. The SSL context won't be initialized.");
             return null;
         }
 
-        // if client authentification is enabled a trustmanager needs to be
-        // added to the ServerContext
-        String sNeedsClientAuth = props.getProperty(BrokerConstants.NEED_CLIENT_AUTH, "false");
-        boolean needsClientAuth = Boolean.valueOf(sNeedsClientAuth);
-
         try {
-            LOG.info("Loading keystore. KeystorePath = {}.", jksPath);
-            InputStream jksInputStream = jksDatastore(jksPath);
-            SSLContext serverContext = SSLContext.getInstance("TLS");
-            final KeyStore ks = KeyStore.getInstance("JKS");
-            ks.load(jksInputStream, keyStorePassword.toCharArray());
-            LOG.info("Initializing key manager...");
-            final KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-            kmf.init(ks, keyManagerPassword.toCharArray());
-            TrustManager[] trustManagers = null;
-            if (needsClientAuth) {
-                LOG.warn(
-                        "Client authentication is enabled. "
-                        + "The keystore will be used as a truststore. KeystorePath = {}.",
-                        jksPath);
-                // use keystore as truststore, as server needs to trust certificates signed by the
-                // server certificates
-                TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-                tmf.init(ks);
-                trustManagers = tmf.getTrustManagers();
+            SslProvider sslProvider = getSSLProvider();
+            KeyStore ks = loadKeyStore();
+            SslContextBuilder contextBuilder;
+            switch (sslProvider) {
+            case JDK:
+                contextBuilder = builderWithJdkProvider(ks, keyPassword);
+                break;
+            case OPENSSL:
+            case OPENSSL_REFCNT:
+                contextBuilder = builderWithOpenSSLProvider(ks, keyPassword);
+                break;
+            default:
+                LOG.error("unsupported SSL provider {}", sslProvider);
+                return null;
             }
-            // init sslContext
-            LOG.info("Initializing SSL context...");
-            serverContext.init(kmf.getKeyManagers(), trustManagers, null);
+            // if client authentification is enabled a trustmanager needs to be added to the ServerContext
+            String sNeedsClientAuth = props.getProperty(BrokerConstants.NEED_CLIENT_AUTH, "false");
+            if (Boolean.valueOf(sNeedsClientAuth)) {
+                addClientAuthentication(ks, contextBuilder);
+            }
+            contextBuilder.sslProvider(sslProvider);
+            SslContext sslContext = contextBuilder.build();
             LOG.info("The SSL context has been initialized successfully.");
-
-            return serverContext;
-        } catch (NoSuchAlgorithmException | UnrecoverableKeyException | CertificateException | KeyStoreException
-                | KeyManagementException | IOException ex) {
-            LOG.error(
-                    "Unable to initialize SSL context. Cause = {}, errorMessage = {}.",
-                    ex.getCause(),
-                    ex.getMessage());
+            return sslContext;
+        } catch (GeneralSecurityException | IOException ex) {
+            LOG.error("Unable to initialize SSL context.", ex);
             return null;
+        }
+    }
+
+    private KeyStore loadKeyStore() throws IOException, GeneralSecurityException {
+        final String jksPath = props.getProperty(BrokerConstants.JKS_PATH_PROPERTY_NAME);
+        LOG.info("Initializing SSL context. KeystorePath = {}.", jksPath);
+        if (jksPath == null || jksPath.isEmpty()) {
+            LOG.warn("The keystore path is null or empty. The SSL context won't be initialized.");
+            return null;
+        }
+        final String keyStorePassword = props.getProperty(BrokerConstants.KEY_STORE_PASSWORD_PROPERTY_NAME);
+        if (keyStorePassword == null || keyStorePassword.isEmpty()) {
+            LOG.warn("The keystore password is null or empty. The SSL context won't be initialized.");
+            return null;
+        }
+        String ksType = props.getProperty(BrokerConstants.KEY_STORE_TYPE, "jks");
+        final KeyStore keyStore = KeyStore.getInstance(ksType);
+        LOG.info("Loading keystore. KeystorePath = {}.", jksPath);
+        try (InputStream jksInputStream = jksDatastore(jksPath)) {
+            keyStore.load(jksInputStream, keyStorePassword.toCharArray());
+        }
+        return keyStore;
+    }
+
+    private static SslContextBuilder builderWithJdkProvider(KeyStore ks, String keyPassword)
+            throws GeneralSecurityException {
+        LOG.info("Initializing key manager...");
+        final KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(ks, keyPassword.toCharArray());
+        LOG.info("Initializing SSL context...");
+        return SslContextBuilder.forServer(kmf);
+    }
+
+    /**
+     * The OpenSSL provider does not support the {@link KeyManagerFactory}, so we have to lookup the server
+     * certificate and key in order to provide it to OpenSSL.
+     * <p>
+     * TODO: SNI is currently not supported, we use only the first found private key.
+     */
+    private static SslContextBuilder builderWithOpenSSLProvider(KeyStore ks, String keyPassword)
+            throws GeneralSecurityException {
+        for (String alias : Collections.list(ks.aliases())) {
+            if (ks.entryInstanceOf(alias, KeyStore.PrivateKeyEntry.class)) {
+                PrivateKey key = (PrivateKey) ks.getKey(alias, keyPassword.toCharArray());
+                Certificate[] chain = ks.getCertificateChain(alias);
+                X509Certificate[] certChain = new X509Certificate[chain.length];
+                System.arraycopy(chain, 0, certChain, 0, chain.length);
+                return SslContextBuilder.forServer(key, certChain);
+            }
+        }
+        throw new KeyManagementException("the SSL key-store does not contain a private key");
+    }
+
+    private static void addClientAuthentication(KeyStore ks, SslContextBuilder contextBuilder)
+            throws NoSuchAlgorithmException, KeyStoreException {
+        LOG.warn("Client authentication is enabled. The keystore will be used as a truststore.");
+        // use keystore as truststore, as server needs to trust certificates signed by the server certificates
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(ks);
+        contextBuilder.clientAuth(ClientAuth.REQUIRE);
+        contextBuilder.trustManager(tmf);
+    }
+
+    private SslProvider getSSLProvider() {
+        String providerName = props.getProperty(BrokerConstants.SSL_PROVIDER, SslProvider.JDK.name());
+        try {
+            return SslProvider.valueOf(providerName);
+        } catch (IllegalArgumentException e) {
+            LOG.warn("unknown SSL Provider {}, falling back on JDK provider", providerName);
+            return SslProvider.JDK;
         }
     }
 
@@ -124,7 +182,6 @@ class DefaultMoquetteSslContextCreator implements ISslContextCreator {
             LOG.info("Loading external keystore. Url = {}.", jksFile.getAbsolutePath());
             return new FileInputStream(jksFile);
         }
-        LOG.warn("The keystore file does not exist. Url = {}.", jksFile.getAbsolutePath());
-        return null;
+        throw new FileNotFoundException("The keystore file does not exist. Url = " + jksFile.getAbsolutePath());
     }
 }

--- a/broker/src/main/java/io/moquette/spi/security/ISslContextCreator.java
+++ b/broker/src/main/java/io/moquette/spi/security/ISslContextCreator.java
@@ -16,12 +16,12 @@
 
 package io.moquette.spi.security;
 
-import javax.net.ssl.SSLContext;
+import io.netty.handler.ssl.SslContext;
 
 /**
  * SSL certificate loader used to open SSL connections (websocket and MQTT-S).
  */
 public interface ISslContextCreator {
 
-    SSLContext initSSLContext();
+    SslContext initSSLContext();
 }

--- a/broker/src/test/java/io/moquette/server/ServerIntegrationOpenSSLTest.java
+++ b/broker/src/test/java/io/moquette/server/ServerIntegrationOpenSSLTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.moquette.server;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import io.moquette.BrokerConstants;
+import io.netty.handler.ssl.OpenSsl;
+import io.netty.handler.ssl.SslProvider;
+import org.junit.BeforeClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Check that Moquette could also handle SSL with OpenSSL provider.
+ */
+public class ServerIntegrationOpenSSLTest extends ServerIntegrationSSLTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ServerIntegrationOpenSSLTest.class);
+
+    @BeforeClass
+    public static void beforeTests() {
+        LOG.info("try to initialize OpenSSL native library");
+        OpenSsl.ensureAvailability();
+        LOG.info("OpenSSL initialized");
+    }
+
+    @Override
+    protected void startServer() throws IOException {
+        String file = getClass().getResource("/").getPath();
+        System.setProperty("moquette.path", file);
+        m_server = new Server();
+        Properties sslProps = new Properties();
+
+        sslProps.put(BrokerConstants.SSL_PROVIDER, SslProvider.OPENSSL.name());
+        sslProps.put(BrokerConstants.NEED_CLIENT_AUTH, "true");
+
+        sslProps.put(BrokerConstants.SSL_PORT_PROPERTY_NAME, "8883");
+        sslProps.put(BrokerConstants.JKS_PATH_PROPERTY_NAME, "serverkeystore.jks");
+        sslProps.put(BrokerConstants.KEY_STORE_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
+        sslProps.put(BrokerConstants.KEY_MANAGER_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
+        sslProps.put(BrokerConstants.PERSISTENT_STORE_PROPERTY_NAME, IntegrationUtils.localMapDBPath());
+        m_server.startServer(sslProps);
+    }
+}

--- a/broker/src/test/java/io/moquette/server/ServerLowlevelMessagesIntegrationTests.java
+++ b/broker/src/test/java/io/moquette/server/ServerLowlevelMessagesIntegrationTests.java
@@ -97,7 +97,8 @@ public class ServerLowlevelMessagesIntegrationTests {
         MqttConnectVariableHeader mqttConnectVariableHeader = new MqttConnectVariableHeader(
             MqttVersion.MQTT_3_1.protocolName(), MqttVersion.MQTT_3_1.protocolLevel(), false, false, false, 1, false,
             true, keepAlive);
-        MqttConnectPayload mqttConnectPayload = new MqttConnectPayload(clientID, (String)null, (byte[])null, (String)null, (byte[])null);
+        MqttConnectPayload mqttConnectPayload = new MqttConnectPayload(clientID, (String) null, (byte[]) null, 
+                (String) null, (byte[]) null);
         return new MqttConnectMessage(mqttFixedHeader, mqttConnectVariableHeader, mqttConnectPayload);
     }
 

--- a/distribution/src/main/resources/moquette.conf
+++ b/distribution/src/main/resources/moquette.conf
@@ -17,16 +17,28 @@ websocket_port 8080
 
 #*********************************************************************
 # SSL tcp part
+#  ssl_provider: defines the SSL implementation to use, default to "JDK"
+#            supported values are "JDK", "OPENSSL" and "OPENSSL_REFCNT"
+#            By choosing one of the OpenSSL implementations the crypto
+#            operations will be performed by a native Open SSL library.
+#
 #  jks_path: define the file that contains the Java Key Store,
 #            relative to the current broker home
+#
+#  key_store_type: defines the key store container type, default to "jks"
+#            supported values are "jceks", "jks" and "pkcs12"
+#            The "jceks" and "jks" key stores are a propietary SUN
+#            implementations. "pkcs12" is defined in PKCS#12 standard.
 #
 #  key_store_password: is the password used to open the keystore
 #
 #  key_manager_password: is the password used to manage the alias in the
 #            keystore
 #*********************************************************************
-# ssl_port 8883
+#ssl_provider JDK
+#ssl_port 8883
 #jks_path serverkeystore.jks
+#key_store_type jks
 #key_store_password passw0rdsrv
 #key_manager_password passw0rdsrv
 


### PR DESCRIPTION
In order to enable the usage of additional TLS cyphers which are not supported by the JDK SSL implementation it would be nice to have the option to use the Netty OpenSSL provider implementation.

Also the use of PKCS12 key stores is now supported.

The defaults are set to match the previous behavior.