### PR TITLE
Fix issue #412,  Zero-length topic messages accepting

### DIFF
--- a/broker/src/main/java/io/moquette/spi/impl/subscriptions/Topic.java
+++ b/broker/src/main/java/io/moquette/spi/impl/subscriptions/Topic.java
@@ -128,7 +128,10 @@ public class Topic implements Serializable {
 
     public boolean isEmpty() {
         final List<Token> tokens = getTokens();
-        return tokens == null || tokens.isEmpty();
+        if (tokens == null || tokens.isEmpty()){
+            return true;
+        }
+        return tokens.size()==1 && tokens.get(0)==Token.EMPTY;
     }
 
     /**


### PR DESCRIPTION
Depending on the implementation of the MQTT client, it seems that when receiving "" (<-zero length) message, it detects the protocol error and terminates the connection from the client side.

For subscriptions of "#", PUBLISH(TOPIC:"") shouldn't judge to be applicable in the broker side. So, I reviewed the topic's Match and Empty condition. As a result, messages of PUBLISH (TOPIC: "") will not be sent to SUBSCRIBE (TOPIC: "#").