### PR TITLE
Fixed NPE while logging an unknown packet (Replaced with an IOException)

### DIFF
--- a/broker/src/main/java/io/moquette/server/netty/NettyMQTTHandler.java
+++ b/broker/src/main/java/io/moquette/server/netty/NettyMQTTHandler.java
@@ -28,6 +28,8 @@ import org.slf4j.LoggerFactory;
 import static io.netty.channel.ChannelFutureListener.CLOSE_ON_FAILURE;
 import static io.netty.handler.codec.mqtt.MqttQoS.AT_MOST_ONCE;
 
+import java.io.IOException;
+
 @Sharable
 public class NettyMQTTHandler extends ChannelInboundHandlerAdapter {
 
@@ -39,8 +41,11 @@ public class NettyMQTTHandler extends ChannelInboundHandlerAdapter {
     }
 
     @Override
-    public void channelRead(ChannelHandlerContext ctx, Object message) {
+    public void channelRead(ChannelHandlerContext ctx, Object message) throws Exception {
         MqttMessage msg = (MqttMessage) message;
+        if (msg.fixedHeader() == null) {
+        	throw new IOException("Unknown packet");
+        }
         MqttMessageType messageType = msg.fixedHeader().messageType();
         LOG.debug("Processing MQTT message, type: {}", messageType);
         try {

--- a/broker/src/main/java/io/moquette/server/netty/metrics/MQTTMessageLogger.java
+++ b/broker/src/main/java/io/moquette/server/netty/metrics/MQTTMessageLogger.java
@@ -25,6 +25,7 @@ import io.netty.handler.codec.mqtt.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.List;
 
 import static io.moquette.spi.impl.Utils.messageId;
@@ -40,16 +41,19 @@ public class MQTTMessageLogger extends ChannelDuplexHandler {
     private static final Logger LOG = LoggerFactory.getLogger("messageLogger");
 
     @Override
-    public void channelRead(ChannelHandlerContext ctx, Object message) {
+    public void channelRead(ChannelHandlerContext ctx, Object message) throws Exception {
         logMQTTMessage(ctx, message, "C->B");
         ctx.fireChannelRead(message);
     }
 
-    private void logMQTTMessage(ChannelHandlerContext ctx, Object message, String direction) {
+    private void logMQTTMessage(ChannelHandlerContext ctx, Object message, String direction) throws Exception {
         if (!(message instanceof MqttMessage)) {
             return;
         }
         MqttMessage msg = (MqttMessage) message;
+        if (msg.fixedHeader() == null) {
+        	throw new IOException("Unknown packet");
+        }
         String clientID = NettyUtils.clientID(ctx.channel());
         MqttMessageType messageType = msg.fixedHeader().messageType();
         switch (messageType) {


### PR DESCRIPTION
This fix is to avoid the NullPointerException displayed while sending an unknown packet
An  IOException is logged instead.

`[nioEventLoopGroup-3-1] ERROR NettyMQTTHandler  - Unexpected exception while processing MQTT message. Closing Netty channel. CId=null
java.lang.NullPointerException
        at io.moquette.server.netty.metrics.MQTTMessageLogger.logMQTTMessage(MQTTMessageLogger.java:54)
        at io.moquette.server.netty.metrics.MQTTMessageLogger.channelRead(MQTTMessageLogger.java:44)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)`