### PR TITLE
Fixed executor not shutting down.

### DIFF
--- a/broker/src/main/java/io/moquette/server/Server.java
+++ b/broker/src/main/java/io/moquette/server/Server.java
@@ -255,7 +255,9 @@ public class Server {
             }
         }
 
-        scheduler.shutdown();
+		// calling shutdown() does not actually stop tasks that are not cancelled,
+		// and SessionsRepository does not stop its tasks. Thus shutdownNow().
+        scheduler.shutdownNow();
 
         LOG.info("Moquette server has been stopped.");
     }


### PR DESCRIPTION
Similar to #342 and #314, the broker did not properly shut down due to a Thread being left running.

This one is because ExecutorService.shutdown() does not cancel scheduled tasks, and SessionsRepository does not cancel its SessionCleanerTask. 
ExecutorService.shutdownNow() does cancel running tasks.