### PR TITLE
Fixes NPE when client disconnects from the broker

### DIFF
--- a/broker/src/main/java/io/moquette/server/netty/metrics/MQTTMessageLogger.java
+++ b/broker/src/main/java/io/moquette/server/netty/metrics/MQTTMessageLogger.java
@@ -50,11 +50,13 @@ public class MQTTMessageLogger extends ChannelDuplexHandler {
         if (!(message instanceof MqttMessage)) {
             return;
         }
+        String clientID = NettyUtils.clientID(ctx.channel());
         MqttMessage msg = (MqttMessage) message;
         if (msg.fixedHeader() == null) {
+        	LOG.trace("Unknow packet from client {} message: {}", clientID, message);
         	throw new IOException("Unknown packet");
         }
-        String clientID = NettyUtils.clientID(ctx.channel());
+        
         MqttMessageType messageType = msg.fixedHeader().messageType();
         switch (messageType) {
             case CONNACK:

--- a/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessor.java
+++ b/broker/src/main/java/io/moquette/spi/impl/ProtocolProcessor.java
@@ -345,10 +345,12 @@ public class ProtocolProcessor {
         connectionDescriptors.removeConnection(oldConnDescr);
         // publish the Will message (if any) for the clientID
         final ClientSession clientSession = this.sessionsRepository.sessionForClient(clientID);
-        WillMessage will = clientSession.willMessage();
-        if (will != null) {
-            forwardPublishWill(will, clientID);
-            clientSession.removeWill();
+        if (clientSession != null) {
+            WillMessage will = clientSession.willMessage();
+            if (will != null) {
+                forwardPublishWill(will, clientID);
+                clientSession.removeWill();
+            }
         }
 
         String username = NettyUtils.userName(channel);


### PR DESCRIPTION
There's NPE polluting the logs some times when client disconnects abruptly because there's no active session and so ProtocolProcessor::348 throws NPE.