### PR TITLE
LoggerFactory.getLogger: Wrong logging class

### DIFF
--- a/broker/src/main/java/io/moquette/server/netty/metrics/MQTTMessageLogger.java
+++ b/broker/src/main/java/io/moquette/server/netty/metrics/MQTTMessageLogger.java
@@ -38,7 +38,7 @@ import static io.netty.channel.ChannelFutureListener.CLOSE_ON_FAILURE;
 @Sharable
 public class MQTTMessageLogger extends ChannelDuplexHandler {
 
-    private static final Logger LOG = LoggerFactory.getLogger("messageLogger");
+    private static final Logger LOG = LoggerFactory.getLogger(MQTTMessageLogger.class);
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object message) throws Exception {


### PR DESCRIPTION
Replace "MessageLogger" with full class name, as probably intended.

Signed-of-By: David Graeff <david.graeff@web.de>