### PR TITLE
Extended websocket configuration

### DIFF
--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -32,6 +32,8 @@ public final class BrokerConstants {
             + DEFAULT_MOQUETTE_STORE_H2_DB_FILENAME;
     public static final String WEB_SOCKET_PORT_PROPERTY_NAME = "websocket_port";
     public static final String WSS_PORT_PROPERTY_NAME = "secure_websocket_port";
+    public static final String WEB_SOCKET_PATH_PROPERTY_NAME = "websocket_path";
+    public static final String WEB_SOCKET_MAX_FRAME_SIZE_PROPERTY_NAME = "websocket_max_frame_size";
 
     /**
      * Defines the SSL implementation to use, default to "JDK".
@@ -57,6 +59,7 @@ public final class BrokerConstants {
     public static final String DB_AUTHENTICATOR_DIGEST = "authenticator.db.digest";
     public static final int PORT = 1883;
     public static final int WEBSOCKET_PORT = 8080;
+    public static final String WEBSOCKET_PATH = "/mqtt";
     public static final String DISABLED_PORT_BIND = "disabled";
     public static final String HOST = "0.0.0.0";
     public static final String NEED_CLIENT_AUTH = "need_client_auth";

--- a/broker/src/main/java/io/moquette/broker/NewNettyAcceptor.java
+++ b/broker/src/main/java/io/moquette/broker/NewNettyAcceptor.java
@@ -287,6 +287,8 @@ class NewNettyAcceptor {
         final MoquetteIdleTimeoutHandler timeoutHandler = new MoquetteIdleTimeoutHandler();
 
         String host = props.getProperty(BrokerConstants.HOST_PROPERTY_NAME);
+        String path = props.getProperty(BrokerConstants.WEB_SOCKET_PATH_PROPERTY_NAME, BrokerConstants.WEBSOCKET_PATH);
+        int maxFrameSize = props.intProp(BrokerConstants.WEB_SOCKET_MAX_FRAME_SIZE_PROPERTY_NAME, 65536);
         initFactory(host, port, "Websocket MQTT", new PipelineInitializer() {
 
             @Override
@@ -295,7 +297,7 @@ class NewNettyAcceptor {
                 pipeline.addLast(new HttpServerCodec());
                 pipeline.addLast("aggregator", new HttpObjectAggregator(65536));
                 pipeline.addLast("webSocketHandler",
-                        new WebSocketServerProtocolHandler("/mqtt", MQTT_SUBPROTOCOL_CSV_LIST));
+                        new WebSocketServerProtocolHandler(path, MQTT_SUBPROTOCOL_CSV_LIST, false, maxFrameSize));
                 pipeline.addLast("ws2bytebufDecoder", new WebSocketFrameToByteBufDecoder());
                 pipeline.addLast("bytebuf2wsEncoder", new ByteBufToWebSocketFrameEncoder());
                 configureMQTTPipeline(pipeline, timeoutHandler, handler);
@@ -343,6 +345,8 @@ class NewNettyAcceptor {
         int sslPort = Integer.parseInt(sslPortProp);
         final MoquetteIdleTimeoutHandler timeoutHandler = new MoquetteIdleTimeoutHandler();
         String host = props.getProperty(BrokerConstants.HOST_PROPERTY_NAME);
+        String path = props.getProperty(BrokerConstants.WEB_SOCKET_PATH_PROPERTY_NAME, BrokerConstants.WEBSOCKET_PATH);
+        int maxFrameSize = props.intProp(BrokerConstants.WEB_SOCKET_MAX_FRAME_SIZE_PROPERTY_NAME, 65536);
         String sNeedsClientAuth = props.getProperty(BrokerConstants.NEED_CLIENT_AUTH, "false");
         final boolean needsClientAuth = Boolean.valueOf(sNeedsClientAuth);
         initFactory(host, sslPort, "Secure websocket", new PipelineInitializer() {
@@ -355,7 +359,7 @@ class NewNettyAcceptor {
                 pipeline.addLast("httpDecoder", new HttpRequestDecoder());
                 pipeline.addLast("aggregator", new HttpObjectAggregator(65536));
                 pipeline.addLast("webSocketHandler",
-                        new WebSocketServerProtocolHandler("/mqtt", MQTT_SUBPROTOCOL_CSV_LIST));
+                        new WebSocketServerProtocolHandler(path, MQTT_SUBPROTOCOL_CSV_LIST, false, maxFrameSize));
                 pipeline.addLast("ws2bytebufDecoder", new WebSocketFrameToByteBufDecoder());
                 pipeline.addLast("bytebuf2wsEncoder", new ByteBufToWebSocketFrameEncoder());
 

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationWebSocketTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationWebSocketTest.java
@@ -70,7 +70,7 @@ public class ServerIntegrationWebSocketTest {
     @Test
     public void checkPlainConnect() throws Exception {
         LOG.info("*** checkPlainConnect ***");
-        String destUri = "ws://localhost:" + BrokerConstants.WEBSOCKET_PORT + "/mqtt";
+        String destUri = "ws://localhost:" + BrokerConstants.WEBSOCKET_PORT + BrokerConstants.WEBSOCKET_PATH;
 
         MQTTWebSocket socket = new MQTTWebSocket();
         client.start();


### PR DESCRIPTION
Extended websocket configuration in order to configure websocket path and max frame size; default values are still the same.

Example to add custom path name and custom websocket frame size:
```kotlin
val brokerConfig = MemoryConfig(Properties().apply {
    setProperty(WEB_SOCKET_PORT_PROPERTY_NAME, 61616)
    setProperty(WEB_SOCKET_PATH_PROPERTY_NAME, "/ws")
    setProperty(WEB_SOCKET_MAX_FRAME_SIZE_PROPERTY_NAME, 3145728) // 3MB
    setProperty(NETTY_MAX_BYTES_PROPERTY_NAME, 3145728) // 3MB
})
Server().startServer(brokerConfig)
```