### PR TITLE
Added possibility to configure additional Netty channel handlers

### DIFF
--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -135,6 +135,11 @@ public class Server {
 
     public void startServer(IConfig config, List<? extends InterceptHandler> handlers, ISslContextCreator sslCtxCreator,
                             IAuthenticator authenticator, IAuthorizatorPolicy authorizatorPolicy) {
+        startServer(config, handlers, sslCtxCreator, authenticator, authorizatorPolicy, null);
+    }
+
+    public void startServer(IConfig config, List<? extends InterceptHandler> handlers, ISslContextCreator sslCtxCreator,
+                            IAuthenticator authenticator, IAuthorizatorPolicy authorizatorPolicy, INettyChannelPipelineConfigurer pipelineConfigurer) {
         final long start = System.currentTimeMillis();
         if (handlers == null) {
             handlers = Collections.emptyList();
@@ -184,7 +189,7 @@ public class Server {
                                                                             dispatcher);
 
         final NewNettyMQTTHandler mqttHandler = new NewNettyMQTTHandler(connectionFactory);
-        acceptor = new NewNettyAcceptor();
+        acceptor = new NewNettyAcceptor(pipelineConfigurer);
         acceptor.initialize(mqttHandler, config, sslCtxCreator);
 
         final long startTime = System.currentTimeMillis() - start;

--- a/broker/src/main/java/io/moquette/broker/config/INettyChannelPipelineConfigurer.java
+++ b/broker/src/main/java/io/moquette/broker/config/INettyChannelPipelineConfigurer.java
@@ -1,0 +1,9 @@
+package io.moquette.broker.config;
+
+import io.netty.channel.ChannelPipeline;
+
+public interface INettyChannelPipelineConfigurer {
+
+    default void configure(ChannelPipeline pipeline) {
+    }
+}


### PR DESCRIPTION
Added possibility to configure additional Netty channel handlers in order to extend Moquette configuration possibility.

Example to add CORS configuration in Kotlin:
```kotlin
val pipelineConfigurer: INettyChannelPipelineConfigurer = object : INettyChannelPipelineConfigurer {
    override fun configure(pipeline: ChannelPipeline?) {
        if (pipeline == null) throw RuntimeException("Unable to configure pipeline")
        pipeline.addBefore("aggregator", "cors", CorsHandler(CorsConfigBuilder.forAnyOrigin().build()))
    }
}
Server().startServer(null, null, null, null, null, pipelineConfigurer)
```