### PR TITLE
Fix a bug Session#resendInflightNotAcked() fails due to handling a freed ByteBuf

### DIFF
--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -218,6 +218,8 @@ class PostOffice {
                           sub.getClientId(), sub.getTopicFilter(), qos);
                 // we need to retain because duplicate only copy r/w indexes and don't retain() causing refCnt = 0
                 ByteBuf payload = origPayload.retainedDuplicate();
+                // without this retain(), Session.resendInflightNotAcked() fails because it tries to handle a freed ByteBuf
+                payload.retain();
                 targetSession.sendPublishOnSessionAtQos(topic, qos, payload);
             } else {
                 // If we are, the subscriber disconnected after the subscriptions tree selected that session as a

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -276,7 +276,10 @@ class Session {
 
     void pubAckReceived(int ackPacketId) {
         // TODO remain to invoke in somehow m_interceptor.notifyMessageAcknowledged
-        inflightWindow.remove(ackPacketId);
+        SessionRegistry.EnqueuedMessage message = inflightWindow.remove(ackPacketId);
+        if (message instanceof SessionRegistry.PublishedMessage) {
+            ((SessionRegistry.PublishedMessage) message).payload.release();
+        }
         inflightSlots.incrementAndGet();
         drainQueueToConnection();
     }

--- a/broker/src/test/java/io/moquette/integration/ServerLowlevelMessagesIntegrationTests.java
+++ b/broker/src/test/java/io/moquette/integration/ServerLowlevelMessagesIntegrationTests.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import org.awaitility.Awaitility;
 import java.io.IOException;
 import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.*;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -157,6 +158,49 @@ public class ServerLowlevelMessagesIntegrationTests {
         org.eclipse.paho.client.mqttv3.MqttMessage receivedTestament = m_messageCollector.waitMessage(1);
         assertEquals(willTestamentMsg, new String(receivedTestament.getPayload(), UTF_8));
         m_willSubscriber.disconnect();
+    }
+
+    @Test
+    public void testResendNotAckedPublishes()
+            throws MqttException, InterruptedException
+    {
+        LOG.info("*** testResendNotAckedPublishes ***");
+        String topic = "/test";
+
+        MqttClient subscriber = new MqttClient("tcp://localhost:1883", "Subscriber");
+        MqttClient publisher = new MqttClient("tcp://localhost:1883", "Publisher");
+
+        try {
+            subscriber.connect();
+            publisher.connect();
+
+            CountDownLatch countDownLatch = new CountDownLatch(1);
+            subscriber.subscribe(topic, 1, new IMqttMessageListener()
+            {
+                @Override
+                public void messageArrived(String topic, org.eclipse.paho.client.mqttv3.MqttMessage message)
+                        throws Exception
+                {
+                    LOG.debug("messageArrived: start");
+                    TimeUnit.SECONDS.sleep(20);
+                    LOG.debug("messageArrived: end");
+                    countDownLatch.countDown();
+                }
+            });
+
+            LOG.debug("publish: start");
+            publisher.publish(topic, "hello".getBytes(), 1, false);
+            LOG.debug("publish: end");
+            countDownLatch.await();
+        }
+        finally {
+            try {
+                subscriber.disconnect();
+            }
+            finally {
+                publisher.disconnect();
+            }
+        }
     }
 
 }


### PR DESCRIPTION
I ran into this exception when Moquette was running with QoS1 under heavy load.
```
07:42:33.467 [nioEventLoopGroup-3-1] ERROR i.m.broker.NewNettyMQTTHandler - Unexpected exception while processing MQTT message. Closing Netty channel. CId=internal-client
io.netty.util.IllegalReferenceCountException: refCnt: 0, increment: 1
        at io.netty.buffer.AbstractReferenceCountedByteBuf.retain0(AbstractReferenceCountedByteBuf.java:67)
        at io.netty.buffer.AbstractReferenceCountedByteBuf.retain(AbstractReferenceCountedByteBuf.java:54)
        at io.netty.buffer.AbstractPooledDerivedByteBuf.init(AbstractPooledDerivedByteBuf.java:59)
        at io.netty.buffer.PooledDuplicatedByteBuf.newInstance(PooledDuplicatedByteBuf.java:43)
        at io.netty.buffer.PooledDuplicatedByteBuf.retainedDuplicate(PooledDuplicatedByteBuf.java:102)
        at io.moquette.broker.Session.resendInflightNotAcked(Session.java:297)
        at io.moquette.broker.MQTTConnection.resendNotAckedPublishes(MQTTConnection.java:481)
        at io.moquette.broker.NewNettyMQTTHandler.userEventTriggered(NewNettyMQTTHandler.java:106)
        at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:329)
        at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:315)
        at io.netty.channel.AbstractChannelHandlerContext.fireUserEventTriggered(AbstractChannelHandlerContext.java:307)
        at io.netty.channel.ChannelInboundHandlerAdapter.userEventTriggered(ChannelInboundHandlerAdapter.java:108)
        at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:329)
        at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:315)
        at io.netty.channel.AbstractChannelHandlerContext.fireUserEventTriggered(AbstractChannelHandlerContext.java:307)
        at io.netty.channel.ChannelInboundHandlerAdapter.userEventTriggered(ChannelInboundHandlerAdapter.java:108)
        at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:329)
        at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:315)
        at io.netty.channel.AbstractChannelHandlerContext.fireUserEventTriggered(AbstractChannelHandlerContext.java:307)
        at io.netty.channel.ChannelInboundHandlerAdapter.userEventTriggered(ChannelInboundHandlerAdapter.java:108)
        at io.netty.handler.codec.ByteToMessageDecoder.userEventTriggered(ByteToMessageDecoder.java:353)
        at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:329)
        at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:315)
        at io.netty.channel.AbstractChannelHandlerContext.fireUserEventTriggered(AbstractChannelHandlerContext.java:307)
        at io.netty.channel.ChannelInboundHandlerAdapter.userEventTriggered(ChannelInboundHandlerAdapter.java:108)
        at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:329)
        at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:315)
        at io.netty.channel.AbstractChannelHandlerContext.fireUserEventTriggered(AbstractChannelHandlerContext.java:307)
        at io.netty.channel.ChannelInboundHandlerAdapter.userEventTriggered(ChannelInboundHandlerAdapter.java:108)
        at io.moquette.broker.MoquetteIdleTimeoutHandler.userEventTriggered(MoquetteIdleTimeoutHandler.java:48)
        at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:329)
        at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:315)
        at io.netty.channel.AbstractChannelHandlerContext.fireUserEventTriggered(AbstractChannelHandlerContext.java:307)
        at io.netty.channel.ChannelInboundHandlerAdapter.userEventTriggered(ChannelInboundHandlerAdapter.java:108)
        at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:329)
        at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:315)
        at io.netty.channel.AbstractChannelHandlerContext.fireUserEventTriggered(AbstractChannelHandlerContext.java:307)
        at io.netty.channel.ChannelInboundHandlerAdapter.userEventTriggered(ChannelInboundHandlerAdapter.java:108)
        at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:329)
        at io.netty.channel.AbstractChannelHandlerContext.invokeUserEventTriggered(AbstractChannelHandlerContext.java:315)
        at io.netty.channel.AbstractChannelHandlerContext.fireUserEventTriggered(AbstractChannelHandlerContext.java:307)
        at io.moquette.broker.InflightResender.resendNotAcked(InflightResender.java:160)
        at io.moquette.broker.InflightResender.access$100(InflightResender.java:32)
        at io.moquette.broker.InflightResender$WriterIdleTimeoutTask.run(InflightResender.java:58)
```

It looks like Session#resendInflightNotAcked() was triggered, but it dealt with a ByteBuf already freed. After this exception, the channel didn't work at all and I think this is a critical bug.

I reproduced this bug as `ServerLowlevelMessagesIntegrationTests#testResendNotAckedPublishes` and I tried fixing it somehow by retaining the duplicated buffer. It works so far.