### PR TITLE
Make the number of Netty worker threads number configurable

### DIFF
--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -71,6 +71,7 @@ public final class BrokerConstants {
     public static final String NETTY_EPOLL_PROPERTY_NAME = "netty.epoll";
     public static final String NETTY_MAX_BYTES_PROPERTY_NAME = "netty.mqtt.message_size";
     public static final int DEFAULT_NETTY_MAX_BYTES_IN_MESSAGE = 8092;
+    public static final String NETTY_WORKER_THREADS = "netty.worker_threads";
     public static final String IMMEDIATE_BUFFER_FLUSH_PROPERTY_NAME = "immediate_buffer_flush";
     public static final String METRICS_ENABLE_PROPERTY_NAME = "use_metrics";
     public static final String METRICS_LIBRATO_EMAIL_PROPERTY_NAME = "metrics.librato.email";

--- a/broker/src/main/java/io/moquette/broker/NewNettyAcceptor.java
+++ b/broker/src/main/java/io/moquette/broker/NewNettyAcceptor.java
@@ -146,17 +146,28 @@ class NewNettyAcceptor {
         nettyChannelTimeoutSeconds = props.intProp(BrokerConstants.NETTY_CHANNEL_TIMEOUT_SECONDS_PROPERTY_NAME, 10);
         maxBytesInMessage = props.intProp(BrokerConstants.NETTY_MAX_BYTES_PROPERTY_NAME,
                 BrokerConstants.DEFAULT_NETTY_MAX_BYTES_IN_MESSAGE);
+        int nettyWorkerThreads = props.intProp(BrokerConstants.NETTY_WORKER_THREADS, 0);
 
         boolean epoll = props.boolProp(BrokerConstants.NETTY_EPOLL_PROPERTY_NAME, false);
         if (epoll) {
             LOG.info("Netty is using Epoll");
             bossGroup = new EpollEventLoopGroup();
-            workerGroup = new EpollEventLoopGroup();
+            if (nettyWorkerThreads == 0) {
+                workerGroup = new EpollEventLoopGroup();
+            }
+            else {
+                workerGroup = new EpollEventLoopGroup(nettyWorkerThreads);
+            }
             channelClass = EpollServerSocketChannel.class;
         } else {
             LOG.info("Netty is using NIO");
             bossGroup = new NioEventLoopGroup();
-            workerGroup = new NioEventLoopGroup();
+            if (nettyWorkerThreads == 0) {
+                workerGroup = new NioEventLoopGroup();
+            }
+            else {
+                workerGroup = new NioEventLoopGroup(nettyWorkerThreads);
+            }
             channelClass = NioServerSocketChannel.class;
         }
 


### PR DESCRIPTION
I noticed Moquette users can't configure the number of Netty worker threads in current Moquette. Increasing Netty worker threads number is important in our use case that handles a lot of MQTT requests.

This PR makes it configurable.
