### PR TITLE
remove unnecessary quotes which fixes execution in windows 10

### DIFF
--- a/distribution/src/main/scripts/moquette.bat
+++ b/distribution/src/main/scripts/moquette.bat
@@ -31,7 +31,7 @@ goto end
 
 rem Set JavaHome if it exists
 if exist { "%JAVA_HOME%\bin\java" } (
-    set "JAVA="%JAVA_HOME%\bin\java"
+    set JAVA="%JAVA_HOME%\bin\java"
 )
 
 echo Using JAVA_HOME:       "%JAVA_HOME%"
@@ -83,6 +83,6 @@ rem set JAVA_OPTS=%JAVA_OPTS% -XX:PrintFLSStatistics=1
 rem set JAVA_OPTS=%JAVA_OPTS% -Xloggc:/var/log/moquette/gc.log
 set JAVA_OPTS=%JAVA_OPTS% -XX:+UseGCLogFileRotation
 set JAVA_OPTS=%JAVA_OPTS% -XX:NumberOfGCLogFiles=10
-set JAVA_OPTS=%JAVA_OPTS% -XX:GCLogFileSize=10M"
+set JAVA_OPTS=%JAVA_OPTS% -XX:GCLogFileSize=10M
 
 %JAVA% -server %JAVA_OPTS% %JAVA_OPTS_SCRIPT% -Dlog4j.configuration=file:%LOG_FILE% -Dmoquette.path=%MOQUETTE_PATH% -cp %MOQUETTE_HOME%\lib\* io.moquette.broker.Server


### PR DESCRIPTION
removed unnecessary quotes on line 34 and  line 86; these quotes make an execution in Windows 10 impossible;