### PR TITLE
Fix retained messages with wildcard subscriptions

### DIFF
--- a/broker/src/main/java/io/moquette/broker/MemoryRetainedRepository.java
+++ b/broker/src/main/java/io/moquette/broker/MemoryRetainedRepository.java
@@ -42,7 +42,7 @@ final class MemoryRetainedRepository implements IRetainedRepository {
         final ByteBuf payload = msg.content();
         byte[] rawPayload = new byte[payload.readableBytes()];
         payload.getBytes(0, rawPayload);
-        final RetainedMessage toStore = new RetainedMessage(msg.fixedHeader().qosLevel(), rawPayload);
+        final RetainedMessage toStore = new RetainedMessage(topic, msg.fixedHeader().qosLevel(), rawPayload);
         storage.put(topic, toStore);
     }
 
@@ -57,7 +57,7 @@ final class MemoryRetainedRepository implements IRetainedRepository {
         final List<RetainedMessage> matchingMessages = new ArrayList<>();
         for (Map.Entry<Topic, RetainedMessage> entry : storage.entrySet()) {
             final Topic scanTopic = entry.getKey();
-            if (searchTopic.match(scanTopic)) {
+            if (scanTopic.match(searchTopic)) {
                 matchingMessages.add(entry.getValue());
             }
         }

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -109,10 +109,8 @@ class PostOffice {
                 final MqttQoS retainedQos = retainedMsg.qosLevel();
                 MqttQoS qos = lowerQosToTheSubscriptionDesired(subscription, retainedQos);
 
-//                final ByteBuf origPayload = retainedMsg.getPayload();
                 final ByteBuf payloadBuf = Unpooled.wrappedBuffer(retainedMsg.getPayload());
-//                ByteBuf payload = origPayload.retainedDuplicate();
-                targetSession.sendRetainedPublishOnSessionAtQos(subscription.getTopicFilter(), qos, payloadBuf);
+                targetSession.sendRetainedPublishOnSessionAtQos(retainedMsg.getTopic(), qos, payloadBuf);
             }
         }
     }

--- a/broker/src/main/java/io/moquette/broker/RetainedMessage.java
+++ b/broker/src/main/java/io/moquette/broker/RetainedMessage.java
@@ -1,17 +1,24 @@
 package io.moquette.broker;
 
+import io.moquette.broker.subscriptions.Topic;
 import io.netty.handler.codec.mqtt.MqttQoS;
 
 import java.io.Serializable;
 
 public class RetainedMessage implements Serializable{
 
+    private final Topic topic;
     private final MqttQoS qos;
     private final byte[] payload;
 
-    public RetainedMessage(MqttQoS qos, byte[] payload) {
+    public RetainedMessage(Topic topic, MqttQoS qos, byte[] payload) {
+        this.topic = topic;
         this.qos = qos;
         this.payload = payload;
+    }
+
+    public Topic getTopic() {
+        return topic;
     }
 
     public MqttQoS qosLevel() {

--- a/broker/src/main/java/io/moquette/persistence/H2RetainedRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/H2RetainedRepository.java
@@ -30,7 +30,7 @@ public class H2RetainedRepository implements IRetainedRepository {
         final ByteBuf payload = msg.content();
         byte[] rawPayload = new byte[payload.readableBytes()];
         payload.getBytes(0, rawPayload);
-        final RetainedMessage toStore = new RetainedMessage(msg.fixedHeader().qosLevel(), rawPayload);
+        final RetainedMessage toStore = new RetainedMessage(topic, msg.fixedHeader().qosLevel(), rawPayload);
         queueMap.put(topic, toStore);
     }
 

--- a/broker/src/test/java/io/moquette/broker/MemoryRetainedRepositoryTest.java
+++ b/broker/src/test/java/io/moquette/broker/MemoryRetainedRepositoryTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.moquette.broker;
+
+import io.moquette.broker.subscriptions.Topic;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class MemoryRetainedRepositoryTest {
+
+    @Test
+    public void testRetainedOnTopicReturnsExactTopicMatch() {
+        MemoryRetainedRepository repository = new MemoryRetainedRepository();
+        Topic retainedTopic = new Topic("foo/bar/baz");
+        Topic otherRetainedTopic = new Topic("foo/bar/bazzz");
+        
+        repository.retain(retainedTopic, MqttMessageBuilders
+            .publish()
+            .qos(MqttQoS.AT_LEAST_ONCE)
+            .topicName("foo/bar/baz")
+            .retained(true)
+            .payload(Unpooled.buffer(0))
+            .build());
+        repository.retain(otherRetainedTopic, MqttMessageBuilders
+            .publish()
+            .qos(MqttQoS.AT_LEAST_ONCE)
+            .topicName("foo/bar/bazzz")
+            .retained(true)
+            .payload(Unpooled.buffer(0))
+            .build());
+
+        List<RetainedMessage> retainedMessages = repository.retainedOnTopic("foo/bar/baz");
+        
+        assertEquals(1, retainedMessages.size());
+        assertEquals("foo/bar/baz", retainedMessages.get(0).getTopic().toString());
+    }
+
+    @Test
+    public void testRetainedOnTopicReturnsWildcardTopicMatch() {
+        MemoryRetainedRepository repository = new MemoryRetainedRepository();
+        Topic retainedTopic = new Topic("foo/bar/baz");
+        Topic otherRetainedTopic = new Topic("foo/baz/bar");
+
+        repository.retain(retainedTopic, MqttMessageBuilders
+            .publish()
+            .qos(MqttQoS.AT_LEAST_ONCE)
+            .topicName("foo/bar/baz")
+            .retained(true)
+            .payload(Unpooled.buffer(0))
+            .build());
+        repository.retain(otherRetainedTopic, MqttMessageBuilders
+            .publish()
+            .qos(MqttQoS.AT_LEAST_ONCE)
+            .topicName("foo/baz/bar")
+            .retained(true)
+            .payload(Unpooled.buffer(0))
+            .build());
+
+        List<RetainedMessage> retainedMessages = repository.retainedOnTopic("foo/bar/#");
+
+        assertEquals(1, retainedMessages.size());
+        assertEquals("foo/bar/baz", retainedMessages.get(0).getTopic().toString());
+
+        retainedMessages = repository.retainedOnTopic("foo/#");
+
+        assertEquals(2, retainedMessages.size());
+        assertEquals("foo/bar/baz", retainedMessages.get(0).getTopic().toString());
+        assertEquals("foo/baz/bar", retainedMessages.get(1).getTopic().toString());
+    }
+
+    @Test
+    public void testRetainedOnTopicReturnsSingleWildcardTopicMatch() {
+        MemoryRetainedRepository repository = new MemoryRetainedRepository();
+        Topic retainedTopic = new Topic("foo/bar/baz");
+        Topic otherRetainedTopic = new Topic("foo/baz/bar");
+
+        repository.retain(retainedTopic, MqttMessageBuilders
+            .publish()
+            .qos(MqttQoS.AT_LEAST_ONCE)
+            .topicName("foo/bar/baz")
+            .retained(true)
+            .payload(Unpooled.buffer(0))
+            .build());
+        repository.retain(otherRetainedTopic, MqttMessageBuilders
+            .publish()
+            .qos(MqttQoS.AT_LEAST_ONCE)
+            .topicName("foo/baz/bar")
+            .retained(true)
+            .payload(Unpooled.buffer(0))
+            .build());
+
+        List<RetainedMessage> retainedMessages = repository.retainedOnTopic("foo/+/baz");
+
+        assertEquals(1, retainedMessages.size());
+        assertEquals("foo/bar/baz", retainedMessages.get(0).getTopic().toString());
+    }
+}


### PR DESCRIPTION
This PR is a fix for #488 

I changed the conditional for `retainedOnTopic` method of `MemoryRetainedRepository` and added some tests around it.

This same change probably also needs to happen to `H2RetainedRepository`, but I did not want to mess with that as I was unsure how to add tests for it, etc.

This also uncovered another bug around retained messages. When you subscribe to a wildcard topic that has any number of retained messages that match it, those retained messages get sent with the same topic as you subscribed. This is incorrect, and the retained messages should also retain their respective topics. I added a topic field to the `RetainedMessage` class also and then used it in the `publishRetainedMessagesForSubscriptions` method of the `PostOffice` class so they are sent with the correct topics. This probably also needs tests, but I was unsure how to add them as they are a bit complex.