### PR TITLE
fixed throw NullPointerException when new connection

### DIFF
--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -503,6 +503,8 @@ final class MQTTConnection {
 
     public void readCompleted() {
         // TODO drain all messages in target's session in-flight message queue
-        postOffice.flushInFlight(this);
+        if (isConnected()) {
+            postOffice.flushInFlight(this);
+        }
     }
 }


### PR DESCRIPTION
java.lang.NullPointerException
 at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936)
 at io.moquette.broker.SessionRegistry.retrieve(SessionRegistry.java:233)
 at io.moquette.broker.PostOffice.flushInFlight(PostOffice.java:313)
 at io.moquette.broker.MQTTConnection.readCompleted(MQTTConnection.java:507)
 at io.moquette.broker.NewNettyMQTTHandler.channelReadComplete(NewNettyMQTTHandler.java:76)