### PR TITLE
Fixes #529, #505: NPE caused by matching on a TNode

### DIFF
--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
@@ -74,15 +74,15 @@ public class CTrie {
         if (action == NavigationAction.STOP) {
             return Collections.emptySet();
         }
-        if (cnode instanceof TNode) {
-            return Collections.emptySet();
-        }
         Topic remainingTopic = (ROOT.equals(cnode.token)) ? topic : topic.exceptHeadToken();
         Set<Subscription> subscriptions = new HashSet<>();
         if (remainingTopic.isEmpty()) {
             subscriptions.addAll(cnode.subscriptions);
         }
         for (INode subInode : cnode.allChildren()) {
+            if (subInode.mainNode() instanceof TNode) {
+                continue;
+            }
             subscriptions.addAll(recursiveMatch(remainingTopic, subInode));
         }
         return subscriptions;


### PR DESCRIPTION
This PR fixes #529, #505.
In high load conditions, TNodes are not removed from the tree fast enough, and are evaluated when matching topics.
This PR moves the check that skips TNodes forward, before child nodes are even considered. As a side effect, no EmptySet is created and added to the matched subscriptions.