### PR TITLE
Added specific handling for BindExcpetion when the port is occupied

### DIFF
--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -502,7 +502,9 @@ final class MQTTConnection {
     }
 
     public void readCompleted() {
-        // TODO drain all messages in target's session in-flight message queue
-        postOffice.flushInFlight(this);
+        if (getClientId() != null) {
+            // TODO drain all messages in target's session in-flight message queue
+            postOffice.flushInFlight(this);
+        }
     }
 }

--- a/broker/src/main/java/io/moquette/broker/NewNettyAcceptor.java
+++ b/broker/src/main/java/io/moquette/broker/NewNettyAcceptor.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLEngine;
+import java.net.BindException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.HashMap;
@@ -219,10 +220,14 @@ class NewNettyAcceptor {
             f.sync()
                 .addListener(new LocalPortReaderFutureListener(protocol))
                 .addListener(FIRE_EXCEPTION_ON_FAILURE);
-            //TODO java.net.BindException
         } catch (Exception ex) {
-            LOG.error("An interruptedException was caught while initializing integration. Protocol={}", protocol, ex);
-            throw new RuntimeException(ex);
+            if (ex instanceof BindException) {
+               LOG.error("Cannot bind to port: " + port, ex);
+               System.exit(1);
+            } else {
+                LOG.error("An interruptedException was caught while initializing integration. Protocol={}", protocol, ex);
+                throw new RuntimeException(ex);
+            }
         }
     }
 


### PR DESCRIPTION
*What fixes*
If another process is using the MQTT ports the server fails with an exception, now exit with error message. Fixed also the invokation of  `readComplete` when a connection is not yet fully bootstrapped with MQTT, like when a connection is opened on an SSL port and the connection is closed without having fully bootstrapped the MQTT settngs.