### PR TITLE
Introduced test to verify that connectionLost remove the new client session

### DIFF
--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -287,6 +287,7 @@ final class MQTTConnection {
             postOffice.fireWill(session.getWill());
         }
         if (session.isClean()) {
+            LOG.debug("Remove session for client CId: {}, channel: {}", clientID, channel);
             sessionRegistry.remove(clientID);
         } else {
             sessionRegistry.disconnect(clientID);
@@ -527,6 +528,7 @@ final class MQTTConnection {
     }
 
     public void readCompleted() {
+        LOG.debug("readCompleted client CId: {}, channel: {}", getClientId(), channel);
         if (getClientId() != null) {
             // TODO drain all messages in target's session in-flight message queue
             postOffice.flushInFlight(this);

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -169,6 +169,7 @@ final class MQTTConnection {
             LOG.trace("Binding MQTTConnection (channel: {}) to session", channel);
             result = sessionRegistry.createOrReopenSession(msg, clientId, this.getUsername());
             result.session.bind(this);
+            sessionRegistry.storeInConnectionRegistry(this, result.session);
         } catch (SessionCorruptedException scex) {
             LOG.warn("MQTT session for client ID {} cannot be created, channel: {}", clientId, channel);
             abortConnection(CONNECTION_REFUSED_SERVER_UNAVAILABLE);
@@ -208,7 +209,7 @@ final class MQTTConnection {
                     }
                 } else {
                     sessionRegistry.disconnect(clientIdUsed);
-                    sessionRegistry.remove(clientIdUsed);
+                    sessionRegistry.remove(MQTTConnection.this, clientIdUsed);
                     LOG.error("CONNACK send failed, cleanup session and close the connection", future.cause());
                     channel.close();
                 }
@@ -288,7 +289,7 @@ final class MQTTConnection {
         }
         if (session.isClean()) {
             LOG.debug("Remove session for client CId: {}, channel: {}", clientID, channel);
-            sessionRegistry.remove(clientID);
+            sessionRegistry.remove(this, clientID);
         } else {
             sessionRegistry.disconnect(clientID);
         }

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -309,8 +309,8 @@ class PostOffice {
         interceptor.notifyClientConnectionLost(clientId, userName);
     }
 
-    void flushInFlight(MQTTConnection mqttConnection) {
-        Session targetSession = sessionRegistry.retrieve(mqttConnection.getClientId());
-        targetSession.flushAllQueuedMessages();
-    }
+//    void flushInFlight(MQTTConnection mqttConnection) {
+//        Session targetSession = sessionRegistry.retrieve(mqttConnection.getClientId());
+//        targetSession.flushAllQueuedMessages();
+//    }
 }

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -152,8 +152,10 @@ public class SessionRegistry {
 
         final boolean published;
         if (creationResult.mode == CreationModeEnum.DROP_EXISTING) {
+            LOG.debug("Drop session of already connected client with same id");
             published = pool.replace(clientId, oldSession, newSession);
         } else {
+            LOG.debug("Replace session of client with same id");
             published = pool.replace(clientId, oldSession, oldSession);
         }
         if (!published) {

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -75,7 +75,6 @@ public class SessionRegistry {
     private static final Logger LOG = LoggerFactory.getLogger(SessionRegistry.class);
 
     private final ConcurrentMap<String, Session> pool = new ConcurrentHashMap<>();
-    private final ConcurrentMap<MQTTConnection, Session> bindedConnections = new ConcurrentHashMap<>();
     private final ISubscriptionsDirectory subscriptionsDirectory;
     private final IQueueRepository queueRepository;
     private final Authorizator authorizator;
@@ -225,23 +224,8 @@ public class SessionRegistry {
         return pool.get(clientID);
     }
 
-    void storeInConnectionRegistry(MQTTConnection mqttcOnnection, Session session) {
-        bindedConnections.put(mqttcOnnection, session);
-    }
-
-    public void remove(MQTTConnection connection, String clientID) {
-        final Session session = bindedConnections.get(connection);
-        pool.remove(clientID, session);
-        bindedConnections.remove(connection);
-    }
-
-    public void disconnect(String clientID) {
-        final Session session = retrieve(clientID);
-        if (session == null) {
-            LOG.debug("Some other thread already removed the session CId={}", clientID);
-            return;
-        }
-        session.disconnect();
+    public void remove(Session session) {
+        pool.remove(session.getClientID(), session);
     }
 
     private void dropQueuesForClient(String clientId) {

--- a/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
@@ -88,9 +88,10 @@ public class SessionRegistryTest {
         NettyUtils.cleanSession(channel, false);
 
         // Connect a first time
-        sut.createOrReopenSession(msg, FAKE_CLIENT_ID, connection.getUsername());
+        final SessionRegistry.SessionCreationResult res = sut.createOrReopenSession(msg, FAKE_CLIENT_ID, connection.getUsername());
         // disconnect
-        sut.disconnect(FAKE_CLIENT_ID);
+        res.session.disconnect();
+//        sut.disconnect(FAKE_CLIENT_ID);
 
         // Exercise, reconnect
         EmbeddedChannel anotherChannel = new EmbeddedChannel();

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationMultiConnectTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationMultiConnectTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.moquette.integration;
+
+import io.moquette.broker.Server;
+import io.moquette.broker.config.IConfig;
+import io.moquette.broker.config.MemoryConfig;
+import org.eclipse.paho.client.mqttv3.IMqttClient;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttClientPersistence;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ServerIntegrationMultiConnectTest {
+
+    static MqttConnectOptions CLEAN_SESSION_OPT = new MqttConnectOptions();
+    private static PrintStream ORIG_OUT;
+
+    Server server;
+    IMqttClient client;
+    IConfig configuration;
+    MessageCollector m_messageCollector;
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+    private String dbPath;
+    private static ByteArrayOutputStream STRING_OUT;
+
+    protected void startServer(String dbPath) throws IOException {
+        server = new Server();
+        final Properties configProps = IntegrationUtils.prepareTestProperties(dbPath);
+        configuration = new MemoryConfig(configProps);
+        server.startServer(configuration);
+    }
+
+    @BeforeClass
+    public static void beforeTests() {
+        STRING_OUT = new ByteArrayOutputStream();
+        ORIG_OUT = System.out;
+        System.setOut(new java.io.PrintStream(STRING_OUT));
+        CLEAN_SESSION_OPT.setCleanSession(true);
+    }
+
+    @AfterClass
+    public static void afterTests() {
+        // reset the System.out
+        System.setOut(ORIG_OUT);
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        dbPath = IntegrationUtils.tempH2Path(tempFolder);
+
+        startServer(dbPath);
+
+        m_messageCollector = new MessageCollector();
+
+        client = createNewClient("tcp://localhost:1883", "Client1");
+    }
+
+    private MqttClient createNewClient(String host, String clientId) throws IOException, MqttException {
+        MqttClientPersistence clientDataStore = new MqttDefaultFilePersistence(tempFolder.newFolder().getAbsolutePath());
+        return new MqttClient(host, clientId, clientDataStore);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (client != null && client.isConnected()) {
+            client.disconnect();
+        }
+
+        server.stopServer();
+
+        tempFolder.delete();
+    }
+
+    @Test
+    public void testMultipleClientConnectsWithSameClientId() throws MqttException, IOException, InterruptedException {
+        for (int i = 0 ; i < 10; i++) {
+            client.connect(CLEAN_SESSION_OPT);
+            MqttClient anotherClient = createNewClient("tcp://localhost:1883", "Client1");
+            anotherClient.connect(CLEAN_SESSION_OPT);
+            Thread.sleep(250);
+
+            if (STRING_OUT.toString().contains("java.lang.NullPointerException")) {
+                System.out.println("EXCEPTION raised \n\n" + STRING_OUT);
+                fail("Found NPE on logs");
+            }
+        }
+        assertTrue("No Exception raised in broker", true);
+    }
+}

--- a/broker/src/test/resources/log4j.properties
+++ b/broker/src/test/resources/log4j.properties
@@ -1,17 +1,15 @@
 log4j.rootLogger=ERROR, stdout, file
 
-log4j.logger.io.moquette=DEBUG
-log4j.logger.io.moquette.broker=DEBUG
+log4j.logger.io.moquette=WARN
+log4j.logger.io.moquette.broker=WARN
+log4j.logger.io.moquette.broker.MQTTConnection=DEBUG
+log4j.logger.io.moquette.broker.SessionRegistry=DEBUG
+log4j.logger.io.moquette.broker.PostOffice=DEBUG
 #log4j.logger.io.moquette.broker=WARN
-
-#Storage service
-#log4j.logger.io.moquette.spi.impl.subscriptions.SubscriptionsDirectorytory=DEBUG
-log4j.logger.io.moquette.spi.persistence.MapDBPersistentStore=WARN
-log4j.logger.io.moquette.spi.persistence.MapDBSessionsStore=WARN
 
 # stdout appender is set to be consoleAppender.
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Threshold=WARN
+log4j.appender.stdout.Threshold=DEBUG
 
 # for debug trace
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
@@ -19,15 +17,15 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{dd/MM/yyyy HH:mm:ss,SSS} [%t] %-5p %c{1} %M %L %x - %m%n
 
 #file appender
-log4j.appender.file=org.apache.log4j.RollingFileAppender
-log4j.appender.file.Threshold=INFO
-# only for tests log4j.appender.file.Threshold=TRACE
-log4j.appender.file.File=moquette.log
-log4j.appender.file.MaxFileSize=100MB
-log4j.appender.file.MaxBackupIndex=1
-log4j.appender.file.layout=org.apache.log4j.PatternLayout
-#log4j.appender.file.layout.ConversionPattern=%-4r [%t] %-5p %c{1} %x - %m%n
-log4j.appender.file.layout.ConversionPattern=%d{HH:mm:ss,SSS} [%t] %-5p %c{1} %L %x - %m%n
+#log4j.appender.file=org.apache.log4j.RollingFileAppender
+#log4j.appender.file.Threshold=INFO
+## only for tests log4j.appender.file.Threshold=TRACE
+#log4j.appender.file.File=moquette.log
+#log4j.appender.file.MaxFileSize=100MB
+#log4j.appender.file.MaxBackupIndex=1
+#log4j.appender.file.layout=org.apache.log4j.PatternLayout
+##log4j.appender.file.layout.ConversionPattern=%-4r [%t] %-5p %c{1} %x - %m%n
+#log4j.appender.file.layout.ConversionPattern=%d{HH:mm:ss,SSS} [%t] %-5p %c{1} %L %x - %m%n
 
 ####################################
 #   Message Logger Configuration   #


### PR DESCRIPTION
Fixes #553

This PR add the link `MQTTConnection` -> `Session` so now the two entities are doubly linked. This permit the removal of session from session registry iff the session it's removing is the only one active in the session registry. This also avoid the continuous access to SessionRegistry from the MQTTConnection to retrieve the session linked to the MQTTConnection.