### PR TITLE
Fix recreate sessions when server restarts

### DIFF
--- a/broker/src/main/java/io/moquette/broker/IQueueRepository.java
+++ b/broker/src/main/java/io/moquette/broker/IQueueRepository.java
@@ -1,8 +1,11 @@
 package io.moquette.broker;
 
+import java.util.Map;
 import java.util.Queue;
 
 public interface IQueueRepository {
 
     Queue<SessionRegistry.EnqueuedMessage> createQueue(String cli, boolean clean);
+
+    Map<String, Queue<SessionRegistry.EnqueuedMessage>> listAllQueues();
 }

--- a/broker/src/main/java/io/moquette/broker/MemoryQueueRepository.java
+++ b/broker/src/main/java/io/moquette/broker/MemoryQueueRepository.java
@@ -1,12 +1,24 @@
 package io.moquette.broker;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class MemoryQueueRepository implements IQueueRepository {
 
+    private Map<String, Queue<SessionRegistry.EnqueuedMessage>> queues = new HashMap<>();
+
     @Override
     public Queue<SessionRegistry.EnqueuedMessage> createQueue(String cli, boolean clean) {
-        return new ConcurrentLinkedQueue<>();
+        final ConcurrentLinkedQueue<SessionRegistry.EnqueuedMessage> queue = new ConcurrentLinkedQueue<>();
+        queues.put(cli, queue);
+        return queue;
+    }
+
+    @Override
+    public Map<String, Queue<SessionRegistry.EnqueuedMessage>> listAllQueues() {
+        return Collections.unmodifiableMap(queues);
     }
 }

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -88,7 +88,7 @@ class Session {
     private final String clientId;
     private boolean clean;
     private Will will;
-    private Queue<SessionRegistry.EnqueuedMessage> sessionQueue;
+    private final Queue<SessionRegistry.EnqueuedMessage> sessionQueue;
     private final AtomicReference<SessionStatus> status = new AtomicReference<>(SessionStatus.DISCONNECTED);
     private MQTTConnection mqttConnection;
     private List<Subscription> subscriptions = new ArrayList<>();
@@ -103,6 +103,9 @@ class Session {
     }
 
     Session(String clientId, boolean clean, Queue<SessionRegistry.EnqueuedMessage> sessionQueue) {
+        if (sessionQueue == null) {
+            throw new IllegalArgumentException("sessionQueue parameter can't be null");
+        }
         this.clientId = clientId;
         this.clean = clean;
         this.sessionQueue = sessionQueue;

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
@@ -49,6 +49,19 @@ public class CTrieSubscriptionDirectory implements ISubscriptionsDirectory {
         }
     }
 
+    /**
+     * @return the list of client ids that has a subscription stored.
+     */
+    @Override
+    public Set<String> listAllSessionIds() {
+        final List<Subscription> subscriptions = subscriptionsRepository.listAllSubscriptions();
+        final Set<String> clientIds = new HashSet<>(subscriptions.size());
+        for (Subscription subscription : subscriptions) {
+            clientIds.add(subscription.clientId);
+        }
+        return clientIds;
+    }
+
     Optional<CNode> lookup(Topic topic) {
         return ctrie.lookup(topic);
     }

--- a/broker/src/main/java/io/moquette/broker/subscriptions/ISubscriptionsDirectory.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/ISubscriptionsDirectory.java
@@ -24,6 +24,8 @@ public interface ISubscriptionsDirectory {
 
     void init(ISubscriptionsRepository sessionsRepository);
 
+    Set<String> listAllSessionIds();
+
     Set<Subscription> matchWithoutQosSharpening(Topic topic);
 
     Set<Subscription> matchQosSharpening(Topic topic);

--- a/broker/src/main/java/io/moquette/persistence/H2QueueRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/H2QueueRepository.java
@@ -1,9 +1,11 @@
 package io.moquette.persistence;
 
 import io.moquette.broker.IQueueRepository;
-import io.moquette.broker.SessionRegistry;
+import io.moquette.broker.SessionRegistry.EnqueuedMessage;
 import org.h2.mvstore.MVStore;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
@@ -16,10 +18,20 @@ public class H2QueueRepository implements IQueueRepository {
     }
 
     @Override
-    public Queue<SessionRegistry.EnqueuedMessage> createQueue(String cli, boolean clean) {
+    public Queue<EnqueuedMessage> createQueue(String cli, boolean clean) {
         if (!clean) {
             return new H2PersistentQueue<>(mvStore, cli);
         }
         return new ConcurrentLinkedQueue<>();
+    }
+
+    @Override
+    public Map<String, Queue<EnqueuedMessage>> listAllQueues() {
+        Map<String, Queue<EnqueuedMessage>> result = new HashMap<>();
+        mvStore.getMapNames().stream()
+            .filter(name -> name.startsWith("queue_") && !name.endsWith("_meta"))
+            .map(name -> name.substring("queue_".length()))
+            .forEach(name -> result.put(name, new H2PersistentQueue<EnqueuedMessage>(mvStore, name)));
+        return result;
     }
 }

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationPahoTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationPahoTest.java
@@ -151,7 +151,6 @@ public class ServerIntegrationPahoTest {
 
     @Test
     public void testSubcriptionDoesntStayActiveAfterARestart() throws Exception {
-        LOG.info("*** testSubcriptionDoesntStayActiveAfterARestart ***");
         // clientForSubscribe1 connect and subscribe to /topic QoS2
         MqttClientPersistence dsSubscriberA = new MqttDefaultFilePersistence(
             IntegrationUtils.newFolder(tempFolder, "clientForSubscribe1").getAbsolutePath());


### PR DESCRIPTION
When server restars the session must be recreated in the SessionRegistry pool, else the session is not found in lookup operation and the following published messages are not queued to the session.