### PR TITLE
Fixed NPE due to TNode processing before CNode

### DIFF
--- a/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
@@ -19,7 +19,7 @@ import java.util.*;
 
 class CNode {
 
-    Token token;
+    private Token token;
     private List<INode> children;
     Set<Subscription> subscriptions;
 
@@ -33,6 +33,14 @@ class CNode {
         this.token = token; // keep reference, root comparison in directory logic relies on it for now.
         this.subscriptions = new HashSet<>(subscriptions);
         this.children = new ArrayList<>(children);
+    }
+
+    public Token getToken() {
+        return token;
+    }
+
+    public void setToken(Token token) {
+        this.token = token;
     }
 
     boolean anyChildrenMatch(Token token) {
@@ -75,6 +83,7 @@ class CNode {
     public void add(INode newINode) {
         this.children.add(newINode);
     }
+
     public void remove(INode node) {
         this.children.remove(node);
     }

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
@@ -25,7 +25,7 @@ public class CTrie {
 
     CTrie() {
         final CNode mainNode = new CNode();
-        mainNode.token = ROOT;
+        mainNode.setToken(ROOT);
         this.root = new INode(mainNode);
     }
 
@@ -48,14 +48,14 @@ public class CTrie {
     }
 
     private NavigationAction evaluate(Topic topic, CNode cnode) {
-        if (Token.MULTI.equals(cnode.token)) {
+        if (Token.MULTI.equals(cnode.getToken())) {
             return NavigationAction.MATCH;
         }
         if (topic.isEmpty()) {
             return NavigationAction.STOP;
         }
         final Token token = topic.headToken();
-        if (!(Token.SINGLE.equals(cnode.token) || cnode.token.equals(token) || ROOT.equals(cnode.token))) {
+        if (!(Token.SINGLE.equals(cnode.getToken()) || cnode.getToken().equals(token) || ROOT.equals(cnode.getToken()))) {
             return NavigationAction.STOP;
         }
         return NavigationAction.GODEEP;
@@ -67,6 +67,9 @@ public class CTrie {
 
     private Set<Subscription> recursiveMatch(Topic topic, INode inode) {
         CNode cnode = inode.mainNode();
+        if (cnode instanceof TNode) {
+            return Collections.emptySet();
+        }
         NavigationAction action = evaluate(topic, cnode);
         if (action == NavigationAction.MATCH) {
             return cnode.subscriptions;
@@ -74,10 +77,7 @@ public class CTrie {
         if (action == NavigationAction.STOP) {
             return Collections.emptySet();
         }
-        if (cnode instanceof TNode) {
-            return Collections.emptySet();
-        }
-        Topic remainingTopic = (ROOT.equals(cnode.token)) ? topic : topic.exceptHeadToken();
+        Topic remainingTopic = (ROOT.equals(cnode.getToken())) ? topic : topic.exceptHeadToken();
         Set<Subscription> subscriptions = new HashSet<>();
         if (remainingTopic.isEmpty()) {
             subscriptions.addAll(cnode.subscriptions);
@@ -134,7 +134,7 @@ public class CTrie {
         if (!remainingTopic.isEmpty()) {
             INode inode = createPathRec(remainingTopic, newSubscription);
             CNode cnode = new CNode();
-            cnode.token = topic.headToken();
+            cnode.setToken(topic.headToken());
             cnode.add(inode);
             return new INode(cnode);
         } else {
@@ -144,7 +144,7 @@ public class CTrie {
 
     private INode createLeafNodes(Token token, Subscription newSubscription) {
         CNode newLeafCnode = new CNode();
-        newLeafCnode.token = token;
+        newLeafCnode.setToken(token);
         newLeafCnode.addSubscription(newSubscription);
 
         return new INode(newLeafCnode);

--- a/broker/src/main/java/io/moquette/broker/subscriptions/DumpTreeVisitor.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/DumpTreeVisitor.java
@@ -24,7 +24,7 @@ class DumpTreeVisitor implements CTrie.IVisitor<String> {
     @Override
     public void visit(CNode node, int deep) {
         String indentTabs = indentTabs(deep);
-        s += indentTabs + (node.token == null ? "''" : node.token.toString()) + prettySubscriptions(node) + "\n";
+        s += indentTabs + (node.getToken() == null ? "''" : node.getToken().toString()) + prettySubscriptions(node) + "\n";
     }
 
     private String prettySubscriptions(CNode node) {

--- a/broker/src/main/java/io/moquette/broker/subscriptions/TNode.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/TNode.java
@@ -18,6 +18,16 @@ package io.moquette.broker.subscriptions;
 class TNode extends CNode {
 
     @Override
+    public Token getToken() {
+        throw new IllegalStateException("Can't be invoked on TNode");
+    }
+
+    @Override
+    public void setToken(Token token) {
+        throw new IllegalStateException("Can't be invoked on TNode");
+    }
+
+    @Override
     INode childOf(Token token) {
         throw new IllegalStateException("Can't be invoked on TNode");
     }


### PR DESCRIPTION
This PR added accessors methods to `topic`, in this way the TNode could throw exception if it's called. This let us fix #505 and #529, implementing the suggestion in #505 to move forward the TNode check.

Close #505
Close #529

----

**How to test**
usually the error appeared with a couple of run of: 
```
sudo docker run --rm --network host inovex/mqtt-stresser -broker tcp://localhost:1883 -num-clients 40 -num-messages 150 -rampup-delay 1s -rampup-size 10 -global-timeout 180s -timeout 20s
```