### PR TITLE
Fixes #566: NotSerializableException: SessionRegistry$PublishedMessage

### DIFF
--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -67,8 +67,8 @@ public class SessionRegistry {
             ByteBuf copy = payload.copy();
             copy.readBytes(byteArr);
             copy.release();
-            oos.writeObject(byteArr.length);
-            oos.writeObject(byteArr);
+            oos.writeInt(byteArr.length);
+            oos.write(byteArr);
         }
 
         private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {


### PR DESCRIPTION
Fixes #566

Instances of implementations of the interface
SessionRegistry$EnqueuedMessage are put in the queue, which can be
backed by the H2 store. But since this class is not serializable, H2
can not store it. This commit makes the interface serializable, and
deals with the non-serializable ByteBuf that the PublishedMessage
subclass has as a field.