### PR TITLE
Fixes #569: NoSuchElementException in Session.drainQueueToConnection

### DIFF
--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -334,7 +334,11 @@ class Session {
     private void drainQueueToConnection() {
         // consume the queue
         while (!sessionQueue.isEmpty() && inflighHasSlotsAndConnectionIsUp()) {
-            final SessionRegistry.EnqueuedMessage msg = sessionQueue.remove();
+            final SessionRegistry.EnqueuedMessage msg = sessionQueue.poll();
+            if (msg == null) {
+                // Our message was already fetched by another Thread.
+                return;
+            }
             inflightSlots.decrementAndGet();
             int sendPacketId = mqttConnection.nextPacketId();
             inflightWindow.put(sendPacketId, msg);


### PR DESCRIPTION
Session.drainQueueToConnection checks sessionQueue.isEmpty(), and then
uses sessionQueue.remove(). However, between the check and the remove,
another thread can steal the last message, causing the remove() to throw
an exception. Better to use sessionQueue.poll() with a null-check.