### PR TITLE
Fixes #571: ConcurrentModificationException in MemorySubscriptionsRepository

### DIFF
--- a/broker/src/main/java/io/moquette/broker/ISubscriptionsRepository.java
+++ b/broker/src/main/java/io/moquette/broker/ISubscriptionsRepository.java
@@ -17,11 +17,11 @@ package io.moquette.broker;
 
 import io.moquette.broker.subscriptions.Subscription;
 
-import java.util.List;
+import java.util.Set;
 
 public interface ISubscriptionsRepository {
 
-    List<Subscription> listAllSubscriptions();
+    Set<Subscription> listAllSubscriptions();
 
     void addNewSubscription(Subscription subscription);
 

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
@@ -54,7 +54,7 @@ public class CTrieSubscriptionDirectory implements ISubscriptionsDirectory {
      */
     @Override
     public Set<String> listAllSessionIds() {
-        final List<Subscription> subscriptions = subscriptionsRepository.listAllSubscriptions();
+        final Set<Subscription> subscriptions = subscriptionsRepository.listAllSubscriptions();
         final Set<String> clientIds = new HashSet<>(subscriptions.size());
         for (Subscription subscription : subscriptions) {
             clientIds.add(subscription.clientId);

--- a/broker/src/main/java/io/moquette/persistence/H2SubscriptionsRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/H2SubscriptionsRepository.java
@@ -8,8 +8,8 @@ import org.h2.mvstore.MVStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 public class H2SubscriptionsRepository implements ISubscriptionsRepository {
 
@@ -23,10 +23,10 @@ public class H2SubscriptionsRepository implements ISubscriptionsRepository {
     }
 
     @Override
-    public List<Subscription> listAllSubscriptions() {
+    public Set<Subscription> listAllSubscriptions() {
         LOG.debug("Retrieving existing subscriptions");
 
-        List<Subscription> results = new ArrayList<>();
+        Set<Subscription> results = new HashSet<>();
         Cursor<String, Subscription> mapCursor = subscriptions.cursor(null);
         while (mapCursor.hasNext()) {
             String subscriptionStr = mapCursor.next();

--- a/broker/src/main/java/io/moquette/persistence/MemorySubscriptionsRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/MemorySubscriptionsRepository.java
@@ -18,17 +18,23 @@ package io.moquette.persistence;
 import io.moquette.broker.ISubscriptionsRepository;
 import io.moquette.broker.subscriptions.Subscription;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentSkipListSet;
 
 public class MemorySubscriptionsRepository implements ISubscriptionsRepository {
 
-    private final List<Subscription> subscriptions = new ArrayList<>();
+    private final Set<Subscription> subscriptions = new ConcurrentSkipListSet<>((o1, o2) -> {
+        int compare = o1.getClientId().compareTo(o2.getClientId());
+        if (compare != 0) {
+            return compare;
+        }
+        return o1.getTopicFilter().toString().compareTo(o2.getTopicFilter().toString());
+    });
 
     @Override
-    public List<Subscription> listAllSubscriptions() {
-        return Collections.unmodifiableList(subscriptions);
+    public Set<Subscription> listAllSubscriptions() {
+        return Collections.unmodifiableSet(subscriptions);
     }
 
     @Override


### PR DESCRIPTION
The MemorySubscriptionsRepository implementation does not synchronise
write access to the subscriptions list. As a result, Iterations over the
list will break when another Thread modifies the list.
This changes the ArrayList to a ConcurrentSkipListSet and changes the
interface of the public List<Subscription> listAllSubscriptions() method
to return a Set.