### PR TITLE
Fixes the exception on DROP TABLE, by adding IF EXISTS

### DIFF
--- a/broker/src/test/java/io/moquette/broker/security/DBAuthenticatorTest.java
+++ b/broker/src/test/java/io/moquette/broker/security/DBAuthenticatorTest.java
@@ -46,7 +46,7 @@ public class DBAuthenticatorTest {
         this.connection = DriverManager.getConnection(JDBC_H2_MEM_TEST);
         Statement statement = this.connection.createStatement();
         try {
-            statement.execute("DROP TABLE ACCOUNT");
+            statement.execute("DROP TABLE IF EXISTS ACCOUNT");
         } catch (SQLException sqle) {
             LOG.info("Table not found, not dropping", sqle);
         }


### PR DESCRIPTION
The DBAuthenticatorTest throws an ugly exception when it tries to drop a non-existing ACCOUNT table.
This can simply be fixed by adding "IF EXISTS" to the query.