### PR TITLE
Improves build by caching maven repo

### DIFF
--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -22,7 +22,19 @@ jobs:
         name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
 
         steps:
-            - uses: actions/checkout@v2
+            - name: Check out repository
+              uses: actions/checkout@v2
+
+            - name: Cache maven repository
+              uses: actions/cache@v2
+              with:
+                  path: |
+                      ~/.m2/repository
+                  key: ${{ matrix.arch }}-${{ runner.os }}-maven-${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
+                  restore-keys: |
+                      ${{ matrix.arch }}-${{ runner.os }}-maven-${{ matrix.java }}
+                      ${{ matrix.arch }}-${{ runner.os }}-maven
+
             - name: Set up JDK
               uses: actions/setup-java@v1
               with:
@@ -30,3 +42,4 @@ jobs:
                   architecture: ${{ matrix.arch }}
             - name: Test with Maven
               run: mvn verify -B --file pom.xml
+


### PR DESCRIPTION
The current builds often fail when a download from maven central fails. They are also very slow, because all dependencies are downloaded anew every time. This PR fixes that by adding caching of the ~/.m2/repository directory.