### PR TITLE
Use static netty-tcnative

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -191,7 +191,7 @@
 
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative</artifactId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
             <version>${netty.tcnative.version}</version>
             <classifier>linux-x86_64</classifier>
             <scope>test</scope>


### PR DESCRIPTION
Ubuntu 20.04 no longer has openssl1.0.0, and thus the dynamically linked netty-tcnative no longer works.