### PR TITLE
Fix #423 resent msg not added to timeout queue

### DIFF
--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -355,6 +355,7 @@ class Session {
                 final MqttQoS qos = msg.publishingQos;
                 final ByteBuf payload = msg.payload;
                 MqttPublishMessage publishMsg = publishNotRetainedDuplicated(notAckPacketId, topic, qos, payload);
+                inflightTimeouts.add(new InFlightPacket(notAckPacketId.packetId, FLIGHT_BEFORE_RESEND_MS));
                 mqttConnection.sendPublish(publishMsg);
             }
         }


### PR DESCRIPTION
Messages that are re-sent were not added to the timeout queue, as a result, if the re-sent failed as well, the message was not resent again, instead remaining on the inflightWindow for ever. By re-adding it to the inflightTimeouts, the message is "kept alive" until sending succeeds.

`
inflightTimeouts.add(new InFlightPacket(notAckPacketId.packetId, FLIGHT_BEFORE_RESEND_MS));
`

The second commit is a slight performance optimisation, doing a get + null check instead of a contains + get