### PR TITLE
Fixes #585 MessageId not limited to 65535

### DIFF
--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -503,7 +503,7 @@ final class MQTTConnection {
     }
 
     int nextPacketId() {
-        return lastPacketId.incrementAndGet();
+        return lastPacketId.updateAndGet(v -> v == 65535 ? 1 : v + 1);
     }
 
     @Override

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
@@ -319,4 +319,13 @@ public class MQTTConnectionConnectTest {
         assertFalse(channel.isOpen(), "First 'FAKE_CLIENT_ID' channel MUST be closed by the broker");
         assertTrue(anotherChannel.isOpen(), "Second 'FAKE_CLIENT_ID' channel MUST be still open");
     }
+
+    @Test
+    public void testMessageIdGeneration() {
+        for (int i = 0; i < 65_536; i++) {
+            int nextPacketId = sut.nextPacketId();
+            assertTrue(nextPacketId > 0, "Packet ID must be > 0");
+            assertTrue(nextPacketId <= 65_535, "Packet ID must be <= 65_535");
+        }
+    }
 }


### PR DESCRIPTION
Message ID should always be in the range 1 - 65535. This adds a test, and resets the counter to 1 when needed.