### PR TITLE
Introduce H2 ValueType to serialize PublishedMessage

### DIFF
--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -66,7 +66,7 @@ public class SessionRegistry {
         }
     }
 
-    static final class PubRelMarker extends EnqueuedMessage {
+    public static final class PubRelMarker extends EnqueuedMessage {
     }
 
     public enum CreationModeEnum {

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -41,16 +41,28 @@ public class SessionRegistry {
     public abstract static class EnqueuedMessage {
     }
 
-    static class PublishedMessage extends EnqueuedMessage {
+    public static class PublishedMessage extends EnqueuedMessage {
 
         final Topic topic;
         final MqttQoS publishingQos;
         final ByteBuf payload;
 
-        PublishedMessage(Topic topic, MqttQoS publishingQos, ByteBuf payload) {
+        public PublishedMessage(Topic topic, MqttQoS publishingQos, ByteBuf payload) {
             this.topic = topic;
             this.publishingQos = publishingQos;
             this.payload = payload;
+        }
+
+        public Topic getTopic() {
+            return topic;
+        }
+
+        public MqttQoS getPublishingQos() {
+            return publishingQos;
+        }
+
+        public ByteBuf getPayload() {
+            return payload;
         }
     }
 

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -28,7 +28,6 @@ import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;

--- a/broker/src/main/java/io/moquette/persistence/ByteBufDataType.java
+++ b/broker/src/main/java/io/moquette/persistence/ByteBufDataType.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2012-2021 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.moquette.persistence;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.h2.mvstore.DataUtils;
+import org.h2.mvstore.WriteBuffer;
+
+import java.nio.ByteBuffer;
+
+public final class ByteBufDataType implements org.h2.mvstore.type.DataType {
+
+    @Override
+    public int compare(Object a, Object b) {
+        return 0;
+    }
+
+    @Override
+    public int getMemory(Object obj) {
+        if (!(obj instanceof ByteBuf)) {
+            throw new IllegalArgumentException("Expected instance of ByteBuf but found " + obj.getClass());
+        }
+        final int payloadSize = ((ByteBuf) obj).readableBytes();
+        return 4 + payloadSize;
+    }
+
+    @Override
+    public void read(ByteBuffer buff, Object[] obj, int len, boolean key) {
+        for (int i = 0; i < len; i++) {
+            obj[i] = read(buff);
+        }
+    }
+
+    @Override
+    public void write(WriteBuffer buff, Object[] obj, int len, boolean key) {
+        for (int i = 0; i < len; i++) {
+            write(buff, obj[i]);
+        }
+    }
+
+    @Override
+    public ByteBuf read(ByteBuffer buff) {
+        final int payloadSize = buff.getInt();
+        byte[] payload = new byte[payloadSize];
+        buff.get(payload);
+        return Unpooled.wrappedBuffer(payload);
+    }
+
+    @Override
+    public void write(WriteBuffer buff, Object obj) {
+        final ByteBuf casted = (ByteBuf) obj;
+        final int payloadSize = casted.readableBytes();
+        byte[] rawBytes = new byte[payloadSize];
+        casted.copy().readBytes(rawBytes);
+        buff.putInt(payloadSize);
+        buff.put(rawBytes);
+    }
+}

--- a/broker/src/main/java/io/moquette/persistence/EnqueuedMessageValueType.java
+++ b/broker/src/main/java/io/moquette/persistence/EnqueuedMessageValueType.java
@@ -38,6 +38,9 @@ public final class EnqueuedMessageValueType implements org.h2.mvstore.type.DataT
 
     @Override
     public int getMemory(Object obj) {
+        if (obj instanceof SessionRegistry.PubRelMarker) {
+            return 1;
+        }
         final SessionRegistry.PublishedMessage casted = (SessionRegistry.PublishedMessage) obj;
         final int payloadSize = casted.getPayload().readableBytes();
         return 1 + // message type

--- a/broker/src/main/java/io/moquette/persistence/EnqueuedMessageValueType.java
+++ b/broker/src/main/java/io/moquette/persistence/EnqueuedMessageValueType.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package io.moquette.persistence;
 
 import io.moquette.broker.SessionRegistry;
@@ -10,7 +25,7 @@ import org.h2.mvstore.type.StringDataType;
 
 import java.nio.ByteBuffer;
 
-public final class PublishedMessageValueType implements org.h2.mvstore.type.DataType {
+public final class EnqueuedMessageValueType implements org.h2.mvstore.type.DataType {
 
     private enum MessageType {PUB_REL_MARKER, PUBLISHED_MESSAGE}
 

--- a/broker/src/main/java/io/moquette/persistence/H2PersistentQueue.java
+++ b/broker/src/main/java/io/moquette/persistence/H2PersistentQueue.java
@@ -23,9 +23,9 @@ import java.util.AbstractQueue;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLong;
 
-class H2PersistentQueue<T> extends AbstractQueue<T> {
+class H2PersistentQueue extends AbstractQueue<SessionRegistry.EnqueuedMessage> {
 
-    private final MVMap<Long, T> queueMap;
+    private final MVMap<Long, SessionRegistry.EnqueuedMessage> queueMap;
     private final MVMap<String, Long> metadataMap;
     private final AtomicLong head;
     private final AtomicLong tail;
@@ -34,7 +34,11 @@ class H2PersistentQueue<T> extends AbstractQueue<T> {
         if (queueName == null || queueName.isEmpty()) {
             throw new IllegalArgumentException("queueName parameter can't be empty or null");
         }
-        this.queueMap = store.openMap("queue_" + queueName);
+        final MVMap.Builder<Long, SessionRegistry.EnqueuedMessage> messageTypeBuilder =
+            new MVMap.Builder<Long, SessionRegistry.EnqueuedMessage>()
+                .valueType(new EnqueuedMessageValueType());
+
+        this.queueMap = store.openMap("queue_" + queueName, messageTypeBuilder);
         this.metadataMap = store.openMap("queue_" + queueName + "_meta");
 
         //setup head index
@@ -62,7 +66,7 @@ class H2PersistentQueue<T> extends AbstractQueue<T> {
     }
 
     @Override
-    public Iterator<T> iterator() {
+    public Iterator<SessionRegistry.EnqueuedMessage> iterator() {
         return null;
     }
 
@@ -72,7 +76,7 @@ class H2PersistentQueue<T> extends AbstractQueue<T> {
     }
 
     @Override
-    public boolean offer(T t) {
+    public boolean offer(SessionRegistry.EnqueuedMessage t) {
         if (t == null) {
             throw new NullPointerException("Inserted element can't be null");
         }
@@ -83,19 +87,19 @@ class H2PersistentQueue<T> extends AbstractQueue<T> {
     }
 
     @Override
-    public T poll() {
+    public SessionRegistry.EnqueuedMessage poll() {
         if (head.equals(tail)) {
             return null;
         }
         final long nextTail = tail.getAndIncrement();
-        final T tail = this.queueMap.get(nextTail);
+        final SessionRegistry.EnqueuedMessage tail = this.queueMap.get(nextTail);
         queueMap.remove(nextTail);
         this.metadataMap.put("tail", nextTail + 1);
         return tail;
     }
 
     @Override
-    public T peek() {
+    public SessionRegistry.EnqueuedMessage peek() {
         if (head.equals(tail)) {
             return null;
         }

--- a/broker/src/main/java/io/moquette/persistence/H2PersistentQueue.java
+++ b/broker/src/main/java/io/moquette/persistence/H2PersistentQueue.java
@@ -15,6 +15,7 @@
  */
 package io.moquette.persistence;
 
+import io.moquette.broker.SessionRegistry;
 import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
 

--- a/broker/src/main/java/io/moquette/persistence/H2QueueRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/H2QueueRepository.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
 package io.moquette.persistence;
 
 import io.moquette.broker.IQueueRepository;
@@ -20,7 +35,7 @@ public class H2QueueRepository implements IQueueRepository {
     @Override
     public Queue<EnqueuedMessage> createQueue(String cli, boolean clean) {
         if (!clean) {
-            return new H2PersistentQueue<>(mvStore, cli);
+            return new H2PersistentQueue(mvStore, cli);
         }
         return new ConcurrentLinkedQueue<>();
     }
@@ -31,7 +46,7 @@ public class H2QueueRepository implements IQueueRepository {
         mvStore.getMapNames().stream()
             .filter(name -> name.startsWith("queue_") && !name.endsWith("_meta"))
             .map(name -> name.substring("queue_".length()))
-            .forEach(name -> result.put(name, new H2PersistentQueue<EnqueuedMessage>(mvStore, name)));
+            .forEach(name -> result.put(name, new H2PersistentQueue(mvStore, name)));
         return result;
     }
 }

--- a/broker/src/main/java/io/moquette/persistence/PublishedMessageValueType.java
+++ b/broker/src/main/java/io/moquette/persistence/PublishedMessageValueType.java
@@ -1,0 +1,71 @@
+package io.moquette.persistence;
+
+import io.moquette.broker.SessionRegistry;
+import io.moquette.broker.subscriptions.Topic;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import org.h2.mvstore.WriteBuffer;
+import org.h2.mvstore.type.StringDataType;
+
+import java.nio.ByteBuffer;
+
+public final class PublishedMessageValueType implements org.h2.mvstore.type.DataType {
+    private final StringDataType topicDataType = new StringDataType();
+
+    @Override
+    public int compare(Object a, Object b) {
+        return 0;
+    }
+
+    @Override
+    public int getMemory(Object obj) {
+        final SessionRegistry.PublishedMessage casted = (SessionRegistry.PublishedMessage) obj;
+        final int payloadSize = casted.getPayload().readableBytes();
+        return 1 + // qos
+            topicDataType.getMemory(casted.getTopic().toString()) + // topic
+            4 + payloadSize; // payload
+    }
+
+    @Override
+    public void write(WriteBuffer buff, Object obj) {
+        if (obj instanceof SessionRegistry.PublishedMessage) {
+            final SessionRegistry.PublishedMessage casted = (SessionRegistry.PublishedMessage) obj;
+            buff.put((byte) casted.getPublishingQos().value());
+
+            final String token = casted.getTopic().toString();
+            topicDataType.write(buff, token);
+
+            final int payloadSize = casted.getPayload().readableBytes();
+            byte[] rawBytes = new byte[payloadSize];
+            casted.getPayload().copy().readBytes(rawBytes);
+            buff.putInt(payloadSize);
+            buff.put(rawBytes);
+        }
+    }
+
+    @Override
+    public void write(WriteBuffer buff, Object[] obj, int len, boolean key) {
+        for (int i = 0; i < len; i++) {
+            write(buff, obj[i]);
+        }
+    }
+
+    @Override
+    public Object read(ByteBuffer buff) {
+        final MqttQoS qos = MqttQoS.valueOf(buff.get());
+        final String topicStr = topicDataType.read(buff);
+        final int payloadSize = buff.getInt();
+        byte[] payload = new byte[payloadSize];
+        buff.get(payload);
+        final ByteBuf byteBuf = Unpooled.wrappedBuffer(payload);
+        return new SessionRegistry.PublishedMessage(Topic.asTopic(topicStr), qos, byteBuf);
+    }
+
+    @Override
+    public void read(ByteBuffer buff, Object[] obj, int len, boolean key) {
+        for (int i = 0; i < len; i++) {
+            obj[i] = read(buff);
+        }
+    }
+}

--- a/broker/src/main/java/io/moquette/persistence/PublishedMessageValueType.java
+++ b/broker/src/main/java/io/moquette/persistence/PublishedMessageValueType.java
@@ -11,6 +11,9 @@ import org.h2.mvstore.type.StringDataType;
 import java.nio.ByteBuffer;
 
 public final class PublishedMessageValueType implements org.h2.mvstore.type.DataType {
+
+    private enum MessageType {PUB_REL_MARKER, PUBLISHED_MESSAGE}
+
     private final StringDataType topicDataType = new StringDataType();
 
     @Override
@@ -22,7 +25,8 @@ public final class PublishedMessageValueType implements org.h2.mvstore.type.Data
     public int getMemory(Object obj) {
         final SessionRegistry.PublishedMessage casted = (SessionRegistry.PublishedMessage) obj;
         final int payloadSize = casted.getPayload().readableBytes();
-        return 1 + // qos
+        return 1 + // message type
+            1 + // qos
             topicDataType.getMemory(casted.getTopic().toString()) + // topic
             4 + payloadSize; // payload
     }
@@ -30,6 +34,8 @@ public final class PublishedMessageValueType implements org.h2.mvstore.type.Data
     @Override
     public void write(WriteBuffer buff, Object obj) {
         if (obj instanceof SessionRegistry.PublishedMessage) {
+            buff.put((byte) MessageType.PUBLISHED_MESSAGE.ordinal());
+
             final SessionRegistry.PublishedMessage casted = (SessionRegistry.PublishedMessage) obj;
             buff.put((byte) casted.getPublishingQos().value());
 
@@ -41,6 +47,10 @@ public final class PublishedMessageValueType implements org.h2.mvstore.type.Data
             casted.getPayload().copy().readBytes(rawBytes);
             buff.putInt(payloadSize);
             buff.put(rawBytes);
+        } else if (obj instanceof SessionRegistry.PubRelMarker) {
+            buff.put((byte) MessageType.PUB_REL_MARKER.ordinal());
+        } else {
+            throw new IllegalArgumentException("Unrecognized message class " + obj.getClass());
         }
     }
 
@@ -53,13 +63,20 @@ public final class PublishedMessageValueType implements org.h2.mvstore.type.Data
 
     @Override
     public Object read(ByteBuffer buff) {
-        final MqttQoS qos = MqttQoS.valueOf(buff.get());
-        final String topicStr = topicDataType.read(buff);
-        final int payloadSize = buff.getInt();
-        byte[] payload = new byte[payloadSize];
-        buff.get(payload);
-        final ByteBuf byteBuf = Unpooled.wrappedBuffer(payload);
-        return new SessionRegistry.PublishedMessage(Topic.asTopic(topicStr), qos, byteBuf);
+        final byte messageType = buff.get();
+        if (messageType == MessageType.PUB_REL_MARKER.ordinal()) {
+            return new SessionRegistry.PubRelMarker();
+        } else if (messageType == MessageType.PUBLISHED_MESSAGE.ordinal()) {
+            final MqttQoS qos = MqttQoS.valueOf(buff.get());
+            final String topicStr = topicDataType.read(buff);
+            final int payloadSize = buff.getInt();
+            byte[] payload = new byte[payloadSize];
+            buff.get(payload);
+            final ByteBuf byteBuf = Unpooled.wrappedBuffer(payload);
+            return new SessionRegistry.PublishedMessage(Topic.asTopic(topicStr), qos, byteBuf);
+        } else {
+            throw new IllegalArgumentException("Can't recognize record of type: " + messageType);
+        }
     }
 
     @Override

--- a/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
@@ -16,7 +16,7 @@
 package io.moquette.broker;
 
 import io.moquette.BrokerConstants;
-import io.moquette.persistence.PublishedMessageValueType;
+import io.moquette.persistence.EnqueuedMessageValueType;
 import io.moquette.broker.security.PermitAllAuthorizatorPolicy;
 import io.moquette.broker.subscriptions.CTrieSubscriptionDirectory;
 import io.moquette.broker.subscriptions.ISubscriptionsDirectory;
@@ -149,7 +149,7 @@ public class SessionRegistryTest {
             .open();
         final MVMap.Builder<String, SessionRegistry.PublishedMessage> builder =
             new MVMap.Builder<String, SessionRegistry.PublishedMessage>()
-                .valueType(new PublishedMessageValueType());
+                .valueType(new EnqueuedMessageValueType());
 
         final ByteBuf payload = Unpooled.wrappedBuffer("Hello World!".getBytes(StandardCharsets.UTF_8));
         SessionRegistry.PublishedMessage msg = new SessionRegistry.PublishedMessage(Topic.asTopic("/say"),

--- a/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
@@ -15,18 +15,29 @@
  */
 package io.moquette.broker;
 
+import io.moquette.BrokerConstants;
+import io.moquette.persistence.PublishedMessageValueType;
 import io.moquette.broker.security.PermitAllAuthorizatorPolicy;
 import io.moquette.broker.subscriptions.CTrieSubscriptionDirectory;
 import io.moquette.broker.subscriptions.ISubscriptionsDirectory;
 import io.moquette.broker.security.IAuthenticator;
+import io.moquette.broker.subscriptions.Topic;
 import io.moquette.persistence.MemorySubscriptionsRepository;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.handler.codec.mqtt.MqttVersion;
+import org.h2.mvstore.MVMap;
+import org.h2.mvstore.MVStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
 
 import static io.moquette.broker.NettyChannelAssertions.assertEqualsConnAck;
 import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_ACCEPTED;
@@ -52,7 +63,6 @@ public class SessionRegistryTest {
 
     @BeforeEach
     public void setUp() {
-        System.out.println("setup invoked");
         connMsg = MqttMessageBuilders.connect().protocolVersion(MqttVersion.MQTT_3_1).cleanSession(true);
 
         createMQTTConnection(ALLOW_ANONYMOUS_AND_ZEROBYTE_CLIENT_ID);
@@ -129,5 +139,45 @@ public class SessionRegistryTest {
         // Verify client session is clean false
         Session session = sut.retrieve(FAKE_CLIENT_ID);
         assertFalse(session.isClean());
+    }
+
+    @Test
+    public void testSerializabilityOfPublishedMessage() {
+        MVStore mvStore = new MVStore.Builder()
+            .fileName(BrokerConstants.DEFAULT_PERSISTENT_PATH)
+            .autoCommitDisabled()
+            .open();
+        final MVMap.Builder<String, SessionRegistry.PublishedMessage> builder =
+            new MVMap.Builder<String, SessionRegistry.PublishedMessage>()
+                .valueType(new PublishedMessageValueType());
+
+        final ByteBuf payload = Unpooled.wrappedBuffer("Hello World!".getBytes(StandardCharsets.UTF_8));
+        SessionRegistry.PublishedMessage msg = new SessionRegistry.PublishedMessage(Topic.asTopic("/say"),
+            MqttQoS.AT_LEAST_ONCE, payload);
+        try {
+            // store a message in the MVStore
+            final String mapName = "test_map";
+            MVMap<String, SessionRegistry.PublishedMessage> persistentMap = mvStore.openMap(mapName, builder);
+            String key = "message";
+            persistentMap.put(key, msg);
+            mvStore.close();
+
+            // reopen the MVStore and read it
+            mvStore = new MVStore.Builder()
+                .fileName(BrokerConstants.DEFAULT_PERSISTENT_PATH)
+                .autoCommitDisabled()
+                .open();
+            final SessionRegistry.PublishedMessage reloadedMsg = mvStore.openMap(mapName, builder).get(key);
+
+            // Verify
+            assertEquals("/say", reloadedMsg.topic.toString());
+        } finally {
+            mvStore.close();
+            File dbFile = new File(BrokerConstants.DEFAULT_PERSISTENT_PATH);
+            if (dbFile.exists()) {
+                dbFile.delete();
+            }
+            assertFalse(dbFile.exists());
+        }
     }
 }


### PR DESCRIPTION
Introduce H2 ValueType and use it in Builder to serialize PublishedMessage instances.

Fixes #566
Closes #568