### PR TITLE
Fixed #573 ByteBuf reference counting

### DIFF
--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -18,6 +18,7 @@ package io.moquette.broker;
 import io.moquette.broker.subscriptions.Topic;
 import io.moquette.broker.security.IAuthenticator;
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
@@ -37,6 +38,7 @@ import static io.netty.channel.ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE;
 import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.*;
 import static io.netty.handler.codec.mqtt.MqttMessageIdVariableHeader.from;
 import static io.netty.handler.codec.mqtt.MqttQoS.*;
+import io.netty.util.ReferenceCountUtil;
 
 final class MQTTConnection {
 
@@ -377,7 +379,6 @@ final class MQTTConnection {
             case EXACTLY_ONCE: {
                 bindedSession.receivedPublishQos2(messageID, msg);
                 postOffice.receivedPublishQos2(this, msg, username);
-//                msg.release();
                 break;
             }
             default:
@@ -419,11 +420,19 @@ final class MQTTConnection {
             LOG.debug("OUT {}", msg.fixedHeader().messageType());
         }
         if (channel.isWritable()) {
+
+            // Sending to external, retain a duplicate. Just retain is not
+            // enough, since the receiver must have full control.
+            Object retainedDup = msg;
+            if (msg instanceof ByteBufHolder) {
+                retainedDup = ((ByteBufHolder) msg).retainedDuplicate();
+            }
+
             ChannelFuture channelFuture;
             if (brokerConfig.isImmediateBufferFlush()) {
-                channelFuture = channel.writeAndFlush(msg);
+                channelFuture = channel.writeAndFlush(retainedDup);
             } else {
-                channelFuture = channel.write(msg);
+                channelFuture = channel.write(retainedDup);
             }
             channelFuture.addListener(FIRE_EXCEPTION_ON_FAILURE);
         }

--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -295,7 +295,7 @@ public class Server {
      * Use the broker to publish a message. It's intended for embedding applications. It can be used
      * only after the integration is correctly started with startServer.
      *
-     * @param msg      the message to forward.
+     * @param msg      the message to forward. The ByteBuf in the message will be released.
      * @param clientId the id of the sending integration.
      * @throws IllegalStateException if the integration is not yet started
      */
@@ -308,6 +308,7 @@ public class Server {
         }
         LOG.trace("Internal publishing message CId: {}, messageId: {}", clientId, messageID);
         dispatcher.internalPublish(msg);
+        msg.payload().release();
     }
 
     public void stopServer() {

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -38,6 +38,18 @@ import java.util.stream.Collectors;
 public class SessionRegistry {
 
     public abstract static class EnqueuedMessage {
+
+        /**
+         * Releases any held resources. Must be called when the EnqueuedMessage is no
+         * longer needed.
+         */
+        public void release() {}
+
+        /**
+         * Retains any held resources. Must be called when the EnqueuedMessage is added
+         * to a store.
+         */
+        public void retain() {}
     }
 
     public static class PublishedMessage extends EnqueuedMessage {
@@ -63,6 +75,17 @@ public class SessionRegistry {
         public ByteBuf getPayload() {
             return payload;
         }
+
+        @Override
+        public void release() {
+            payload.release();
+        }
+
+        @Override
+        public void retain() {
+            payload.retain();
+        }
+
     }
 
     public static final class PubRelMarker extends EnqueuedMessage {

--- a/broker/src/main/java/io/moquette/interception/AbstractInterceptHandler.java
+++ b/broker/src/main/java/io/moquette/interception/AbstractInterceptHandler.java
@@ -48,6 +48,7 @@ public abstract class AbstractInterceptHandler implements InterceptHandler {
 
     @Override
     public void onPublish(InterceptPublishMessage msg) {
+        msg.getPayload().release();
     }
 
     @Override

--- a/broker/src/main/java/io/moquette/interception/BrokerInterceptor.java
+++ b/broker/src/main/java/io/moquette/interception/BrokerInterceptor.java
@@ -130,7 +130,8 @@ public final class BrokerInterceptor implements Interceptor {
                     for (InterceptHandler handler : handlers.get(InterceptPublishMessage.class)) {
                         LOG.debug("Notifying MQTT PUBLISH message to interceptor. CId={}, messageId={}, topic={}, "
                                 + "interceptorId={}", clientID, messageId, topic, handler.getID());
-                        handler.onPublish(new InterceptPublishMessage(msg, clientID, username));
+                        // Sending to the outside, make a retainedDuplicate.
+                        handler.onPublish(new InterceptPublishMessage(msg.retainedDuplicate(), clientID, username));
                     }
                 } finally {
                     ReferenceCountUtil.release(msg);

--- a/broker/src/main/java/io/moquette/interception/InterceptHandler.java
+++ b/broker/src/main/java/io/moquette/interception/InterceptHandler.java
@@ -52,6 +52,12 @@ public interface InterceptHandler {
 
     void onConnectionLost(InterceptConnectionLostMessage msg);
 
+    /**
+     * Called when a message is published. The receiver MUST release the payload of the message, either
+     * by calling super.onPublish, or by calling msg.getPayload.release() directly.
+     *
+     * @param msg The message that was published.
+     */
     void onPublish(InterceptPublishMessage msg);
 
     void onSubscribe(InterceptSubscribeMessage msg);

--- a/broker/src/main/java/io/moquette/persistence/ByteBufDataType.java
+++ b/broker/src/main/java/io/moquette/persistence/ByteBufDataType.java
@@ -65,7 +65,7 @@ public final class ByteBufDataType implements org.h2.mvstore.type.DataType {
         final ByteBuf casted = (ByteBuf) obj;
         final int payloadSize = casted.readableBytes();
         byte[] rawBytes = new byte[payloadSize];
-        casted.copy().readBytes(rawBytes);
+        casted.copy().readBytes(rawBytes).release();
         buff.putInt(payloadSize);
         buff.put(rawBytes);
     }

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
@@ -20,6 +20,7 @@ import io.moquette.broker.subscriptions.CTrieSubscriptionDirectory;
 import io.moquette.broker.subscriptions.ISubscriptionsDirectory;
 import io.moquette.broker.security.IAuthenticator;
 import io.moquette.persistence.MemorySubscriptionsRepository;
+import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
@@ -81,16 +82,18 @@ public class MQTTConnectionPublishTest {
     @Test
     public void dropConnectionOnPublishWithInvalidTopicFormat() {
         // Connect message with clean session set to true and client id is null.
+        final ByteBuf payload = Unpooled.copiedBuffer("Hello MQTT world!".getBytes(UTF_8));
         MqttPublishMessage publish = MqttMessageBuilders.publish()
             .topicName("")
             .retained(false)
             .qos(MqttQoS.AT_MOST_ONCE)
-            .payload(Unpooled.copiedBuffer("Hello MQTT world!".getBytes(UTF_8))).build();
+            .payload(payload).build();
 
         sut.processPublish(publish);
 
         // Verify
         assertFalse(channel.isOpen(), "Connection should be closed by the broker");
+        payload.release();
     }
 
 }

--- a/broker/src/test/java/io/moquette/broker/SessionTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionTest.java
@@ -39,6 +39,13 @@ public class SessionTest {
 
         // Verify
         assertTrue(queuedMessages.isEmpty(), "Messages should be drained");
+        
+        // release the rest, to avoid leaking buffers
+        for (int i = 2; i <= 11; i++) {
+            client.pubAckReceived(i);
+        }
+        client.closeImmediately();
+        testChannel.close();
     }
 
     private void sendQoS1To(Session client, Topic destinationTopic, String message) {

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationPahoCanPublishOnReadBlockedTopicTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationPahoCanPublishOnReadBlockedTopicTest.java
@@ -146,6 +146,8 @@ public class ServerIntegrationPahoCanPublishOnReadBlockedTopicTest {
             .payload(Unpooled.copiedBuffer("Hello World!!".getBytes(UTF_8)))
             .build();
 
+        // We will be sending the same message again, retain the payload.
+        message.payload().retain();
         m_server.internalPublish(message, "INTRLPUB");
 
         Awaitility.await().until(m_messagesCollector::isMessageReceived);

--- a/broker/src/test/java/io/moquette/integration/ServerLowlevelMessagesIntegrationTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerLowlevelMessagesIntegrationTest.java
@@ -190,7 +190,7 @@ public class ServerLowlevelMessagesIntegrationTest {
             subscriber.subscribe(topic, 1, (String topic1, org.eclipse.paho.client.mqttv3.MqttMessage message) -> {
                 if (isFirst.getAndSet(false)) {
                     // wait to trigger resending PUBLISH
-                    TimeUnit.SECONDS.sleep(FLIGHT_BEFORE_RESEND_MS * 2);
+                    TimeUnit.MILLISECONDS.sleep(FLIGHT_BEFORE_RESEND_MS * 2);
                 } else {
                     receivedPublish.set(true);
                 }


### PR DESCRIPTION
The reworks most of the ByteBuf reference counting by moving all buffer release/retain calls to the outside interfaces of moquette.
This supersedes #576 and is based on the discussion there.

Close #576
Close #599
Fix #573


