### PR TITLE
Fixed #610: Subscriptions not removed from session on unsubscribe

### DIFF
--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -134,6 +134,7 @@ class PostOffice {
 
     public void unsubscribe(List<String> topics, MQTTConnection mqttConnection, int messageId) {
         final String clientID = mqttConnection.getClientId();
+        final Session session = sessionRegistry.retrieve(clientID);
         for (String t : topics) {
             Topic topic = new Topic(t);
             boolean validTopic = topic.isValid();
@@ -147,8 +148,7 @@ class PostOffice {
             LOG.trace("Removing subscription topic={}", topic);
             subscriptions.removeSubscription(topic, clientID);
 
-            // TODO remove the subscriptions to Session
-//            clientSession.unsubscribeFrom(topic);
+            session.removeSubscription(topic);
 
             String username = NettyUtils.userName(mqttConnection.channel);
             interceptor.notifyTopicUnsubscribed(topic.toString(), clientID, username);

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -93,7 +93,7 @@ class Session {
     private final Queue<SessionRegistry.EnqueuedMessage> sessionQueue;
     private final AtomicReference<SessionStatus> status = new AtomicReference<>(SessionStatus.DISCONNECTED);
     private MQTTConnection mqttConnection;
-    private List<Subscription> subscriptions = new ArrayList<>();
+    private final Set<Subscription> subscriptions = new HashSet<>();
     private final Map<Integer, SessionRegistry.EnqueuedMessage> inflightWindow = new HashMap<>();
     private final DelayQueue<InFlightPacket> inflightTimeouts = new DelayQueue<>();
     private final Map<Integer, MqttPublishMessage> qos2Receiving = new HashMap<>();
@@ -148,6 +148,10 @@ class Session {
 
     public void addSubscriptions(List<Subscription> newSubscriptions) {
         subscriptions.addAll(newSubscriptions);
+    }
+
+    public void removeSubscription(Topic topic) {
+        subscriptions.remove(new Subscription(clientId, topic, MqttQoS.EXACTLY_ONCE));
     }
 
     public boolean hasWill() {


### PR DESCRIPTION
On unsubscribe, subscriptions were not removed from Sessions and duplicate subscriptions did not replace the old subscription in the Session.

By changing Session.subscription from a List to a Set, duplicate subscriptions automatically replace old ones, and removing subscriptions becomes easier.
Also adds a Test.