### PR TITLE
feat: expose netty enabled tls protocols option

### DIFF
--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -71,6 +71,7 @@ public final class BrokerConstants {
     public static final String NETTY_EPOLL_PROPERTY_NAME = "netty.epoll";
     public static final String NETTY_MAX_BYTES_PROPERTY_NAME = "netty.mqtt.message_size";
     public static final int DEFAULT_NETTY_MAX_BYTES_IN_MESSAGE = 8092;
+    public static final String NETTY_ENABLED_TLS_PROTOCOLS_PROPERTY_NAME = "netty.enabled.tls.protocols";
     public static final String IMMEDIATE_BUFFER_FLUSH_PROPERTY_NAME = "immediate_buffer_flush";
     public static final String METRICS_ENABLE_PROPERTY_NAME = "use_metrics";
     public static final String METRICS_LIBRATO_EMAIL_PROPERTY_NAME = "metrics.librato.email";

--- a/broker/src/main/java/io/moquette/broker/DefaultMoquetteSslContextCreator.java
+++ b/broker/src/main/java/io/moquette/broker/DefaultMoquetteSslContextCreator.java
@@ -89,6 +89,14 @@ class DefaultMoquetteSslContextCreator implements ISslContextCreator {
             if (Boolean.valueOf(sNeedsClientAuth)) {
                 addClientAuthentication(ks, contextBuilder);
             }
+
+            // if enabled tls protocols are not provided, we use the default
+            String enabledTLSProtocols = props.getProperty(BrokerConstants.NETTY_ENABLED_TLS_PROTOCOLS_PROPERTY_NAME);
+            if (enabledTLSProtocols != null) {
+                LOG.info(String.format("Enabled TLS Protocols: {%s}", enabledTLSProtocols));
+                contextBuilder.protocols(enabledTLSProtocols.split(";"));
+            }
+
             contextBuilder.sslProvider(sslProvider);
             SslContext sslContext = contextBuilder.build();
             LOG.info("The SSL context has been initialized successfully.");

--- a/distribution/src/main/resources/moquette.conf
+++ b/distribution/src/main/resources/moquette.conf
@@ -1,8 +1,8 @@
 ##############################################
-#  Moquette configuration file. 
+#  Moquette configuration file.
 #
 #  The synthax is equals to mosquitto.conf
-# 
+#
 ##############################################
 
 port 1883
@@ -126,10 +126,13 @@ password_file config/password_file.conf
 # http://netty.io/wiki/native-transports.html for more information
 # netty.mqtt.message_size : by default the max size of message is set at 8092 bytes
 # http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/errata01/os/mqtt-v3.1.1-errata01-os-complete.html#_Toc442180836
-# Fore more information about payload size specs.
+# For more information about payload size specs.
+# netty.enabled.tls.protocols : semi-colon separated list of TLS protocols to enable.
+# This is useful for disabling older or insecure TLS versions.
 #*********************************************************************
 # netty.epoll true
 # netty.mqtt.message_size 8092
+# netty.enabled.tls.protocols "TLSv1.2;TLSv1.3"
 
 #*********************************************************************
 # Metrics Configuration


### PR DESCRIPTION
By exposing this configurations, customers can choose to disable older
or insecure versions of TLS. For example, with this change, it is
possible to force clients to use TLSv1.2

This was tested by using mosquitto client tools to force a specific TLS version and confirm that older protocols were, indeed, disabled. Though it would be nice to have an explicit test to this. I can look at adding one.