### PR TITLE
fix: re-factor Session creation logic and fix Session mem leaks

### DIFF
--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -38,7 +38,6 @@ import static io.netty.channel.ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE;
 import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.*;
 import static io.netty.handler.codec.mqtt.MqttMessageIdVariableHeader.from;
 import static io.netty.handler.codec.mqtt.MqttQoS.*;
-import io.netty.util.ReferenceCountUtil;
 
 final class MQTTConnection {
 

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -187,7 +187,7 @@ public class SessionRegistry {
 
     private void terminateSession(Session session) {
         unsubscribe(session);
-        // TODO - terminate session
+        session.terminateSession();
     }
 
     private void reactivateSubscriptions(Session session, String username) {
@@ -237,6 +237,7 @@ public class SessionRegistry {
     }
 
     public void remove(Session session) {
+        session.terminateSession();
         pool.remove(session.getClientID(), session);
     }
 

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -187,7 +187,7 @@ public class SessionRegistry {
 
     private void terminateSession(Session session) {
         unsubscribe(session);
-        session.terminateSession();
+        session.release();
     }
 
     private void reactivateSubscriptions(Session session, String username) {
@@ -237,8 +237,9 @@ public class SessionRegistry {
     }
 
     public void remove(Session session) {
-        session.terminateSession();
-        pool.remove(session.getClientID(), session);
+        if (pool.remove(session.getClientID(), session)) {
+            session.release();
+        }
     }
 
     Collection<ClientDescriptor> listConnectedClients() {

--- a/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
@@ -100,7 +100,8 @@ public class SessionRegistryTest {
         NettyUtils.cleanSession(channel, false);
 
         // Connect a first time
-        final SessionRegistry.SessionCreationResult res = sut.createOrReopenSession(msg, FAKE_CLIENT_ID, connection.getUsername());
+        final SessionRegistry.SessionCreationResult res = sut.openAndBindSession(msg, FAKE_CLIENT_ID,
+            connection.getUsername(), connection);
         // disconnect
         res.session.disconnect();
 //        sut.disconnect(FAKE_CLIENT_ID);
@@ -108,7 +109,8 @@ public class SessionRegistryTest {
         // Exercise, reconnect
         EmbeddedChannel anotherChannel = new EmbeddedChannel();
         MQTTConnection anotherConnection = createMQTTConnection(ALLOW_ANONYMOUS_AND_ZEROBYTE_CLIENT_ID, anotherChannel);
-        final SessionRegistry.SessionCreationResult result = sut.createOrReopenSession(msg, FAKE_CLIENT_ID, anotherConnection.getUsername());
+        final SessionRegistry.SessionCreationResult result = sut.openAndBindSession(msg, FAKE_CLIENT_ID,
+            anotherConnection.getUsername(), anotherConnection);
 
         // Verify
         assertEquals(SessionRegistry.CreationModeEnum.CREATED_CLEAN_NEW, result.mode);


### PR DESCRIPTION
There are a lot of changes in this PR. I can can probably try to tease them apart and submit separate PRs, but everything is related so it may be easier to review with full context.

There are several issues with how the SessionRegistry manages Sessions, and Sessions themselves are not properly cleaned up. See the discussion in #608 

This attempts to solve these issues by refactoring Session management logic. If a Session is being resumed, then the same Session object is used (rather than copying state into a new one). Conversely, clean sessions always result in a brand new Session. This eliminates current issues where resumed Sessions actually drop messages that are in the inflightQueue, and also where clean sessions can still receive messages queued in the old Session.

This change also properly "terminates" a Session so that netty ByteBuf's aren't leaked when Session objects are GC'd. I've added reference counting to the Session object to prevent messages from being queued while a Session is being terminated.