### PR TITLE
Fix #629: Adding subscriptions is very slow

### DIFF
--- a/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
@@ -40,22 +40,15 @@ class CNode implements Comparable<CNode> {
         return token;
     }
 
-    boolean anyChildrenMatch(Token token) {
-        int idx = Collections.binarySearch(children, token, (Object node, Object token1) -> ((INode) node).mainNode().token.compareTo((Token) token1));
-        return idx >= 0;
-    }
-
     List<INode> allChildren() {
         return new ArrayList<>(this.children);
     }
 
     INode childOf(Token token) {
         int idx = Collections.binarySearch(children, token, (Object node, Object token1) -> ((INode) node).mainNode().token.compareTo((Token) token1));
-        INode child = children.get(idx);
-        if (child != null) {
-            return child;
-        }
-        throw new IllegalArgumentException("Asked for a token that doesn't exists in any child [" + token + "]");
+        if (idx < 0)
+            return null;
+        return children.get(idx);
     }
 
     private boolean equalsToken(Token token) {

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
@@ -72,7 +72,7 @@ class CNode implements Comparable<CNode> {
     }
 
     public void add(INode newINode) {
-        int idx = Collections.binarySearch(children, token, (Object node, Object token1) -> ((INode) node).mainNode().token.compareTo((Token) token1));
+        int idx = Collections.binarySearch(children, newINode.mainNode().token, (Object node, Object token1) -> ((INode) node).mainNode().token.compareTo((Token) token1));
         if (idx < 0) {
             children.add(-1 - idx, newINode);
         } else {

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
@@ -45,10 +45,16 @@ class CNode implements Comparable<CNode> {
     }
 
     INode childOf(Token token) {
-        int idx = Collections.binarySearch(children, token, (Object node, Object token1) -> ((INode) node).mainNode().token.compareTo((Token) token1));
-        if (idx < 0)
+        int idx = findIndexForToken(token);
+        if (idx < 0) {
             return null;
+        }
         return children.get(idx);
+    }
+
+    private int findIndexForToken(Token token) {
+        final INode tempTokenNode = new INode(new CNode(token));
+        return Collections.binarySearch(children, tempTokenNode, (INode node, INode tokenHolder) -> node.mainNode().token.compareTo(tokenHolder.mainNode().token));
     }
 
     private boolean equalsToken(Token token) {
@@ -65,7 +71,7 @@ class CNode implements Comparable<CNode> {
     }
 
     public void add(INode newINode) {
-        int idx = Collections.binarySearch(children, newINode.mainNode().token, (Object node, Object token1) -> ((INode) node).mainNode().token.compareTo((Token) token1));
+        int idx = findIndexForToken(newINode.mainNode().token);
         if (idx < 0) {
             children.add(-1 - idx, newINode);
         } else {
@@ -74,7 +80,7 @@ class CNode implements Comparable<CNode> {
     }
 
     public void remove(INode node) {
-        int idx = Collections.binarySearch(children, node.mainNode().token, (Object node1, Object token1) -> ((INode) node1).mainNode().token.compareTo((Token) token1));
+        int idx = findIndexForToken(node.mainNode().token);
         this.children.remove(idx);
     }
 

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
@@ -44,12 +44,12 @@ class CNode implements Comparable<CNode> {
         return new ArrayList<>(this.children);
     }
 
-    INode childOf(Token token) {
+    Optional<INode> childOf(Token token) {
         int idx = findIndexForToken(token);
         if (idx < 0) {
-            return null;
+            return Optional.empty();
         }
-        return children.get(idx);
+        return Optional.of(children.get(idx));
     }
 
     private int findIndexForToken(Token token) {

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
@@ -78,11 +78,24 @@ public class CTrie {
         }
         Topic remainingTopic = (ROOT.equals(cnode.getToken())) ? topic : topic.exceptHeadToken();
         Set<Subscription> subscriptions = new HashSet<>();
+
+        // We should only consider the maximum three children children of
+        // type #, + or exact match
+        INode subInode = cnode.childOf(Token.MULTI);
+        if (subInode != null) {
+            subscriptions.addAll(recursiveMatch(remainingTopic, subInode));
+        }
+        subInode = cnode.childOf(Token.SINGLE);
+        if (subInode != null) {
+            subscriptions.addAll(recursiveMatch(remainingTopic, subInode));
+        }
         if (remainingTopic.isEmpty()) {
             subscriptions.addAll(cnode.subscriptions);
-        }
-        for (INode subInode : cnode.allChildren()) {
-            subscriptions.addAll(recursiveMatch(remainingTopic, subInode));
+        } else {
+            subInode = cnode.childOf(remainingTopic.headToken());
+            if (subInode != null) {
+                subscriptions.addAll(recursiveMatch(remainingTopic, subInode));
+            }
         }
         return subscriptions;
     }

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
@@ -24,8 +24,7 @@ public class CTrie {
     INode root;
 
     CTrie() {
-        final CNode mainNode = new CNode();
-        mainNode.setToken(ROOT);
+        final CNode mainNode = new CNode(ROOT);
         this.root = new INode(mainNode);
     }
 
@@ -133,8 +132,7 @@ public class CTrie {
         Topic remainingTopic = topic.exceptHeadToken();
         if (!remainingTopic.isEmpty()) {
             INode inode = createPathRec(remainingTopic, newSubscription);
-            CNode cnode = new CNode();
-            cnode.setToken(topic.headToken());
+            CNode cnode = new CNode(topic.headToken());
             cnode.add(inode);
             return new INode(cnode);
         } else {
@@ -143,8 +141,7 @@ public class CTrie {
     }
 
     private INode createLeafNodes(Token token, Subscription newSubscription) {
-        CNode newLeafCnode = new CNode();
-        newLeafCnode.setToken(token);
+        CNode newLeafCnode = new CNode(token);
         newLeafCnode.addSubscription(newSubscription);
 
         return new INode(newLeafCnode);
@@ -176,7 +173,7 @@ public class CTrie {
                 if (inode == this.root) {
                     return inode.compareAndSet(cnode, inode.mainNode().copy()) ? Action.OK : Action.REPEAT;
                 }
-                TNode tnode = new TNode();
+                TNode tnode = new TNode(cnode.getToken());
                 return inode.compareAndSet(cnode, tnode) ? cleanTomb(inode, iParent) : Action.REPEAT;
             } else if (cnode.contains(clientId) && topic.isEmpty()) {
                 CNode updatedCnode = cnode.copy();

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
@@ -129,13 +129,22 @@ public class CTrie {
     }
 
     private Action insertSubscription(INode inode, CNode cnode, Subscription newSubscription) {
-        final CNode updatedCnode = cnode.copy().addSubscription(newSubscription);
+        final CNode updatedCnode;
+        if (cnode instanceof TNode)
+            updatedCnode = new CNode(cnode.getToken());
+        else
+            updatedCnode = cnode.copy();
+        updatedCnode.addSubscription(newSubscription);
         return inode.compareAndSet(cnode, updatedCnode) ? Action.OK : Action.REPEAT;
     }
 
     private Action createNodeAndInsertSubscription(Topic topic, INode inode, CNode cnode, Subscription newSubscription) {
         final INode newInode = createPathRec(topic, newSubscription);
-        final CNode updatedCnode = cnode.copy();
+        final CNode updatedCnode;
+        if (cnode instanceof TNode)
+            updatedCnode = new CNode(cnode.getToken());
+        else
+            updatedCnode = cnode.copy();
         updatedCnode.add(newInode);
 
         return inode.compareAndSet(cnode, updatedCnode) ? Action.OK : Action.REPEAT;

--- a/broker/src/main/java/io/moquette/broker/subscriptions/TNode.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/TNode.java
@@ -17,13 +17,12 @@ package io.moquette.broker.subscriptions;
 
 class TNode extends CNode {
 
-    @Override
-    public Token getToken() {
-        throw new IllegalStateException("Can't be invoked on TNode");
+    public TNode(Token token) {
+        super(token);
     }
 
     @Override
-    public void setToken(Token token) {
+    public Token getToken() {
         throw new IllegalStateException("Can't be invoked on TNode");
     }
 

--- a/broker/src/main/java/io/moquette/broker/subscriptions/TNode.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/TNode.java
@@ -22,11 +22,6 @@ class TNode extends CNode {
     }
 
     @Override
-    public Token getToken() {
-        throw new IllegalStateException("Can't be invoked on TNode");
-    }
-
-    @Override
     INode childOf(Token token) {
         throw new IllegalStateException("Can't be invoked on TNode");
     }

--- a/broker/src/main/java/io/moquette/broker/subscriptions/TNode.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/TNode.java
@@ -61,8 +61,4 @@ class TNode extends CNode {
         throw new IllegalStateException("Can't be invoked on TNode");
     }
 
-    @Override
-    boolean anyChildrenMatch(Token token) {
-        return false;
-    }
 }

--- a/broker/src/main/java/io/moquette/broker/subscriptions/TNode.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/TNode.java
@@ -15,6 +15,8 @@
  */
 package io.moquette.broker.subscriptions;
 
+import java.util.Optional;
+
 class TNode extends CNode {
 
     public TNode(Token token) {
@@ -22,7 +24,7 @@ class TNode extends CNode {
     }
 
     @Override
-    INode childOf(Token token) {
+    Optional<INode> childOf(Token token) {
         throw new IllegalStateException("Can't be invoked on TNode");
     }
 

--- a/broker/src/main/java/io/moquette/broker/subscriptions/Token.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/Token.java
@@ -19,7 +19,7 @@ package io.moquette.broker.subscriptions;
 /**
  * Internal use only class.
  */
-public class Token {
+public class Token implements Comparable<Token> {
 
     static final Token EMPTY = new Token("");
     static final Token MULTI = new Token("#");
@@ -71,5 +71,19 @@ public class Token {
     @Override
     public String toString() {
         return name;
+    }
+
+    @Override
+    public int compareTo(Token other) {
+        if (name == null) {
+            if (other.name == null) {
+                return 0;
+            }
+            return 1;
+        }
+        if (other.name == null) {
+            return -1;
+        }
+        return name.compareTo(other.name);
     }
 }

--- a/broker/src/test/java/io/moquette/broker/subscriptions/CTrieSpeedTest.java
+++ b/broker/src/test/java/io/moquette/broker/subscriptions/CTrieSpeedTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2012-2023 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.moquette.broker.subscriptions;
+
+import static io.moquette.broker.subscriptions.Topic.asTopic;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CTrieSpeedTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CTrieSpeedTest.class.getName());
+
+    private static final int MAX_DURATION_S = 5 * 60;
+    private static final int CHECK_INTERVAL = 50_000;
+    private static final int TOTAL_SUBSCRIPTIONS = 500_000;
+
+    static Subscription clientSubOnTopic(String clientID, String topicName) {
+        return new Subscription(clientID, asTopic(topicName), null);
+    }
+
+    @Test
+    @Timeout(value = MAX_DURATION_S)
+    public void testFlat() {
+        List<Subscription> results = prepareSubscriptionsFlat();
+        createSubscriptions(results);
+    }
+
+    @Test
+    @Timeout(value = MAX_DURATION_S)
+    public void testDeep() {
+        List<Subscription> results = prepareSubscriptionsDeep();
+        createSubscriptions(results);
+    }
+
+    public void createSubscriptions(List<Subscription> results) {
+        int count = 0;
+        long start = System.currentTimeMillis();
+        int log = CHECK_INTERVAL;
+        CTrie tree = new CTrie();
+        for (Subscription result : results) {
+            tree.addToTree(result);
+            count++;
+            log--;
+            if (log <= 0) {
+                log = CHECK_INTERVAL;
+                long end = System.currentTimeMillis();
+                long duration = end - start;
+                LOGGER.info("Added {} subscriptions in {} ms ({}/ms)", count, duration, Math.round(1.0 * count / duration));
+            }
+            if (Thread.currentThread().isInterrupted()) {
+                return;
+            }
+        }
+        long end = System.currentTimeMillis();
+        long duration = end - start;
+        LOGGER.info("Added " + count + " subscriptions in " + duration + " ms (" + Math.round(1000.0 * count / duration) + "/s)");
+    }
+
+    public List<Subscription> prepareSubscriptionsFlat() {
+        List<Subscription> results = new ArrayList<>(TOTAL_SUBSCRIPTIONS);
+        int count = 0;
+        long start = System.currentTimeMillis();
+        for (int topicNr = 0; topicNr < TOTAL_SUBSCRIPTIONS / 10; topicNr++) {
+            for (int clientNr = 0; clientNr < 10; clientNr++) {
+                count++;
+                results.add(clientSubOnTopic("Client-" + clientNr, "mainTopic-" + topicNr));
+            }
+        }
+        long end = System.currentTimeMillis();
+        long duration = end - start;
+        LOGGER.info("Prepared {} subscriptions in {} ms", count, duration);
+        return results;
+    }
+
+    public List<Subscription> prepareSubscriptionsDeep() {
+        List<Subscription> results = new ArrayList<>(TOTAL_SUBSCRIPTIONS);
+        long countPerLevel = Math.round(Math.pow(TOTAL_SUBSCRIPTIONS, 0.25));
+        LOGGER.info("Preparing {} subscriptions, 4 deep with {} per level", TOTAL_SUBSCRIPTIONS, countPerLevel);
+        int count = 0;
+        long start = System.currentTimeMillis();
+        outerloop:
+        for (int clientNr = 0; clientNr < countPerLevel; clientNr++) {
+            for (int firstLevelNr = 0; firstLevelNr < countPerLevel; firstLevelNr++) {
+                for (int secondLevelNr = 0; secondLevelNr < countPerLevel; secondLevelNr++) {
+                    for (int thirdLevelNr = 0; thirdLevelNr < countPerLevel; thirdLevelNr++) {
+                        count++;
+                        results.add(clientSubOnTopic("Client-" + clientNr, "mainTopic-" + firstLevelNr + "/subTopic-" + secondLevelNr + "/subSubTopic" + thirdLevelNr));
+                        // Due to the 4th-power-root we don't get exactly the required number of subs.
+                        if (count >= TOTAL_SUBSCRIPTIONS) {
+                            break outerloop;
+                        }
+                    }
+                }
+            }
+        }
+        long end = System.currentTimeMillis();
+        long duration = end - start;
+        LOGGER.info("Prepared {} subscriptions in {} ms", count, duration);
+        return results;
+    }
+
+}

--- a/broker/src/test/java/io/moquette/integration/PublishToManySubscribersUseCaseTest.java
+++ b/broker/src/test/java/io/moquette/integration/PublishToManySubscribersUseCaseTest.java
@@ -162,7 +162,7 @@ public class PublishToManySubscribersUseCaseTest extends AbstractIntegration {
     }
 
     private void segmentedParallelSubscriptions(BiConsumer<IMqttAsyncClient, IMqttActionListener> biConsumer) throws InterruptedException {
-        int openSlotCount = COMMAND_QUEUE_SIZE;
+        int openSlotCount = COMMAND_QUEUE_SIZE / 2;
         Semaphore openSlots = new Semaphore(openSlotCount);
         IMqttActionListener completionCallback = createMqttCallback(openSlots);
         for (IMqttAsyncClient subscriber : this.subscribers) {

--- a/broker/src/test/resources/log4j.properties
+++ b/broker/src/test/resources/log4j.properties
@@ -7,6 +7,7 @@ log4j.logger.io.moquette=WARN
 #log4j.logger.io.moquette.broker.SessionRegistry=DEBUG
 #log4j.logger.io.moquette.broker.PostOffice=DEBUG
 #log4j.logger.io.moquette.broker=WARN
+log4j.logger.io.moquette.broker.subscriptions.CTrieSpeedTest=INFO
 
 # stdout appender is set to be consoleAppender.
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender


### PR DESCRIPTION
- Sort CNode.children by token
  - made Token comparable
  - made CNode.token final
  - Changed all searches to use Collections.binarySearch()
  - Changed inserts to respect sorting order
- Optimised away all instances that loop over all children
- Optimised away double lookup caused by "contains then get"