### PR TITLE
Adds session events processors and queues of commands

### DIFF
--- a/.github/workflows/maven_central_release_version.yml
+++ b/.github/workflows/maven_central_release_version.yml
@@ -8,11 +8,7 @@ name: Build and ship to Maven Central
 #            - "v*"
 on:
     release:
-<<<<<<< HEAD
         types: [released]
-=======
-        types: [created]
->>>>>>> ed873606... Revert "Removed Maven publishing workflows from personal fork"
 
 jobs:
     publish:

--- a/.github/workflows/maven_central_release_version.yml
+++ b/.github/workflows/maven_central_release_version.yml
@@ -8,7 +8,11 @@ name: Build and ship to Maven Central
 #            - "v*"
 on:
     release:
+<<<<<<< HEAD
         types: [released]
+=======
+        types: [created]
+>>>>>>> ed873606... Revert "Removed Maven publishing workflows from personal fork"
 
 jobs:
     publish:

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,5 +1,6 @@
 Version 0.16-SNAPSHOT:
    [build] drop generation of broker-test, removed distribution and embedding_moquette modules from deploy phase (#616)
+   [fix] introduces sessions event processors to segregate changes to a session in one single thread, simplifying concurrency and code (#631)
 
 Version 0.15.1:
    [fix] avoid double subscription (#612)

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -196,26 +196,26 @@
 <!--                </executions>-->
 <!--            </plugin>-->
 
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                    <compilerArgs>
-                        <arg>-XDcompilePolicy=simple</arg>
-                        <arg>-Xplugin:ErrorProne</arg>
-                    </compilerArgs>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>com.google.errorprone</groupId>
-                            <artifactId>error_prone_core</artifactId>
-                            <version>2.4.0</version>
-                        </path>
-                    </annotationProcessorPaths>
-                </configuration>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-compiler-plugin</artifactId>-->
+<!--                <version>3.8.0</version>-->
+<!--                <configuration>-->
+<!--                    <source>1.8</source>-->
+<!--                    <target>1.8</target>-->
+<!--                    <compilerArgs>-->
+<!--                        <arg>-XDcompilePolicy=simple</arg>-->
+<!--                        <arg>-Xplugin:ErrorProne</arg>-->
+<!--                    </compilerArgs>-->
+<!--                    <annotationProcessorPaths>-->
+<!--                        <path>-->
+<!--                            <groupId>com.google.errorprone</groupId>-->
+<!--                            <artifactId>error_prone_core</artifactId>-->
+<!--                            <version>2.4.0</version>-->
+<!--                        </path>-->
+<!--                    </annotationProcessorPaths>-->
+<!--                </configuration>-->
+<!--            </plugin>-->
 
             <plugin>
                 <groupId>com.github.spotbugs</groupId>

--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -34,6 +34,7 @@ public final class BrokerConstants {
     public static final String WSS_PORT_PROPERTY_NAME = "secure_websocket_port";
     public static final String WEB_SOCKET_PATH_PROPERTY_NAME = "websocket_path";
     public static final String WEB_SOCKET_MAX_FRAME_SIZE_PROPERTY_NAME = "websocket_max_frame_size";
+    public static final String SESSION_QUEUE_SIZE = "session_queue_size";
 
     /**
      * Defines the SSL implementation to use, default to "JDK".

--- a/broker/src/main/java/io/moquette/broker/DebugUtils.java
+++ b/broker/src/main/java/io/moquette/broker/DebugUtils.java
@@ -29,6 +29,7 @@ public final class DebugUtils {
             final int size = copy.readableBytes();
             bytesContent = new byte[size];
             copy.readBytes(bytesContent);
+            copy.release();
         } else {
             bytesContent = copy.array();
         }

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -45,7 +46,7 @@ import static io.netty.handler.codec.mqtt.MqttQoS.*;
 final class MQTTConnection {
 
     private static final Logger LOG = LoggerFactory.getLogger(MQTTConnection.class);
-    public static final Future FAILED_FUTURE = new Future() {
+    public static final Future<Void> FAILED_FUTURE = new Future<Void>() {
         @Override
         public boolean cancel(boolean mayInterruptIfRunning) {
             return false;
@@ -62,12 +63,12 @@ final class MQTTConnection {
         }
 
         @Override
-        public Object get() throws InterruptedException, ExecutionException {
+        public Void get() throws InterruptedException, ExecutionException {
             return null;
         }
 
         @Override
-        public Object get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        public Void get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
             return null;
         }
     };
@@ -136,12 +137,22 @@ final class MQTTConnection {
 
     private void processPubComp(MqttMessage msg) {
         final int messageID = ((MqttMessageIdVariableHeader) msg.variableHeader()).messageId();
-        bindedSession.processPubComp(messageID);
+        final SessionCommand.Publish pubCompCmd = new SessionCommand.Publish(bindedSession.getClientID(), () -> {
+            bindedSession.processPubComp(messageID);
+            return null;
+        });
+
+        this.postOffice.routeCommand(pubCompCmd);
     }
 
     private void processPubRec(MqttMessage msg) {
         final int messageID = ((MqttMessageIdVariableHeader) msg.variableHeader()).messageId();
-        bindedSession.processPubRec(messageID);
+        final SessionCommand.Publish pubRecCmd = new SessionCommand.Publish(bindedSession.getClientID(), () -> {
+            bindedSession.processPubRec(messageID);
+            return null;
+        });
+
+        this.postOffice.routeCommand(pubRecCmd);
     }
 
     static MqttMessage pubrel(int messageID) {
@@ -151,10 +162,16 @@ final class MQTTConnection {
 
     private void processPubAck(MqttMessage msg) {
         final int messageID = ((MqttMessageIdVariableHeader) msg.variableHeader()).messageId();
-        bindedSession.pubAckReceived(messageID);
+        final String clientId = getClientId();
+        final SessionCommand.Publish pubAckCmd = new SessionCommand.Publish(clientId, () -> {
+            bindedSession.pubAckReceived(messageID);
+            return null;
+        });
+
+        this.postOffice.routeCommand(pubAckCmd);
     }
 
-    Future processConnect(MqttConnectMessage msg) {
+    Future<Void> processConnect(MqttConnectMessage msg) {
         MqttConnectPayload payload = msg.payload();
         String clientId = payload.clientIdentifier();
         final String username = payload.userName();
@@ -397,7 +414,7 @@ final class MQTTConnection {
         LOG.trace("Client unsubscribed from topics <{}>", topics);
     }
 
-    void processPublish(MqttPublishMessage msg) {
+    Future<Void> processPublish(MqttPublishMessage msg) {
         final MqttQoS qos = msg.fixedHeader().qosLevel();
         final String username = NettyUtils.userName(channel);
         final String topicName = msg.variableHeader().topicName();
@@ -409,22 +426,29 @@ final class MQTTConnection {
             LOG.debug("Drop connection because of invalid topic format");
             dropConnection();
         }
+
+//        // retain else msg is cleaned by the NewNettyMQTTHandler and is not available
+//        // in execution by SessionEventLoop
+        msg.retain();
         switch (qos) {
             case AT_MOST_ONCE:
-                postOffice.receivedPublishQos0(topic, username, clientId, msg);
-                break;
+                return postOffice.receivedPublishQos0(topic, username, clientId, msg);
             case AT_LEAST_ONCE: {
-                postOffice.receivedPublishQos1(this, topic, username, messageID, msg);
-                break;
+                return postOffice.receivedPublishQos1(this, topic, username, messageID, msg);
             }
             case EXACTLY_ONCE: {
-                bindedSession.receivedPublishQos2(messageID, msg);
-                postOffice.receivedPublishQos2(this, msg, username);
-                break;
+                final SessionCommand.Publish publishFirstStepCmd = new SessionCommand.Publish(clientId, () -> {
+                    bindedSession.receivedPublishQos2(messageID, msg);
+                    return null;
+                });
+                final CompletableFuture<Void> firstStepFuture = postOffice.routeCommand(publishFirstStepCmd);
+                return firstStepFuture.thenCompose(v -> postOffice.receivedPublishQos2(this, msg, username));
             }
             default:
                 LOG.error("Unknown QoS-Type:{}", qos);
-                break;
+                final CompletableFuture<Void> failed = new CompletableFuture<>();
+                failed.completeExceptionally(new Error("Unknown QoS-"));
+                return failed;
         }
     }
 
@@ -438,6 +462,15 @@ final class MQTTConnection {
 
     private void processPubRel(MqttMessage msg) {
         final int messageID = ((MqttMessageIdVariableHeader) msg.variableHeader()).messageId();
+        final SessionCommand.Publish pubRelCmd = new SessionCommand.Publish(bindedSession.getClientID(), () -> {
+            executePubRel(messageID);
+            return null;
+        });
+
+        this.postOffice.routeCommand(pubRelCmd);
+    }
+
+    private void executePubRel(int messageID) {
         bindedSession.receivedPubRelQos2(messageID);
         sendPubCompMessage(messageID);
     }

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -349,7 +349,7 @@ final class MQTTConnection {
             channel.close().addListener(FIRE_EXCEPTION_ON_FAILURE);
             LOG.trace("Processed DISCONNECT");
             String userName = NettyUtils.userName(channel);
-            postOffice.dispatchDisconnection(clientID, userName);
+            postOffice.clientDisconnected(clientID, userName);
             LOG.trace("dispatch disconnection userName={}", userName);
             return null;
         });

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -425,7 +425,7 @@ final class MQTTConnection {
         }
     }
 
-    void sendPublishReceived(int messageID) {
+    void sendPubRec(int messageID) {
         LOG.trace("sendPubRec invoked, messageID: {}", messageID);
         MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.PUBREC, false, AT_MOST_ONCE,
             false, 0);

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -181,7 +181,7 @@ class PostOffice {
     CompletableFuture<Void> receivedPublishQos0(Topic topic, String username, String clientID, MqttPublishMessage msg) {
         if (!authorizator.canWrite(topic, username, clientID)) {
             LOG.error("client is not authorized to publish on topic: {}", topic);
-            return null;
+            return CompletableFuture.completedFuture(null);
         }
         final CompletableFuture<Void> publishFuture = publish2Subscribers(msg.payload(), topic, AT_MOST_ONCE);
 

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -149,6 +149,8 @@ class PostOffice {
 
     private static final Logger LOG = LoggerFactory.getLogger(PostOffice.class);
 
+    private static final Set<String> NO_FILTER = new HashSet<>();
+
     private final Authorizator authorizator;
     private final ISubscriptionsDirectory subscriptions;
     private final IRetainedRepository retainedRepository;
@@ -362,7 +364,7 @@ class PostOffice {
     }
 
     private CompletableFuture<RoutingResults> publish2Subscribers(ByteBuf payload, Topic topic, MqttQoS publishingQos) {
-        return publish2Subscribers(payload, topic, publishingQos, Collections.emptySet());
+        return publish2Subscribers(payload, topic, publishingQos, NO_FILTER);
     }
 
     private class BatchingPublishesCollector {
@@ -422,7 +424,7 @@ class PostOffice {
         final BatchingPublishesCollector collector = new BatchingPublishesCollector(eventLoops);
 
         for (final Subscription sub : topicMatchingSubscriptions) {
-            if (filterTargetClients.isEmpty() || filterTargetClients.contains(sub.getClientId())) {
+            if (filterTargetClients == NO_FILTER || filterTargetClients.contains(sub.getClientId())) {
                 collector.add(sub);
             }
         }

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -523,6 +523,11 @@ class PostOffice {
         }
     }
 
+    public void terminate() {
+        for (Thread processor:sessionExecutors) {
+            processor.interrupt();
+        }
+    }
 //    void flushInFlight(MQTTConnection mqttConnection) {
 //        Session targetSession = sessionRegistry.retrieve(mqttConnection.getClientId());
 //        targetSession.flushAllQueuedMessages();

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -262,6 +262,13 @@ class PostOffice {
     public void unsubscribe(List<String> topics, MQTTConnection mqttConnection, int messageId) {
         final String clientID = mqttConnection.getClientId();
         final Session session = sessionRegistry.retrieve(clientID);
+        if (session == null) {
+            // Session is already destroyed.
+            // Just ack the client
+            LOG.warn("Session not found when unsubscribing {}", clientID);
+            mqttConnection.sendUnsubAckMessage(topics, clientID, messageId);
+            return;
+        }
         for (String t : topics) {
             Topic topic = new Topic(t);
             boolean validTopic = topic.isValid();

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -581,6 +581,10 @@ class PostOffice {
             cmd.complete();
             return cmd.getSessionId();
         });
+        if (Thread.currentThread() == sessionExecutors[targetQueueId]) {
+            SessionEventLoop.executeTask(task);
+            return cmd.completableFuture().thenApply(RouteResult::success);
+        }
         if (this.sessionQueues[targetQueueId].offer(task)) {
             return cmd.completableFuture().thenApply(RouteResult::success);
         } else {

--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -179,7 +179,9 @@ public class Server {
         subscriptions.init(subscriptionsRepository);
         final Authorizator authorizator = new Authorizator(authorizatorPolicy);
         sessions = new SessionRegistry(subscriptions, queueRepository, authorizator);
-        dispatcher = new PostOffice(subscriptions, retainedRepository, sessions, interceptor, authorizator);
+        final int sessionQueueSize = config.intProp(BrokerConstants.SESSION_QUEUE_SIZE, 1024);
+        dispatcher = new PostOffice(subscriptions, retainedRepository, sessions, interceptor, authorizator,
+                                    sessionQueueSize);
         final BrokerConfiguration brokerConfig = new BrokerConfiguration(config);
         MQTTConnectionFactory connectionFactory = new MQTTConnectionFactory(brokerConfig, authenticator, sessions,
                                                                             dispatcher);

--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.text.ParseException;
 import java.util.*;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -298,8 +299,9 @@ public class Server {
      * @param msg      the message to forward. The ByteBuf in the message will be released.
      * @param clientId the id of the sending integration.
      * @throws IllegalStateException if the integration is not yet started
+     * @return
      */
-    public void internalPublish(MqttPublishMessage msg, final String clientId) {
+    public CompletableFuture<Void> internalPublish(MqttPublishMessage msg, final String clientId) {
         final int messageID = msg.variableHeader().packetId();
         if (!initialized) {
             LOG.error("Moquette is not started, internal message cannot be published. CId: {}, messageId: {}", clientId,
@@ -307,8 +309,8 @@ public class Server {
             throw new IllegalStateException("Can't publish on a integration is not yet started");
         }
         LOG.trace("Internal publishing message CId: {}, messageId: {}", clientId, messageID);
-        dispatcher.internalPublish(msg);
-        msg.payload().release();
+        return dispatcher.internalPublish(msg)
+            .thenRun(() -> msg.payload().release());
     }
 
     public void stopServer() {

--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -329,6 +329,7 @@ public class Server {
         }
 
         interceptor.stop();
+        dispatcher.terminate();
         LOG.info("Moquette integration has been stopped.");
     }
 

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -201,6 +201,9 @@ class Session {
             return;
         }
 
+        if (mqttConnection == null) {
+            return;
+        }
         inflightWindow.put(pubRecPacketId, new SessionRegistry.PubRelMarker());
         inflightTimeouts.add(new InFlightPacket(pubRecPacketId, FLIGHT_BEFORE_RESEND_MS));
         MqttMessage pubRel = MQTTConnection.pubrel(pubRecPacketId);

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -364,8 +364,8 @@ class Session {
                 final Topic topic = pubMsg.topic;
                 final MqttQoS qos = pubMsg.publishingQos;
                 final ByteBuf payload = pubMsg.payload;
-                final ByteBuf copiedPayload = payload.retainedDuplicate();
-                MqttPublishMessage publishMsg = publishNotRetainedDuplicated(notAckPacketId, topic, qos, copiedPayload);
+                // message fetched from map, but not removed from map. No need to duplicate or release.
+                MqttPublishMessage publishMsg = publishNotRetainedDuplicated(notAckPacketId, topic, qos, payload);
                 inflightTimeouts.add(new InFlightPacket(notAckPacketId.packetId, FLIGHT_BEFORE_RESEND_MS));
                 mqttConnection.sendPublish(publishMsg);
             }

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -443,7 +443,7 @@ class Session {
         // In case of evil client with duplicate msgid.
         ReferenceCountUtil.release(old);
 
-        mqttConnection.sendPublishReceived(messageID);
+//        mqttConnection.sendPublishReceived(messageID);
     }
 
     public void receivedPubRelQos2(int messageID) {

--- a/broker/src/main/java/io/moquette/broker/SessionCommand.java
+++ b/broker/src/main/java/io/moquette/broker/SessionCommand.java
@@ -6,10 +6,10 @@ import java.util.concurrent.CompletableFuture;
 final class SessionCommand {
 
     private final String sessionId;
-    private final Callable<Void> action;
-    private final CompletableFuture<Void> task;
+    private final Callable<String> action;
+    private final CompletableFuture<String> task;
 
-    public  SessionCommand(String sessionId, Callable<Void> action) {
+    public  SessionCommand(String sessionId, Callable<String> action) {
         this.sessionId = sessionId;
         this.action = action;
         this.task = new CompletableFuture<>();
@@ -27,7 +27,7 @@ final class SessionCommand {
         task.complete(null);
     }
 
-    public CompletableFuture<Void> completableFuture() {
+    public CompletableFuture<String> completableFuture() {
         return task;
     }
 }

--- a/broker/src/main/java/io/moquette/broker/SessionCommand.java
+++ b/broker/src/main/java/io/moquette/broker/SessionCommand.java
@@ -23,9 +23,8 @@ final class SessionCommand {
         action.call();
     }
 
-    public CompletableFuture<Void> complete() {
+    public void complete() {
         task.complete(null);
-        return this.task;
     }
 
     public CompletableFuture<Void> completableFuture() {

--- a/broker/src/main/java/io/moquette/broker/SessionCommand.java
+++ b/broker/src/main/java/io/moquette/broker/SessionCommand.java
@@ -39,4 +39,19 @@ abstract class SessionCommand {
             mqttConnection.executeConnect(this.msg, getSessionId());
         }
     }
+
+    static final class Disconnect extends SessionCommand {
+
+        private final MQTTConnection mqttConnection;
+
+        public Disconnect(String sessionId, MQTTConnection mqttConnection) {
+            super(sessionId, CommandType.DISCONNECT);
+            this.mqttConnection = mqttConnection;
+        }
+
+        @Override
+        public void execute() {
+            mqttConnection.executeDisconnect(getSessionId());
+        }
+    }
 }

--- a/broker/src/main/java/io/moquette/broker/SessionCommand.java
+++ b/broker/src/main/java/io/moquette/broker/SessionCommand.java
@@ -1,33 +1,27 @@
 package io.moquette.broker;
 
-import io.netty.handler.codec.mqtt.MqttConnectMessage;
-
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 
-abstract class SessionCommand {
-
-    enum CommandType { CONNECT, SUBSCRIBE, UNSUBSCRIBE, PUBLISH, DISCONNECT, PUBACK, PUBREC, PUBREL, PUBCOMP}
+final class SessionCommand {
 
     private final String sessionId;
-
-    private final CommandType type;
+    private final Callable<Void> action;
     private final CompletableFuture<Void> task;
-    private  SessionCommand(String sessionId, CommandType type) {
-        this.sessionId = sessionId;
-        this.type = type;
-        this.task = new CompletableFuture<>();
-    }
 
-    public CommandType getType() {
-        return this.type;
+    public  SessionCommand(String sessionId, Callable<Void> action) {
+        this.sessionId = sessionId;
+        this.action = action;
+        this.task = new CompletableFuture<>();
     }
 
     public String getSessionId() {
         return this.sessionId;
     }
 
-    public abstract void execute() throws Exception;
+    public void execute() throws Exception {
+        action.call();
+    }
 
     public CompletableFuture<Void> complete() {
         task.complete(null);
@@ -36,51 +30,5 @@ abstract class SessionCommand {
 
     public CompletableFuture<Void> completableFuture() {
         return task;
-    }
-
-    static final class Connect extends SessionCommand {
-        private final MQTTConnection mqttConnection;
-        private final MqttConnectMessage msg;
-
-        public Connect(String sessionId, MQTTConnection mqttConnection, MqttConnectMessage msg) {
-            super(sessionId, CommandType.CONNECT);
-            this.mqttConnection = mqttConnection;
-            this.msg = msg;
-        }
-
-        @Override
-        public void execute() {
-            mqttConnection.executeConnect(this.msg, getSessionId());
-        }
-    }
-
-    static final class Disconnect extends SessionCommand {
-
-        private final MQTTConnection mqttConnection;
-
-        public Disconnect(String sessionId, MQTTConnection mqttConnection) {
-            super(sessionId, CommandType.DISCONNECT);
-            this.mqttConnection = mqttConnection;
-        }
-
-        @Override
-        public void execute() {
-            mqttConnection.executeDisconnect(getSessionId());
-        }
-    }
-
-    static final class Publish extends SessionCommand {
-
-        private final Callable<Void> action;
-
-        public Publish(String sessionId, Callable<Void> action) {
-            super(sessionId, CommandType.PUBLISH);
-            this.action = action;
-        }
-
-        @Override
-        public void execute() throws Exception {
-            action.call();
-        }
     }
 }

--- a/broker/src/main/java/io/moquette/broker/SessionCommand.java
+++ b/broker/src/main/java/io/moquette/broker/SessionCommand.java
@@ -2,16 +2,21 @@ package io.moquette.broker;
 
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+
 abstract class SessionCommand {
 
-    enum CommandType { CONNECT, SUBSCRIBE, UNSUBSCRIBE, PUBLISH, DISCONNECT;}
+    enum CommandType { CONNECT, SUBSCRIBE, UNSUBSCRIBE, PUBLISH, DISCONNECT, PUBACK, PUBREC, PUBREL, PUBCOMP}
 
     private final String sessionId;
-    private final CommandType type;
 
+    private final CommandType type;
+    private final CompletableFuture<Void> task;
     private  SessionCommand(String sessionId, CommandType type) {
         this.sessionId = sessionId;
         this.type = type;
+        this.task = new CompletableFuture<>();
     }
 
     public CommandType getType() {
@@ -22,7 +27,16 @@ abstract class SessionCommand {
         return this.sessionId;
     }
 
-    public abstract void execute();
+    public abstract void execute() throws Exception;
+
+    public CompletableFuture<Void> complete() {
+        task.complete(null);
+        return this.task;
+    }
+
+    public CompletableFuture<Void> completableFuture() {
+        return task;
+    }
 
     static final class Connect extends SessionCommand {
         private final MQTTConnection mqttConnection;
@@ -52,6 +66,21 @@ abstract class SessionCommand {
         @Override
         public void execute() {
             mqttConnection.executeDisconnect(getSessionId());
+        }
+    }
+
+    static final class Publish extends SessionCommand {
+
+        private final Callable<Void> action;
+
+        public Publish(String sessionId, Callable<Void> action) {
+            super(sessionId, CommandType.PUBLISH);
+            this.action = action;
+        }
+
+        @Override
+        public void execute() throws Exception {
+            action.call();
         }
     }
 }

--- a/broker/src/main/java/io/moquette/broker/SessionCommand.java
+++ b/broker/src/main/java/io/moquette/broker/SessionCommand.java
@@ -24,7 +24,7 @@ final class SessionCommand {
     }
 
     public void complete() {
-        task.complete(null);
+        task.complete(sessionId);
     }
 
     public CompletableFuture<String> completableFuture() {

--- a/broker/src/main/java/io/moquette/broker/SessionCommand.java
+++ b/broker/src/main/java/io/moquette/broker/SessionCommand.java
@@ -1,0 +1,42 @@
+package io.moquette.broker;
+
+import io.netty.handler.codec.mqtt.MqttConnectMessage;
+
+abstract class SessionCommand {
+
+    enum CommandType { CONNECT, SUBSCRIBE, UNSUBSCRIBE, PUBLISH, DISCONNECT;}
+
+    private final String sessionId;
+    private final CommandType type;
+
+    private  SessionCommand(String sessionId, CommandType type) {
+        this.sessionId = sessionId;
+        this.type = type;
+    }
+
+    public CommandType getType() {
+        return this.type;
+    }
+
+    public String getSessionId() {
+        return this.sessionId;
+    }
+
+    public abstract void execute();
+
+    static final class Connect extends SessionCommand {
+        private final MQTTConnection mqttConnection;
+        private final MqttConnectMessage msg;
+
+        public Connect(String sessionId, MQTTConnection mqttConnection, MqttConnectMessage msg) {
+            super(sessionId, CommandType.CONNECT);
+            this.mqttConnection = mqttConnection;
+            this.msg = msg;
+        }
+
+        @Override
+        public void execute() {
+            mqttConnection.executeConnect(this.msg, getSessionId());
+        }
+    }
+}

--- a/broker/src/main/java/io/moquette/broker/SessionEventLoop.java
+++ b/broker/src/main/java/io/moquette/broker/SessionEventLoop.java
@@ -24,7 +24,14 @@ final class SessionEventLoop implements Runnable {
                 final FutureTask<Void> task = this.sessionQueue.take();
 
                 if (!task.isCancelled()) {
-                    task.run();
+                    try {
+                        task.run();
+
+                        // we ran it, but we have to grab the exception if raised
+                        task.get();
+                    } catch (Throwable th) {
+                        LOG.info("SessionEventLoop {} reached exception in processing command", Thread.currentThread().getName(), th);
+                    }
                 }
             } catch (InterruptedException e) {
                 LOG.info("SessionEventLoop {} interrupted", Thread.currentThread().getName());

--- a/broker/src/main/java/io/moquette/broker/SessionEventLoop.java
+++ b/broker/src/main/java/io/moquette/broker/SessionEventLoop.java
@@ -1,0 +1,35 @@
+package io.moquette.broker;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.FutureTask;
+
+final class SessionEventLoop implements Runnable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SessionEventLoop.class);
+
+    private final BlockingQueue<FutureTask<Void>> sessionQueue;
+
+    public SessionEventLoop(BlockingQueue<FutureTask<Void>> sessionQueue) {
+        this.sessionQueue = sessionQueue;
+    }
+
+    @Override
+    public void run() {
+        while (!Thread.interrupted()) {
+            try {
+                // blocking call
+                final FutureTask<Void> task = this.sessionQueue.take();
+
+                if (!task.isCancelled()) {
+                    task.run();
+                }
+            } catch (InterruptedException e) {
+                LOG.info("SessionEventLoop {} interrupted", Thread.currentThread().getName());
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/broker/src/main/java/io/moquette/broker/SessionEventLoop.java
+++ b/broker/src/main/java/io/moquette/broker/SessionEventLoop.java
@@ -22,20 +22,23 @@ final class SessionEventLoop implements Runnable {
             try {
                 // blocking call
                 final FutureTask<String> task = this.sessionQueue.take();
-
-                if (!task.isCancelled()) {
-                    try {
-                        task.run();
-
-                        // we ran it, but we have to grab the exception if raised
-                        task.get();
-                    } catch (Throwable th) {
-                        LOG.info("SessionEventLoop {} reached exception in processing command", Thread.currentThread().getName(), th);
-                    }
-                }
+                executeTask(task);
             } catch (InterruptedException e) {
                 LOG.info("SessionEventLoop {} interrupted", Thread.currentThread().getName());
                 Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    public static void executeTask(final FutureTask<String> task) {
+        if (!task.isCancelled()) {
+            try {
+                task.run();
+
+                // we ran it, but we have to grab the exception if raised
+                task.get();
+            } catch (Throwable th) {
+                LOG.info("SessionEventLoop {} reached exception in processing command", Thread.currentThread().getName(), th);
             }
         }
     }

--- a/broker/src/main/java/io/moquette/broker/SessionEventLoop.java
+++ b/broker/src/main/java/io/moquette/broker/SessionEventLoop.java
@@ -10,9 +10,9 @@ final class SessionEventLoop implements Runnable {
 
     private static final Logger LOG = LoggerFactory.getLogger(SessionEventLoop.class);
 
-    private final BlockingQueue<FutureTask<Void>> sessionQueue;
+    private final BlockingQueue<FutureTask<String>> sessionQueue;
 
-    public SessionEventLoop(BlockingQueue<FutureTask<Void>> sessionQueue) {
+    public SessionEventLoop(BlockingQueue<FutureTask<String>> sessionQueue) {
         this.sessionQueue = sessionQueue;
     }
 
@@ -21,7 +21,7 @@ final class SessionEventLoop implements Runnable {
         while (!Thread.interrupted()) {
             try {
                 // blocking call
-                final FutureTask<Void> task = this.sessionQueue.take();
+                final FutureTask<String> task = this.sessionQueue.take();
 
                 if (!task.isCancelled()) {
                     try {

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
@@ -72,7 +72,7 @@ public class MQTTConnectionConnectTest {
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         sessionRegistry = new SessionRegistry(subscriptions, queueRepository, permitAll);
         postOffice = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
-                                    ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll);
+                                    ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
 
         sut = createMQTTConnection(CONFIG);
         channel = (EmbeddedChannel) sut.channel;

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
@@ -26,7 +26,10 @@ import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttMessageBuilders;
 import io.netty.handler.codec.mqtt.MqttVersion;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
 
 import static io.moquette.broker.NettyChannelAssertions.assertEqualsConnAck;
 import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.*;
@@ -90,7 +93,7 @@ public class MQTTConnectionConnectTest {
     }
 
     @Test
-    public void testZeroByteClientIdWithCleanSession() {
+    public void testZeroByteClientIdWithCleanSession() throws InterruptedException, ExecutionException {
         // Connect message with clean session set to true and client id is null.
         MqttConnectMessage msg = MqttMessageBuilders.connect()
             .protocolVersion(MqttVersion.MQTT_3_1_1)
@@ -98,7 +101,7 @@ public class MQTTConnectionConnectTest {
             .cleanSession(true)
             .build();
 
-        sut.processConnect(msg);
+        sut.processConnect(msg).get();
         assertEqualsConnAck("Connection must be accepted", CONNECTION_ACCEPTED, channel.readOutbound());
         assertNotNull("unique clientid must be generated", sut.getClientId());
         assertTrue(sessionRegistry.retrieve(sut.getClientId()).isClean(), "clean session flag must be true");
@@ -121,39 +124,39 @@ public class MQTTConnectionConnectTest {
     }
 
     @Test
-    public void testConnect_badClientID() {
+    public void testConnect_badClientID() throws ExecutionException, InterruptedException {
         connMsg.clientId("extremely_long_clientID_greater_than_23").build();
 
         // Exercise
-        sut.processConnect(connMsg.clientId("extremely_long_clientID_greater_than_23").build());
+        sut.processConnect(connMsg.clientId("extremely_long_clientID_greater_than_23").build()).get();
 
         // Verify
         assertEqualsConnAck(CONNECTION_ACCEPTED, channel.readOutbound());
     }
 
     @Test
-    public void testWillIsAccepted() {
+    public void testWillIsAccepted() throws ExecutionException, InterruptedException {
         MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID).willFlag(true)
             .willTopic("topic").willMessage("Topic message").build();
 
         // Exercise
-        // m_handler.setMessaging(mockedMessaging);
-        sut.processConnect(msg);
+        sut.processConnect(msg).get();
 
         // Verify
         assertEqualsConnAck(CONNECTION_ACCEPTED, channel.readOutbound());
         assertTrue(channel.isOpen(), "Connection is accepted and therefore should remain open");
     }
 
+    @Disabled("already covered by testWillMessageIsFiredOnClientKeepAliveExpiry and testWillMessageIsPublishedOnClientBadDisconnection")
     @Test
-    public void testWillIsFired() {
+    public void testWillIsFired() throws ExecutionException, InterruptedException {
         final PostOffice postOfficeMock = mock(PostOffice.class);
         sut = createMQTTConnectionWithPostOffice(CONFIG, postOfficeMock);
         channel = (EmbeddedChannel) sut.channel;
 
         MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID).willFlag(true)
             .willTopic("topic").willMessage("Topic message").build();
-        sut.processConnect(msg);
+        sut.processConnect(msg).get();
 
         // Exercise
         sut.handleConnectionLost();
@@ -164,11 +167,11 @@ public class MQTTConnectionConnectTest {
     }
 
     @Test
-    public void acceptAnonymousClient() {
+    public void acceptAnonymousClient() throws ExecutionException, InterruptedException {
         MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID).build();
 
         // Exercise
-        sut.processConnect(msg);
+        sut.processConnect(msg).get();
 
         // Verify
         assertEqualsConnAck(CONNECTION_ACCEPTED, channel.readOutbound());
@@ -176,12 +179,12 @@ public class MQTTConnectionConnectTest {
     }
 
     @Test
-    public void validAuthentication() {
+    public void validAuthentication() throws ExecutionException, InterruptedException {
         MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID)
             .username(TEST_USER).password(TEST_PWD).build();
 
         // Exercise
-        sut.processConnect(msg);
+        sut.processConnect(msg).get();
 
         // Verify
         assertEqualsConnAck(CONNECTION_ACCEPTED, channel.readOutbound());
@@ -268,13 +271,13 @@ public class MQTTConnectionConnectTest {
     }
 
     @Test
-    public void testBindWithSameClientIDBadCredentialsDoesntDropExistingClient() {
+    public void testBindWithSameClientIDBadCredentialsDoesntDropExistingClient() throws ExecutionException, InterruptedException {
         // Connect a client1
         MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID)
             .username(TEST_USER)
             .password(TEST_PWD)
             .build();
-        sut.processConnect(msg);
+        sut.processConnect(msg).get();
         assertEqualsConnAck(CONNECTION_ACCEPTED, channel.readOutbound());
 
         // create another connect same clientID but with bad credentials
@@ -301,17 +304,17 @@ public class MQTTConnectionConnectTest {
     }
 
     @Test
-    public void testForceClientDisconnection_issue116() {
+    public void testForceClientDisconnection_issue116() throws ExecutionException, InterruptedException {
         MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID)
             .username(TEST_USER)
             .password(TEST_PWD)
             .build();
-        sut.processConnect(msg);
+        sut.processConnect(msg).get();
         assertEqualsConnAck(CONNECTION_ACCEPTED, channel.readOutbound());
 
         // now create another connection and check the new one closes the older
         MQTTConnection anotherConnection = createMQTTConnection(CONFIG);
-        anotherConnection.processConnect(msg);
+        anotherConnection.processConnect(msg).get();
         EmbeddedChannel anotherChannel = (EmbeddedChannel) anotherConnection.channel;
         assertEqualsConnAck(CONNECTION_ACCEPTED, anotherChannel.readOutbound());
 

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
@@ -78,7 +78,7 @@ public class MQTTConnectionPublishTest {
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         sessionRegistry = new SessionRegistry(subscriptions, queueRepository, permitAll);
         final PostOffice postOffice = new PostOffice(subscriptions,
-            new MemoryRetainedRepository(), sessionRegistry, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll);
+            new MemoryRetainedRepository(), sessionRegistry, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
         return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, postOffice);
     }
 

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
@@ -31,6 +31,8 @@ import io.netty.handler.codec.mqtt.MqttVersion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.ExecutionException;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
@@ -59,6 +61,7 @@ public class MQTTConnectionPublishTest {
 
     private void createMQTTConnection(BrokerConfiguration config) {
         channel = new EmbeddedChannel();
+        NettyUtils.clientID(channel, "test_client");
         sut = createMQTTConnection(config, channel);
     }
 
@@ -80,7 +83,7 @@ public class MQTTConnectionPublishTest {
     }
 
     @Test
-    public void dropConnectionOnPublishWithInvalidTopicFormat() {
+    public void dropConnectionOnPublishWithInvalidTopicFormat() throws ExecutionException, InterruptedException {
         // Connect message with clean session set to true and client id is null.
         final ByteBuf payload = Unpooled.copiedBuffer("Hello MQTT world!".getBytes(UTF_8));
         MqttPublishMessage publish = MqttMessageBuilders.publish()
@@ -89,7 +92,7 @@ public class MQTTConnectionPublishTest {
             .qos(MqttQoS.AT_MOST_ONCE)
             .payload(payload).build();
 
-        sut.processPublish(publish);
+        sut.processPublish(publish).get();
 
         // Verify
         assertFalse(channel.isOpen(), "Connection should be closed by the broker");

--- a/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static io.moquette.broker.PostOfficeUnsubscribeTest.CONFIG;
 import static io.netty.handler.codec.mqtt.MqttQoS.*;
@@ -108,7 +110,11 @@ public class PostOfficeInternalPublishTest {
             .retained(retained)
             .qos(qos)
             .payload(Unpooled.copiedBuffer(PAYLOAD.getBytes(UTF_8))).build();
-        sut.internalPublish(publish);
+        try {
+            sut.internalPublish(publish).get(5, TimeUnit.SECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Test

--- a/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 import static io.moquette.broker.PostOfficeUnsubscribeTest.CONFIG;
 import static io.netty.handler.codec.mqtt.MqttQoS.*;
@@ -57,7 +58,7 @@ public class PostOfficeInternalPublishTest {
     private MemoryQueueRepository queueRepository;
 
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws ExecutionException, InterruptedException {
         sessionRegistry = initPostOfficeAndSubsystems();
 
         mockAuthenticator = new MockAuthenticator(singleton(FAKE_CLIENT_ID), singletonMap(TEST_USER, TEST_PWD));
@@ -65,7 +66,7 @@ public class PostOfficeInternalPublishTest {
 
         connectMessage = ConnectionTestUtils.buildConnect(FAKE_CLIENT_ID);
 
-        connection.processConnect(connectMessage);
+        connection.processConnect(connectMessage).get();
         ConnectionTestUtils.assertConnectAccepted(channel);
     }
 
@@ -254,7 +255,7 @@ public class PostOfficeInternalPublishTest {
     }
 
     @Test
-    public void testClientSubscribeWithoutCleanSession() {
+    public void testClientSubscribeWithoutCleanSession() throws ExecutionException, InterruptedException {
         subscribe(AT_MOST_ONCE, "foo", connection);
         connection.processDisconnect(null);
         assertEquals(1, subscriptions.size());
@@ -265,7 +266,7 @@ public class PostOfficeInternalPublishTest {
             .clientId(FAKE_CLIENT_ID)
             .cleanSession(false)
             .build();
-        anotherConn.processConnect(connectMessage);
+        anotherConn.processConnect(connectMessage).get();
         ConnectionTestUtils.assertConnectAccepted((EmbeddedChannel) anotherConn.channel);
 
         assertEquals(1, subscriptions.size());

--- a/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
@@ -92,7 +92,7 @@ public class PostOfficeInternalPublishTest {
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         SessionRegistry sessionRegistry = new SessionRegistry(subscriptions, queueRepository, permitAll);
         sut = new PostOffice(subscriptions, retainedRepository, sessionRegistry,
-                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll);
+                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
         return sessionRegistry;
     }
 

--- a/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
-import java.sql.Time;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -100,7 +99,7 @@ public class PostOfficePublishTest {
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         SessionRegistry sessionRegistry = new SessionRegistry(subscriptions, queueRepository, permitAll);
         sut = new PostOffice(subscriptions, retainedRepository, sessionRegistry,
-                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll);
+                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
         return sessionRegistry;
     }
 

--- a/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
@@ -136,6 +136,7 @@ public class PostOfficePublishTest {
             .payload(anyPayload)
             .qos(MqttQoS.EXACTLY_ONCE)
             .retained(false)
+            .messageId(1)
             .topicName(NEWS_TOPIC).build(), "username");
 
         final MQTTConnection clientYA = connectAs("subscriber");
@@ -147,6 +148,7 @@ public class PostOfficePublishTest {
             .payload(anyPayload2)
             .qos(MqttQoS.EXACTLY_ONCE)
             .retained(true)
+            .messageId(2)
             .topicName(NEWS_TOPIC).build(), "username").get(5, TimeUnit.SECONDS);
 
         // Verify
@@ -290,7 +292,8 @@ public class PostOfficePublishTest {
                 .payload(anyPayload)
                 .qos(MqttQoS.EXACTLY_ONCE)
                 .retained(true)
-                .topicName(NEWS_TOPIC).build(), "username").get(5, TimeUnit.SECONDS);
+                .messageId(2)
+                .topicName(NEWS_TOPIC).build(), "username").get(5000, TimeUnit.SECONDS);
 
         // Verify
         ConnectionTestUtils.verifyPublishIsReceived(channel, EXACTLY_ONCE, "Any payload");

--- a/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
@@ -259,7 +259,7 @@ public class PostOfficeSubscribeTest {
      * previous subscription
      */
     @Test
-    public void testCleanSession_correctlyClientSubscriptions() throws ExecutionException, InterruptedException {
+    public void testCleanSession_correctlyClientSubscriptions() throws ExecutionException, InterruptedException, TimeoutException {
         connection.processConnect(connectMessage).get();
         ConnectionTestUtils.assertConnectAccepted(channel);
         assertEquals(0, subscriptions.size(), "After CONNECT subscription MUST be empty");
@@ -270,10 +270,10 @@ public class PostOfficeSubscribeTest {
             .addSubscription(AT_MOST_ONCE, NEWS_TOPIC)
             .messageId(1)
             .build();
-        connection.processSubscribe(subscribeMsg);
+        connection.processSubscribe(subscribeMsg).get(5, TimeUnit.SECONDS);
         assertEquals(1, subscriptions.size(), "Subscribe MUST contain one subscription");
 
-        connection.processDisconnect(null);
+        connection.processDisconnect(null).get(5, TimeUnit.SECONDS);
         assertEquals(1, subscriptions.size(), "Disconnection MUSTN'T clear subscriptions");
 
         connectMessage = MqttMessageBuilders.connect()

--- a/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
@@ -35,6 +35,8 @@ import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static io.moquette.broker.PostOfficePublishTest.ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID;
 import static io.moquette.broker.PostOfficePublishTest.SUBSCRIBER_ID;
@@ -222,7 +224,7 @@ public class PostOfficeSubscribeTest {
     }
 
     @Test
-    public void testCleanSession_maintainClientSubscriptions() throws ExecutionException, InterruptedException {
+    public void testCleanSession_maintainClientSubscriptions() throws ExecutionException, InterruptedException, TimeoutException {
         connection.processConnect(connectMessage).get();
         ConnectionTestUtils.assertConnectAccepted(channel);
         assertEquals(0, subscriptions.size(), "After CONNECT subscription MUST be empty");
@@ -246,7 +248,7 @@ public class PostOfficeSubscribeTest {
                 .payload(payload.retainedDuplicate())
                 .qos(MqttQoS.AT_MOST_ONCE)
                 .retained(false)
-                .topicName(NEWS_TOPIC).build());
+                .topicName(NEWS_TOPIC).build()).get(5, TimeUnit.SECONDS);
 
         ConnectionTestUtils.verifyPublishIsReceived(anotherChannel, AT_MOST_ONCE, "Hello world!");
     }

--- a/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
@@ -97,7 +97,7 @@ public class PostOfficeSubscribeTest {
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         sessionRegistry = new SessionRegistry(subscriptions, queueRepository, permitAll);
         sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
-                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll);
+                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
     }
 
     private MQTTConnection createMQTTConnection(BrokerConfiguration config, Channel channel) {
@@ -170,7 +170,7 @@ public class PostOfficeSubscribeTest {
             .thenReturn(false);
 
         sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
-                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, new Authorizator(prohibitReadOnNewsTopic));
+                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, new Authorizator(prohibitReadOnNewsTopic), 1024);
 
         connection.processConnect(connectMessage).get();
         ConnectionTestUtils.assertConnectAccepted(channel);

--- a/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 import static io.moquette.broker.PostOfficePublishTest.ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID;
 import static io.moquette.broker.PostOfficePublishTest.SUBSCRIBER_ID;
@@ -111,8 +112,8 @@ public class PostOfficeSubscribeTest {
     }
 
     @Test
-    public void testSubscribe() {
-        connection.processConnect(connectMessage);
+    public void testSubscribe() throws ExecutionException, InterruptedException {
+        connection.processConnect(connectMessage).get();
         ConnectionTestUtils.assertConnectAccepted(channel);
 
         // Exercise & verify
@@ -159,7 +160,7 @@ public class PostOfficeSubscribeTest {
     }
 
     @Test
-    public void testSubscribedToNotAuthorizedTopic() {
+    public void testSubscribedToNotAuthorizedTopic() throws ExecutionException, InterruptedException {
         NettyUtils.userName(channel, FAKE_USER_NAME);
 
         IAuthorizatorPolicy prohibitReadOnNewsTopic = mock(IAuthorizatorPolicy.class);
@@ -169,7 +170,7 @@ public class PostOfficeSubscribeTest {
         sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, new Authorizator(prohibitReadOnNewsTopic));
 
-        connection.processConnect(connectMessage);
+        connection.processConnect(connectMessage).get();
         ConnectionTestUtils.assertConnectAccepted(channel);
 
         //Exercise
@@ -191,8 +192,8 @@ public class PostOfficeSubscribeTest {
     }
 
     @Test
-    public void testDoubleSubscribe() {
-        connection.processConnect(connectMessage);
+    public void testDoubleSubscribe() throws ExecutionException, InterruptedException {
+        connection.processConnect(connectMessage).get();
         ConnectionTestUtils.assertConnectAccepted(channel);
         assertEquals(0, subscriptions.size(), "After CONNECT subscription MUST be empty");
         subscribe(channel, NEWS_TOPIC, AT_MOST_ONCE);
@@ -203,8 +204,8 @@ public class PostOfficeSubscribeTest {
     }
 
     @Test
-    public void testSubscribeWithBadFormattedTopic() {
-        connection.processConnect(connectMessage);
+    public void testSubscribeWithBadFormattedTopic() throws ExecutionException, InterruptedException {
+        connection.processConnect(connectMessage).get();
         ConnectionTestUtils.assertConnectAccepted(channel);
         assertEquals(0, subscriptions.size(), "After CONNECT subscription MUST be empty");
 
@@ -221,8 +222,8 @@ public class PostOfficeSubscribeTest {
     }
 
     @Test
-    public void testCleanSession_maintainClientSubscriptions() {
-        connection.processConnect(connectMessage);
+    public void testCleanSession_maintainClientSubscriptions() throws ExecutionException, InterruptedException {
+        connection.processConnect(connectMessage).get();
         ConnectionTestUtils.assertConnectAccepted(channel);
         assertEquals(0, subscriptions.size(), "After CONNECT subscription MUST be empty");
 
@@ -235,7 +236,7 @@ public class PostOfficeSubscribeTest {
 
         EmbeddedChannel anotherChannel = new EmbeddedChannel();
         MQTTConnection anotherConn = createMQTTConnection(ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID, anotherChannel);
-        anotherConn.processConnect(ConnectionTestUtils.buildConnect(FAKE_CLIENT_ID));
+        anotherConn.processConnect(ConnectionTestUtils.buildConnect(FAKE_CLIENT_ID)).get();
         ConnectionTestUtils.assertConnectAccepted(anotherChannel);
         assertEquals(1, subscriptions.size(), "After a reconnect, subscription MUST be still present");
 
@@ -256,8 +257,8 @@ public class PostOfficeSubscribeTest {
      * previous subscription
      */
     @Test
-    public void testCleanSession_correctlyClientSubscriptions() {
-        connection.processConnect(connectMessage);
+    public void testCleanSession_correctlyClientSubscriptions() throws ExecutionException, InterruptedException {
+        connection.processConnect(connectMessage).get();
         ConnectionTestUtils.assertConnectAccepted(channel);
         assertEquals(0, subscriptions.size(), "After CONNECT subscription MUST be empty");
 
@@ -279,7 +280,7 @@ public class PostOfficeSubscribeTest {
             .build();
         channel = new EmbeddedChannel();
         connection = createMQTTConnection(CONFIG, channel);
-        connection.processConnect(connectMessage);
+        connection.processConnect(connectMessage).get();
         ConnectionTestUtils.assertConnectAccepted(channel);
         assertEquals(0, subscriptions.size(), "After CONNECT with clean, subscription MUST be empty");
 
@@ -297,9 +298,9 @@ public class PostOfficeSubscribeTest {
     }
 
     @Test
-    public void testReceiveRetainedPublishRespectingSubscriptionQoSAndNotPublisher() {
+    public void testReceiveRetainedPublishRespectingSubscriptionQoSAndNotPublisher() throws ExecutionException, InterruptedException {
         // publisher publish a retained message on topic /news
-        connection.processConnect(connectMessage);
+        connection.processConnect(connectMessage).get();
         ConnectionTestUtils.assertConnectAccepted(channel);
         final ByteBuf payload = Unpooled.copiedBuffer("Hello world!", Charset.defaultCharset());
         final MqttPublishMessage retainedPubQoS1Msg = MqttMessageBuilders.publish()
@@ -313,7 +314,7 @@ public class PostOfficeSubscribeTest {
         // subscriber connects subscribe to topic /news and receive the last retained message
         EmbeddedChannel subChannel = new EmbeddedChannel();
         MQTTConnection subConn = createMQTTConnection(ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID, subChannel);
-        subConn.processConnect(ConnectionTestUtils.buildConnect(SUBSCRIBER_ID));
+        subConn.processConnect(ConnectionTestUtils.buildConnect(SUBSCRIBER_ID)).get();
         ConnectionTestUtils.assertConnectAccepted(subChannel);
         subscribe(subConn, NEWS_TOPIC, MqttQoS.AT_MOST_ONCE);
 

--- a/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
@@ -89,7 +89,7 @@ public class PostOfficeUnsubscribeTest {
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         sessionRegistry = new SessionRegistry(subscriptions, queueRepository, permitAll);
         sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
-                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll);
+                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
     }
 
     private MQTTConnection createMQTTConnection(BrokerConfiguration config, Channel channel) {

--- a/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
@@ -324,13 +324,13 @@ public class PostOfficeUnsubscribeTest {
 
         ConnectionTestUtils.verifyPublishIsReceived(subscriberChannel, AT_MOST_ONCE, "Hello world2!");
 
-        subscriberConnection.processDisconnect(null);
+        subscriberConnection.processDisconnect(null).get();
 
         assertFalse(subscriberChannel.isOpen(), "after a disconnect the client should be disconnected");
     }
 
     @Test
-    public void checkReplayofStoredPublishResumeAfter_a_disconnect_cleanSessionFalseQoS1() {
+    public void checkReplayofStoredPublishResumeAfter_a_disconnect_cleanSessionFalseQoS1() throws ExecutionException, InterruptedException {
         final MQTTConnection publisher = connectAs("Publisher");
 
         connect(this.connection, FAKE_CLIENT_ID);
@@ -339,7 +339,7 @@ public class PostOfficeUnsubscribeTest {
         // publish from another channel
         publishQos1(publisher, NEWS_TOPIC, "Hello world MQTT!!-1", 99);
         ConnectionTestUtils.verifyPublishIsReceived(channel, AT_LEAST_ONCE, "Hello world MQTT!!-1");
-        connection.processDisconnect(null);
+        connection.processDisconnect(null).get();
 
         publishQos1(publisher, NEWS_TOPIC, "Hello world MQTT!!-2", 100);
         publishQos1(publisher, NEWS_TOPIC, "Hello world MQTT!!-3", 101);

--- a/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
@@ -122,7 +122,7 @@ public class SessionRegistryTest {
         MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID).cleanSession(true).build();
         connection.processConnect(msg).get();
         assertEqualsConnAck(CONNECTION_ACCEPTED, channel.readOutbound());
-        connection.processDisconnect(null);
+        connection.processDisconnect(null).get();
         assertFalse(channel.isOpen());
 
         // second connect with clean session false

--- a/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ExecutionException;
 
 import static io.moquette.broker.NettyChannelAssertions.assertEqualsConnAck;
 import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_ACCEPTED;
@@ -116,10 +117,10 @@ public class SessionRegistryTest {
     }
 
     @Test
-    public void connectWithCleanSessionUpdateClientSession() {
+    public void connectWithCleanSessionUpdateClientSession() throws ExecutionException, InterruptedException {
         // first connect with clean session true
         MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID).cleanSession(true).build();
-        connection.processConnect(msg);
+        connection.processConnect(msg).get();
         assertEqualsConnAck(CONNECTION_ACCEPTED, channel.readOutbound());
         connection.processDisconnect(null);
         assertFalse(channel.isOpen());
@@ -133,7 +134,7 @@ public class SessionRegistryTest {
             .protocolVersion(MqttVersion.MQTT_3_1)
             .build();
 
-        anotherConnection.processConnect(secondConnMsg);
+        anotherConnection.processConnect(secondConnMsg).get();
         assertEqualsConnAck(CONNECTION_ACCEPTED, anotherChannel.readOutbound());
 
         // Verify client session is clean false

--- a/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
@@ -87,7 +87,7 @@ public class SessionRegistryTest {
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         sut = new SessionRegistry(subscriptions, queueRepository, permitAll);
         final PostOffice postOffice = new PostOffice(subscriptions,
-            new MemoryRetainedRepository(), sut, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll);
+            new MemoryRetainedRepository(), sut, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
         return new MQTTConnection(channel, config, mockAuthenticator, sut, postOffice);
     }
 

--- a/broker/src/test/java/io/moquette/integration/IntegrationUtils.java
+++ b/broker/src/test/java/io/moquette/integration/IntegrationUtils.java
@@ -16,6 +16,10 @@
 
 package io.moquette.integration;
 
+import org.eclipse.paho.client.mqttv3.IMqttClient;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttException;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -56,5 +60,11 @@ public final class IntegrationUtils {
     }
 
     private IntegrationUtils() {
+    }
+
+    static void disconnectClient(IMqttClient client) throws MqttException {
+        if (client != null && client.isConnected()) {
+            client.disconnect();
+        }
     }
 }

--- a/broker/src/test/java/io/moquette/integration/IntegrationUtils.java
+++ b/broker/src/test/java/io/moquette/integration/IntegrationUtils.java
@@ -16,14 +16,16 @@
 
 package io.moquette.integration;
 
+import org.eclipse.paho.client.mqttv3.IMqttActionListener;
+import org.eclipse.paho.client.mqttv3.IMqttAsyncClient;
 import org.eclipse.paho.client.mqttv3.IMqttClient;
-import org.eclipse.paho.client.mqttv3.MqttClient;
 import org.eclipse.paho.client.mqttv3.MqttException;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Properties;
+
 import static io.moquette.BrokerConstants.DEFAULT_MOQUETTE_STORE_H2_DB_FILENAME;
 import static io.moquette.BrokerConstants.PERSISTENT_STORE_PROPERTY_NAME;
 import static io.moquette.BrokerConstants.PORT_PROPERTY_NAME;
@@ -63,6 +65,18 @@ public final class IntegrationUtils {
     }
 
     static void disconnectClient(IMqttClient client) throws MqttException {
+        if (client != null && client.isConnected()) {
+            client.disconnect();
+        }
+    }
+
+    static void disconnectClient(IMqttAsyncClient client, IMqttActionListener callback) throws MqttException {
+        if (client != null && client.isConnected()) {
+            client.disconnect(null, callback);
+        }
+    }
+
+    static void disconnectClient(IMqttAsyncClient client) throws MqttException {
         if (client != null && client.isConnected()) {
             client.disconnect();
         }

--- a/broker/src/test/java/io/moquette/integration/PublishToManySubscribersUseCaseTest.java
+++ b/broker/src/test/java/io/moquette/integration/PublishToManySubscribersUseCaseTest.java
@@ -119,7 +119,7 @@ public class PublishToManySubscribersUseCaseTest {
 
         Awaitility.await("Waiting for resend.")
             .atMost(FLIGHT_BEFORE_RESEND_MS * 3, TimeUnit.MILLISECONDS)
-            .pollDelay(FLIGHT_BEFORE_RESEND_MS * 2, TimeUnit.MILLISECONDS)
+//            .pollDelay(FLIGHT_BEFORE_RESEND_MS * 2, TimeUnit.MILLISECONDS)
             .pollInterval(100, TimeUnit.MILLISECONDS)
             .untilAdder(receivedPublish, equalTo((long) NUM_SUBSCRIBERS));
     }

--- a/broker/src/test/java/io/moquette/integration/PublishToManySubscribersUseCaseTest.java
+++ b/broker/src/test/java/io/moquette/integration/PublishToManySubscribersUseCaseTest.java
@@ -1,0 +1,2 @@
+package io.moquette.integration;public class PublishToManySubscribersUseCaseTest {
+}

--- a/broker/src/test/java/io/moquette/integration/PublishToManySubscribersUseCaseTest.java
+++ b/broker/src/test/java/io/moquette/integration/PublishToManySubscribersUseCaseTest.java
@@ -1,2 +1,126 @@
-package io.moquette.integration;public class PublishToManySubscribersUseCaseTest {
+package io.moquette.integration;
+
+import io.moquette.BrokerConstants;
+import io.moquette.broker.Server;
+import io.moquette.broker.config.IConfig;
+import io.moquette.broker.config.MemoryConfig;
+import org.awaitility.Awaitility;
+import org.awaitility.Durations;
+import org.eclipse.paho.client.mqttv3.IMqttClient;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttClientPersistence;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+
+import static io.moquette.BrokerConstants.FLIGHT_BEFORE_RESEND_MS;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.Matchers.equalTo;
+
+// inspired by ServerIntegrationPahoTest
+public class PublishToManySubscribersUseCaseTest {
+
+    private static final int COMMAND_QUEUE_SIZE = 32;
+
+    private static final int EVENT_LOOPS = Runtime.getRuntime().availableProcessors();
+    public static final int NUM_SUBSCRIBERS = COMMAND_QUEUE_SIZE * EVENT_LOOPS * 4;
+    private Server broker;
+    private IConfig brokerConfig;
+
+    @TempDir
+    Path tempFolder;
+    private String dbPath;
+    private MqttClient publisher;
+    private List<IMqttClient> subscribers;
+
+    protected void startServer(String dbPath) throws IOException {
+        broker = new Server();
+        final Properties configProps = IntegrationUtils.prepareTestProperties(dbPath);
+//        configProps.put(BrokerConstants.IMMEDIATE_BUFFER_FLUSH_PROPERTY_NAME, "true");
+        configProps.put(BrokerConstants.SESSION_QUEUE_SIZE, Integer.toString(COMMAND_QUEUE_SIZE));
+        brokerConfig = new MemoryConfig(configProps);
+        broker.startServer(brokerConfig);
+    }
+
+    @BeforeAll
+    public static void beforeTests() {
+        Awaitility.setDefaultTimeout(Durations.ONE_SECOND);
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        dbPath = IntegrationUtils.tempH2Path(tempFolder);
+        startServer(dbPath);
+
+        publisher = createClient("publisher");
+        publisher.connect();
+
+        subscribers = createSubscribers(NUM_SUBSCRIBERS);
+        for (IMqttClient client : subscribers) {
+            client.connect();
+        }
+    }
+
+    private List<IMqttClient> createSubscribers(int numSubscribers) throws MqttException, IOException {
+        List<IMqttClient> clients = new ArrayList<>(numSubscribers);
+        for (int i = 0; i < numSubscribers; i++) {
+            clients.add(createClient("subscriber_" + i));
+        }
+        return clients;
+    }
+
+    private MqttClient createClient(String clientName) throws IOException, MqttException {
+        final String dataPath = IntegrationUtils.newFolder(tempFolder, clientName).getAbsolutePath();
+        MqttClientPersistence clientDataStore = new MqttDefaultFilePersistence(dataPath);
+        return new MqttClient("tcp://localhost:1883", clientName, clientDataStore);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        IntegrationUtils.disconnectClient(this.publisher);
+        disconnectClients(this.subscribers);
+
+        this.broker.stopServer();
+    }
+
+    private void disconnectClients(List<IMqttClient> clients) throws MqttException {
+        for (IMqttClient client : clients) {
+            IntegrationUtils.disconnectClient(client);
+        }
+    }
+
+    @Test
+    void onePublishTriggerManySubscriptionsNotifications() throws MqttException {
+        final LongAdder receivedPublish = new LongAdder();
+
+        //subscribe all
+        for (IMqttClient subscriber : this.subscribers) {
+            subscriber.subscribe("/temperature", 1, (String topic1, org.eclipse.paho.client.mqttv3.MqttMessage message) -> {
+                receivedPublish.increment();
+            });
+        }
+
+        this.publisher.publish("/temperature", "15°C".getBytes(UTF_8), 0, false);
+
+        Awaitility.await("Waiting for resend.")
+            .atMost(FLIGHT_BEFORE_RESEND_MS * 3, TimeUnit.MILLISECONDS)
+            .pollDelay(FLIGHT_BEFORE_RESEND_MS * 2, TimeUnit.MILLISECONDS)
+            .pollInterval(100, TimeUnit.MILLISECONDS)
+            .untilAdder(receivedPublish, equalTo((long) NUM_SUBSCRIBERS));
+    }
 }

--- a/broker/src/test/java/io/moquette/integration/PublishToManySubscribersUseCaseTest.java
+++ b/broker/src/test/java/io/moquette/integration/PublishToManySubscribersUseCaseTest.java
@@ -6,25 +6,27 @@ import io.moquette.broker.config.IConfig;
 import io.moquette.broker.config.MemoryConfig;
 import org.awaitility.Awaitility;
 import org.awaitility.Durations;
-import org.eclipse.paho.client.mqttv3.IMqttClient;
-import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.IMqttActionListener;
+import org.eclipse.paho.client.mqttv3.IMqttAsyncClient;
+import org.eclipse.paho.client.mqttv3.IMqttToken;
+import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
 import org.eclipse.paho.client.mqttv3.MqttClientPersistence;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 
@@ -34,6 +36,8 @@ import static org.hamcrest.Matchers.equalTo;
 
 // inspired by ServerIntegrationPahoTest
 public class PublishToManySubscribersUseCaseTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PublishToManySubscribersUseCaseTest.class);
 
     private static final int COMMAND_QUEUE_SIZE = 32;
 
@@ -45,13 +49,12 @@ public class PublishToManySubscribersUseCaseTest {
     @TempDir
     Path tempFolder;
     private String dbPath;
-    private MqttClient publisher;
-    private List<IMqttClient> subscribers;
+    private MqttAsyncClient publisher;
+    private List<IMqttAsyncClient> subscribers;
 
     protected void startServer(String dbPath) throws IOException {
         broker = new Server();
         final Properties configProps = IntegrationUtils.prepareTestProperties(dbPath);
-//        configProps.put(BrokerConstants.IMMEDIATE_BUFFER_FLUSH_PROPERTY_NAME, "true");
         configProps.put(BrokerConstants.SESSION_QUEUE_SIZE, Integer.toString(COMMAND_QUEUE_SIZE));
         brokerConfig = new MemoryConfig(configProps);
         broker.startServer(brokerConfig);
@@ -68,58 +71,81 @@ public class PublishToManySubscribersUseCaseTest {
         startServer(dbPath);
 
         publisher = createClient("publisher");
-        publisher.connect();
+        publisher.connect().waitForCompletion(1_000);
 
         subscribers = createSubscribers(NUM_SUBSCRIBERS);
-        for (IMqttClient client : subscribers) {
-            client.connect();
+
+        CountDownLatch latch = new CountDownLatch(NUM_SUBSCRIBERS);
+
+        final IMqttActionListener callback = createMqttCallback(latch);
+        for (IMqttAsyncClient client : subscribers) {
+            client.connect(null, callback);
         }
+
+        latch.await();
+        LOG.debug("After all subscriptions completed");
     }
 
-    private List<IMqttClient> createSubscribers(int numSubscribers) throws MqttException, IOException {
-        List<IMqttClient> clients = new ArrayList<>(numSubscribers);
+    private IMqttActionListener createMqttCallback(CountDownLatch latch) {
+        return new IMqttActionListener() {
+            @Override
+            public void onSuccess(IMqttToken asyncActionToken) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(IMqttToken asyncActionToken, Throwable exception) {
+                latch.countDown();
+            }
+        };
+    }
+
+    private List<IMqttAsyncClient> createSubscribers(int numSubscribers) throws MqttException, IOException {
+        List<IMqttAsyncClient> clients = new ArrayList<>(numSubscribers);
         for (int i = 0; i < numSubscribers; i++) {
             clients.add(createClient("subscriber_" + i));
         }
         return clients;
     }
 
-    private MqttClient createClient(String clientName) throws IOException, MqttException {
+    private MqttAsyncClient createClient(String clientName) throws IOException, MqttException {
         final String dataPath = IntegrationUtils.newFolder(tempFolder, clientName).getAbsolutePath();
         MqttClientPersistence clientDataStore = new MqttDefaultFilePersistence(dataPath);
-        return new MqttClient("tcp://localhost:1883", clientName, clientDataStore);
+        return new MqttAsyncClient("tcp://localhost:1883", clientName, clientDataStore);
     }
 
     @AfterEach
     public void tearDown() throws Exception {
         IntegrationUtils.disconnectClient(this.publisher);
-        disconnectClients(this.subscribers);
+        disconnectAsyncClients(this.subscribers);
 
         this.broker.stopServer();
     }
 
-    private void disconnectClients(List<IMqttClient> clients) throws MqttException {
-        for (IMqttClient client : clients) {
-            IntegrationUtils.disconnectClient(client);
+    private void disconnectAsyncClients(List<IMqttAsyncClient> clients) throws MqttException, InterruptedException {
+        CountDownLatch latch = new CountDownLatch(clients.size());
+        final IMqttActionListener completionCallback = createMqttCallback(latch);
+        for (IMqttAsyncClient client : clients) {
+            IntegrationUtils.disconnectClient(client, completionCallback);
         }
+        latch.await();
     }
 
     @Test
-    void onePublishTriggerManySubscriptionsNotifications() throws MqttException {
+    void onePublishTriggerManySubscriptionsNotifications() throws MqttException, InterruptedException {
         final LongAdder receivedPublish = new LongAdder();
 
         //subscribe all
-        for (IMqttClient subscriber : this.subscribers) {
+        for (IMqttAsyncClient subscriber : this.subscribers) {
             subscriber.subscribe("/temperature", 1, (String topic1, org.eclipse.paho.client.mqttv3.MqttMessage message) -> {
-                receivedPublish.increment();
-            });
+                    receivedPublish.increment();
+                }).waitForCompletion();
         }
 
         this.publisher.publish("/temperature", "15°C".getBytes(UTF_8), 0, false);
 
         Awaitility.await("Waiting for resend.")
             .atMost(FLIGHT_BEFORE_RESEND_MS * 3, TimeUnit.MILLISECONDS)
-//            .pollDelay(FLIGHT_BEFORE_RESEND_MS * 2, TimeUnit.MILLISECONDS)
             .pollInterval(100, TimeUnit.MILLISECONDS)
             .untilAdder(receivedPublish, equalTo((long) NUM_SUBSCRIBERS));
     }

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationDBAuthenticatorTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationDBAuthenticatorTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.io.File;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
@@ -102,13 +102,8 @@ public class ServerIntegrationDBAuthenticatorTest {
 
     @AfterEach
     public void tearDown() throws Exception {
-        if (m_client != null && m_client.isConnected()) {
-            m_client.disconnect();
-        }
-
-        if (m_publisher != null && m_publisher.isConnected()) {
-            m_publisher.disconnect();
-        }
+        IntegrationUtils.disconnectClient(m_client);
+        IntegrationUtils.disconnectClient(m_publisher);
 
         stopServer();
     }

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationMultiConnectTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationMultiConnectTest.java
@@ -36,7 +36,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.file.Path;
-import java.security.SecureRandom;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -101,10 +100,7 @@ public class ServerIntegrationMultiConnectTest {
 
     @AfterEach
     public void tearDown() throws Exception {
-        if (client != null && client.isConnected()) {
-            client.disconnect();
-        }
-
+        IntegrationUtils.disconnectClient(client);
         server.stopServer();
     }
 

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationPahoCanPublishOnReadBlockedTopicTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationPahoCanPublishOnReadBlockedTopicTest.java
@@ -113,13 +113,8 @@ public class ServerIntegrationPahoCanPublishOnReadBlockedTopicTest {
 
     @AfterEach
     public void tearDown() throws Exception {
-        if (m_client != null && m_client.isConnected()) {
-            m_client.disconnect();
-        }
-
-        if (m_publisher != null && m_publisher.isConnected()) {
-            m_publisher.disconnect();
-        }
+        IntegrationUtils.disconnectClient(m_client);
+        IntegrationUtils.disconnectClient(m_publisher);
 
         stopServer();
     }

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationPahoTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationPahoTest.java
@@ -82,13 +82,8 @@ public class ServerIntegrationPahoTest {
 
     @AfterEach
     public void tearDown() throws Exception {
-        if (m_client != null && m_client.isConnected()) {
-            m_client.disconnect();
-        }
-
-        if (m_publisher != null && m_publisher.isConnected()) {
-            m_publisher.disconnect();
-        }
+        IntegrationUtils.disconnectClient(m_client);
+        IntegrationUtils.disconnectClient(m_publisher);
 
         stopServer();
     }

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationQoSValidationTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationQoSValidationTest.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -147,7 +148,8 @@ public class ServerIntegrationQoSValidationTest {
         m_subscriber.subscribe("/topic", 1);
 
         m_publisher.publish("/topic", "Hello world MQTT QoS1".getBytes(UTF_8), 1, false);
-        Awaitility.await().until(m_callback::isMessageReceived);
+        Awaitility.await().atMost(5, TimeUnit.SECONDS)
+            .until(m_callback::isMessageReceived);
         MqttMessage message = m_callback.retrieveMessage();
         assertEquals("Hello world MQTT QoS1", message.toString());
         assertEquals(1, message.getQos());

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationRestartTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationRestartTest.java
@@ -98,7 +98,7 @@ public class ServerIntegrationRestartTest {
         m_server.stopServer();
     }
 
-    @DisplayName("given not clean session then after a server restart the session should be present")
+    @DisplayName("given not clean session after a server restart, the session is still present")
     @Test
     public void testNotCleanSessionIsVisibleAfterServerRestart() throws Exception {
         m_subscriber.connect(CLEAN_SESSION_OPT);
@@ -114,6 +114,7 @@ public class ServerIntegrationRestartTest {
 
         //reconnect subscriber and topic should be sent
         m_subscriber.connect(CLEAN_SESSION_OPT);
+
         // verify the sent message while offline is read
         Awaitility.await().until(m_messageCollector::isMessageReceived);
         MqttMessage msg = m_messageCollector.retrieveMessage();

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLClientAuthTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLClientAuthTest.java
@@ -204,9 +204,7 @@ public class ServerIntegrationSSLClientAuthTest {
 
     @AfterEach
     public void tearDown() throws Exception {
-        if (m_client != null && m_client.isConnected()) {
-            m_client.disconnect();
-        }
+        IntegrationUtils.disconnectClient(m_client);
 
         if (m_server != null) {
             m_server.stopServer();

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLTest.java
@@ -135,9 +135,7 @@ public class ServerIntegrationSSLTest {
 
     @AfterEach
     public void tearDown() throws Exception {
-        if (m_client != null && m_client.isConnected()) {
-            m_client.disconnect();
-        }
+        IntegrationUtils.disconnectClient(m_client);
 
         if (m_server != null) {
             m_server.stopServer();

--- a/broker/src/test/java/io/moquette/integration/ServerLowlevelMessagesIntegrationTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerLowlevelMessagesIntegrationTest.java
@@ -116,8 +116,8 @@ public class ServerLowlevelMessagesIntegrationTest {
     }
 
     @Test
-    public void testWillMessageIsWiredOnClientKeepAliveExpiry() throws Exception {
-        LOG.info("*** testWillMessageIsWiredOnClientKeepAliveExpiry ***");
+    public void testWillMessageIsFiredOnClientKeepAliveExpiry() throws Exception {
+        LOG.info("*** testWillMessageIsFiredOnClientKeepAliveExpiry ***");
         String willTestamentTopic = "/will/test";
         String willTestamentMsg = "Bye bye";
 

--- a/distribution/src/main/resources/moquette.conf
+++ b/distribution/src/main/resources/moquette.conf
@@ -132,6 +132,14 @@ password_file config/password_file.conf
 # netty.mqtt.message_size 8092
 
 #*********************************************************************
+# Command session queues
+#
+# session_queue_size:
+#         the size of each session command queue used to Session's Event loops
+#*********************************************************************
+# session_queue_size 1024
+
+#*********************************************************************
 # Metrics Configuration
 #
 # use_metrics: used to enable Dropwizard Metrics sampling metrics.

--- a/embedding_moquette/pom.xml
+++ b/embedding_moquette/pom.xml
@@ -30,6 +30,14 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/embedding_moquette/pom.xml
+++ b/embedding_moquette/pom.xml
@@ -30,14 +30,14 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-compiler-plugin</artifactId>-->
+<!--                <configuration>-->
+<!--                    <source>1.8</source>-->
+<!--                    <target>1.8</target>-->
+<!--                </configuration>-->
+<!--            </plugin>-->
         </plugins>
     </build>
 


### PR DESCRIPTION
## Release notes
Fix: introduces sessions event processors to segregate changes to a session in one single thread, simplifying concurrency and code

## What does this PR do?
Introduces the concept of sticky sessions, all the change operations to a session is done always by the same thread, so this simplifies the concurrency access, segregating the access to only one thread. The same thread can handle multiple sessions.

Every session event processor is an event loop, that peeks commands out of a queue and executes them.
This means that there is an isolation queue between the IO threads that executes the lower layer of protocol  and the event loops that mutate and managed the upper logic, mainly bound to Session's related structures.

The length of those queue can be configured with option `session_queue_size`, by default is has 1024 slots, but it could be that if there is an heavy publisher, the queue becomes full and this case the only thing to do is log an error. So it could happen that for a SUB command no SUBACK is sent (the same is valid for PUB) if a queue is full. In MQTT 3.1.1 there is no timeout specification for missed SUBACK, so the client will not send a second SUB (dup=1) and we potentially could loose SUBscriptions (and PUBlishes).

This commit also implement a couple of optimizations on this event loop side:
- if a command processed by an EventLoop generated the sending of other commands to the same EventLoop, then those commands are inlined and doesn't pass through the queue.
- when a single PUB command involves many subscribers, then all the subsequent PUB that goes to the same queue are compressed on only one command on the queue, instead of insert many single PUB commands

## Related issues
<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates  #608 
