### PR TITLE
Implements concurrent segmented queues

### DIFF
--- a/.github/workflows/maven_central_release_version.yml
+++ b/.github/workflows/maven_central_release_version.yml
@@ -8,11 +8,7 @@ name: Build and ship to Maven Central
 #            - "v*"
 on:
     release:
-<<<<<<< HEAD
         types: [released]
-=======
-        types: [created]
->>>>>>> ed873606... Revert "Removed Maven publishing workflows from personal fork"
 
 jobs:
     publish:

--- a/.github/workflows/maven_central_release_version.yml
+++ b/.github/workflows/maven_central_release_version.yml
@@ -8,7 +8,11 @@ name: Build and ship to Maven Central
 #            - "v*"
 on:
     release:
+<<<<<<< HEAD
         types: [released]
+=======
+        types: [created]
+>>>>>>> ed873606... Revert "Removed Maven publishing workflows from personal fork"
 
 jobs:
     publish:

--- a/broker/src/main/java/io/moquette/broker/queue/PagedFilesAllocator.java
+++ b/broker/src/main/java/io/moquette/broker/queue/PagedFilesAllocator.java
@@ -1,11 +1,9 @@
 package io.moquette.broker.queue;
 
-
 import java.io.IOException;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
-import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Properties;
@@ -48,8 +46,7 @@ class PagedFilesAllocator implements SegmentAllocator {
             }
         }
 
-        final OpenOption[] openOptions = {StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING};
-        try (FileChannel fileChannel = FileChannel.open(pageFile, openOptions)) {
+        try (FileChannel fileChannel = FileChannel.open(pageFile, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
             this.currentPageFile = fileChannel;
             return fileChannel.map(FileChannel.MapMode.READ_WRITE, 0, PAGE_SIZE);
         } catch (IOException e) {
@@ -76,7 +73,7 @@ class PagedFilesAllocator implements SegmentAllocator {
     public Segment reopenSegment(int pageId, int beginOffset) throws QueueException {
         final MappedByteBuffer page = openRWPageFile(pagesFolder, pageId);
         final SegmentPointer begin = new SegmentPointer(pageId, beginOffset);
-        final SegmentPointer end = new SegmentPointer(pageId, beginOffset + segmentSize);
+        final SegmentPointer end = new SegmentPointer(pageId, beginOffset + segmentSize - 1);
         return new Segment(page, begin, end);
     }
 

--- a/broker/src/main/java/io/moquette/broker/queue/PagedFilesAllocator.java
+++ b/broker/src/main/java/io/moquette/broker/queue/PagedFilesAllocator.java
@@ -17,7 +17,7 @@ import java.util.Properties;
  * */
 class PagedFilesAllocator implements SegmentAllocator {
 
-    interface AllocationAction {
+    interface AllocationListener {
         void segmentedCreated(String name, Segment segment);
     }
 

--- a/broker/src/main/java/io/moquette/broker/queue/PagedFilesAllocator.java
+++ b/broker/src/main/java/io/moquette/broker/queue/PagedFilesAllocator.java
@@ -1,0 +1,103 @@
+package io.moquette.broker.queue;
+
+
+import java.io.IOException;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Properties;
+
+/**
+ * Default implementation of SegmentAllocator. It uses a series of files (named pages) and split them in segments.
+ *
+ * This class is not thread safe.
+ * */
+class PagedFilesAllocator implements SegmentAllocator {
+
+    interface AllocationAction {
+        void segmentedCreated(String name, Segment segment);
+    }
+
+    public static final int MB = 1024 * 1024;
+    public static final int PAGE_SIZE = 64 * MB;
+    private final Path pagesFolder;
+    private final int segmentSize;
+    private int lastSegmentAllocated;
+    private int lastPage;
+    private MappedByteBuffer currentPage;
+    private FileChannel currentPageFile;
+
+    PagedFilesAllocator(Path pagesFolder, int segmentSize, int lastPage, int lastSegmentAllocated) throws QueueException {
+        this.pagesFolder = pagesFolder;
+        this.segmentSize = segmentSize;
+        this.lastPage = lastPage;
+        this.lastSegmentAllocated = lastSegmentAllocated;
+        this.currentPage = openRWPageFile(this.pagesFolder, this.lastPage);
+    }
+
+    private MappedByteBuffer openRWPageFile(Path pagesFolder, int pageId) throws QueueException {
+        final Path pageFile = pagesFolder.resolve(String.format("%d.page", pageId));
+        if (!Files.exists(pageFile)) {
+            try {
+                pageFile.toFile().createNewFile();
+            } catch (IOException ex) {
+                throw new QueueException("Reached an IO error during the bootstrapping of empty 'checkpoint.properties'", ex);
+            }
+        }
+
+        final OpenOption[] openOptions = {StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING};
+        try (FileChannel fileChannel = FileChannel.open(pageFile, openOptions)) {
+            this.currentPageFile = fileChannel;
+            return fileChannel.map(FileChannel.MapMode.READ_WRITE, 0, PAGE_SIZE);
+        } catch (IOException e) {
+            throw new QueueException("Can't open page file " + pageFile, e);
+        }
+    }
+
+    @Override
+    public Segment nextFreeSegment() throws QueueException {
+        if (currentPageIsExhausted()) {
+            lastPage ++;
+            currentPage = openRWPageFile(pagesFolder, lastPage);
+            lastSegmentAllocated = 0;
+        }
+
+        final int beginOffset = lastSegmentAllocated * segmentSize;
+        final int endOffset = ((lastSegmentAllocated + 1) * segmentSize) - 1;
+
+        lastSegmentAllocated += 1;
+        return new Segment(currentPage, new SegmentPointer(lastPage, beginOffset), new SegmentPointer(lastPage, endOffset));
+    }
+
+    @Override
+    public Segment reopenSegment(int pageId, int beginOffset) throws QueueException {
+        final MappedByteBuffer page = openRWPageFile(pagesFolder, pageId);
+        final SegmentPointer begin = new SegmentPointer(pageId, beginOffset);
+        final SegmentPointer end = new SegmentPointer(pageId, beginOffset + segmentSize);
+        return new Segment(page, begin, end);
+    }
+
+    @Override
+    public void close() throws QueueException {
+        if (currentPageFile != null) {
+            try {
+                currentPageFile.close();
+            } catch (IOException ex) {
+                throw new QueueException("Problem closing current page file", ex);
+            }
+        }
+    }
+
+    @Override
+    public void dumpState(Properties checkpoint) {
+        checkpoint.setProperty("segments.last_page", String.valueOf(this.lastPage));
+        checkpoint.setProperty("segments.last_segment", String.valueOf(this.lastSegmentAllocated));
+    }
+
+    private boolean currentPageIsExhausted() {
+        return lastSegmentAllocated * segmentSize == PAGE_SIZE;
+    }
+}

--- a/broker/src/main/java/io/moquette/broker/queue/Queue.java
+++ b/broker/src/main/java/io/moquette/broker/queue/Queue.java
@@ -247,7 +247,7 @@ public class Queue {
                     if (tailSegment.get().equals(currentSegment)) {
                         // read the length header that's crossing 2 segments
                         ByteBuffer lengthBuffer = ByteBuffer.allocate(LENGTH_HEADER_SIZE);
-                        final int remainingHeader = (int) currentSegment.bytesAfter(currentTail);
+                        final int remainingHeader = (int) currentSegment.bytesAfter(currentTail) + 1;
                         lengthBuffer.put(currentSegment.read(currentTail, remainingHeader));
 
                         queuePool.consumedTailSegment(name);

--- a/broker/src/main/java/io/moquette/broker/queue/Queue.java
+++ b/broker/src/main/java/io/moquette/broker/queue/Queue.java
@@ -3,7 +3,10 @@ package io.moquette.broker.queue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -15,16 +18,26 @@ public class Queue {
     private final AtomicReference<Segment> headSegment;
     /* First writeable byte */
     private final AtomicReference<SegmentPointer> currentHeadPtr;
+    /* First readable byte */
+    private final AtomicReference<SegmentPointer> currentTailPtr;
+    private final AtomicReference<Segment> tailSegment;
+
     private final SegmentAllocator allocator;
+    private final QueuePool queuePool;
     private final PagedFilesAllocator.AllocationAction action;
     private final ReentrantLock lock = new ReentrantLock();
 
-    Queue(String name, Segment headSegment, SegmentPointer currentHeadPtr, SegmentAllocator allocator, PagedFilesAllocator.AllocationAction action) {
+    Queue(String name, Segment headSegment, SegmentPointer currentHeadPtr,
+          Segment tailSegment, SegmentPointer currentTailPtr,
+          SegmentAllocator allocator, PagedFilesAllocator.AllocationAction action, QueuePool queuePool) {
         this.name = name;
         this.headSegment = new AtomicReference<>(headSegment);
         this.currentHeadPtr = new AtomicReference<>(currentHeadPtr);
+        this.currentTailPtr = new AtomicReference<>(currentTailPtr);
+        this.tailSegment = new AtomicReference<>(tailSegment);
         this.allocator = allocator;
         this.action = action;
+        this.queuePool = queuePool;
     }
 
     /**
@@ -148,5 +161,180 @@ public class Queue {
 
     SegmentPointer currentHead() {
         return this.currentHeadPtr.get();
+    }
+
+    SegmentPointer currentTail() {
+        return this.currentTailPtr.get();
+    }
+
+    /**
+     * Read next message or return null if the queue has no data.
+     * */
+    public ByteBuffer dequeue() throws QueueException {
+        boolean retry;
+        ByteBuffer out = null;
+        do {
+            retry = false;
+            final Segment currentSegment = tailSegment.get();
+            final SegmentPointer currentTail = currentTailPtr.get();
+            if (hasData(currentHeadPtr.get(), currentTail)) {
+                if (currentSegment.bytesAfter(currentTail) >= LENGTH_HEADER_SIZE) {
+                    // header of message (the length) is contained in the current segment
+                    SegmentPointer existingTail = new SegmentPointer(currentTail);
+                    if (isTailFirstUsage(currentSegment, currentTail)) {
+                        existingTail = currentTail.plus(1);
+                    }
+                    int messageLength = currentSegment.readHeader(existingTail);
+                    if (currentSegment.hasSpace(existingTail, messageLength + LENGTH_HEADER_SIZE)) {
+                        final SegmentPointer newTail = existingTail.moveForward(messageLength + LENGTH_HEADER_SIZE);
+                        if (currentTailPtr.compareAndSet(currentTail, newTail)) {
+                            // fast track optimistic lock
+                            // read data from currentTail + 4 bytes(the length)
+                            out = readData(currentSegment, existingTail.moveForward(LENGTH_HEADER_SIZE), messageLength);
+                        } else {
+                            retry = true;
+                        }
+                    } else {
+                        lock.lock();
+                        // ~1
+                        if (tailSegment.get().equals(currentSegment)) {
+                            // consume the segment
+                            messageLength = currentSegment.readHeader(existingTail);
+                            int remaining = messageLength;
+                            SegmentPointer dataStart = existingTail.moveForward(LENGTH_HEADER_SIZE);
+                            // WARN, dataStart point to a byte position to read
+                            // if currentSegment.end is 1023 offset, and data start is 1020, the bytes after are 4 and
+                            // not 1023 - 1020.
+                            final long tmpLen = currentSegment.bytesAfter(dataStart) + 1;
+                            List<ByteBuffer> createdBuffers = new ArrayList<>();
+                            createdBuffers.add(readData(currentSegment, dataStart, (int) tmpLen));
+
+                            queuePool.consumedTailSegment(name);
+
+                            remaining -= tmpLen;
+                            Segment newTailSegment;
+                            SegmentPointer lastTail;
+                            do {
+                                // load next tail segment
+                                newTailSegment = queuePool.openNextTailSegment(name);
+                                dataStart = newTailSegment.begin;
+                                int toRead = Math.min(remaining, (int) Segment.SIZE);
+                                final ByteBuffer readMessagePart = readData(newTailSegment, dataStart, toRead);
+                                createdBuffers.add(readMessagePart);
+                                remaining -= toRead;
+                                lastTail = dataStart.moveForward(toRead);
+                                if (remaining > 0) {
+                                    queuePool.consumedTailSegment(name);
+                                }
+                            } while (remaining > 0);
+
+                            out = joinBuffers(createdBuffers);
+
+                            // assign to tailSegment without CAS because we are in lock
+                            tailSegment.set(newTailSegment);
+                            currentTailPtr.set(lastTail);
+                        } else {
+                            retry = true;
+                        }
+
+                        lock.unlock();
+                    }
+                } else {
+                    lock.lock();
+                    // ~1
+                    if (tailSegment.get().equals(currentSegment)) {
+                        // read the length header that's crossing 2 segments
+                        ByteBuffer lengthBuffer = ByteBuffer.allocate(LENGTH_HEADER_SIZE);
+                        final int remainingHeader = (int) currentSegment.bytesAfter(currentTail);
+                        lengthBuffer.put(currentSegment.read(currentTail, remainingHeader));
+
+                        queuePool.consumedTailSegment(name);
+
+                        final int headerFragmentToRead =  LENGTH_HEADER_SIZE - remainingHeader;
+                        Segment newTailSegment = queuePool.openNextTailSegment(name);
+                        lengthBuffer.put(newTailSegment.read(newTailSegment.begin, headerFragmentToRead));
+                        final SegmentPointer dataStart = newTailSegment.begin.moveForward(headerFragmentToRead);
+
+                        final int messageLength = ((ByteBuffer) lengthBuffer.flip()).getInt();
+                        int remaining = messageLength;
+                        int toRead = Math.min(remaining, (int) Segment.SIZE);
+                        List<ByteBuffer> createdBuffers = new ArrayList<>();
+                        createdBuffers.add(newTailSegment.read(dataStart, toRead));
+
+                        SegmentPointer lastTail = dataStart.moveForward(toRead);
+
+                        remaining -= toRead;
+
+                        while (remaining > 0) {
+                            newTailSegment = queuePool.openNextTailSegment(name);
+                            toRead = Math.min(remaining, (int) Segment.SIZE);
+                            createdBuffers.add(newTailSegment.read(newTailSegment.begin, toRead));
+                            lastTail = newTailSegment.begin.moveForward(toRead);
+                            remaining -= toRead;
+                            if (remaining > 0) {
+                                queuePool.consumedTailSegment(name);
+                            }
+                        }
+
+                        out = joinBuffers(createdBuffers);
+
+                        // assign to tailSegment without CAS because we are in lock
+                        tailSegment.set(newTailSegment);
+                        currentTailPtr.set(lastTail);
+                    } else {
+                        retry = true;
+                    }
+                    lock.unlock();
+                }
+            } else {
+                //TODO the first run tail is (0, 0) while head is (0, -1)
+                if (currentTail.compareTo(currentHeadPtr.get()) == 0) {
+                    return null;
+                }
+                lock.lock();
+                // 1
+                if (tailSegment.get().equals(currentSegment)) {
+                    // load next tail segment
+                    final Segment newTailSegment = queuePool.openNextTailSegment(name);
+
+                    // assign to tailSegment without CAS because we are in lock
+                    tailSegment.set(newTailSegment);
+                    currentTailPtr.set(newTailSegment.begin);
+                }
+                lock.unlock();
+                retry = true;
+            }
+        } while (retry);
+
+        // return data or null
+        return out;
+    }
+
+    private boolean isTailFirstUsage(Segment tailSegment, SegmentPointer tail) {
+        return tail.equals(tailSegment.begin.plus(-1));
+    }
+
+    private boolean hasData(SegmentPointer head, SegmentPointer tail) {
+        return head.compareTo(tail) > 0;
+    }
+
+    /**
+     * @return a ByteBuffer that's a composition of all buffers
+     * */
+    private ByteBuffer joinBuffers(List<ByteBuffer> buffers) {
+        final int neededSpace = buffers.stream().mapToInt(Buffer::remaining).sum();
+        byte[] heapBuffer = new byte[neededSpace];
+        int offset = 0;
+        for (ByteBuffer buffer : buffers) {
+            final int readBytes = buffer.remaining();
+            buffer.get(heapBuffer, offset, readBytes);
+            offset += readBytes;
+        }
+
+        return ByteBuffer.wrap(heapBuffer);
+    }
+
+    private ByteBuffer readData(Segment source, SegmentPointer start, int length) {
+        return source.read(start, length);
     }
 }

--- a/broker/src/main/java/io/moquette/broker/queue/Queue.java
+++ b/broker/src/main/java/io/moquette/broker/queue/Queue.java
@@ -22,7 +22,6 @@ public class Queue {
     private final AtomicReference<VirtualPointer> currentTailPtr;
     private final AtomicReference<Segment> tailSegment;
 
-    private final SegmentAllocator allocator;
     private final QueuePool queuePool;
     private final PagedFilesAllocator.AllocationListener allocationListener;
     private final ReentrantLock lock = new ReentrantLock();
@@ -35,7 +34,6 @@ public class Queue {
         this.currentHeadPtr = new AtomicReference<>(currentHeadPtr);
         this.currentTailPtr = new AtomicReference<>(currentTailPtr);
         this.tailSegment = new AtomicReference<>(tailSegment);
-        this.allocator = allocator;
         this.allocationListener = allocationListener;
         this.queuePool = queuePool;
     }
@@ -93,7 +91,7 @@ public class Queue {
                 // till the payload is not completely stored,
                 // save the remaining part into a new segment.
                 while (rawData.hasRemaining()) {
-                    newSegment = allocator.nextFreeSegment();
+                    newSegment = queuePool.nextFreeSegment();
                     //notify segment creation for queue in queue pool
                     allocationListener.segmentedCreated(name, newSegment);
 

--- a/broker/src/main/java/io/moquette/broker/queue/Queue.java
+++ b/broker/src/main/java/io/moquette/broker/queue/Queue.java
@@ -1,0 +1,158 @@
+package io.moquette.broker.queue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class Queue {
+    private static final Logger LOG = LoggerFactory.getLogger(Queue.class);
+
+    public static final int LENGTH_HEADER_SIZE = 4;
+    private final String name;
+    private final AtomicReference<Segment> headSegment;
+    /* First writeable byte */
+    private final AtomicReference<SegmentPointer> currentHeadPtr;
+    private final SegmentAllocator allocator;
+    private final PagedFilesAllocator.AllocationAction action;
+    private final ReentrantLock lock = new ReentrantLock();
+
+    Queue(String name, Segment headSegment, SegmentPointer currentHeadPtr, SegmentAllocator allocator, PagedFilesAllocator.AllocationAction action) {
+        this.name = name;
+        this.headSegment = new AtomicReference<>(headSegment);
+        this.currentHeadPtr = new AtomicReference<>(currentHeadPtr);
+        this.allocator = allocator;
+        this.action = action;
+    }
+
+    /**
+     * @throws QueueException if an error happens during access to file.
+     * */
+    public void enqueue(byte[] data) throws QueueException {
+        final SegmentPointer res = spinningMove(LENGTH_HEADER_SIZE + data.length);
+        if (res != null) {
+            LOG.trace("CAT insertion at: {}", res);
+            writeData(headSegment.get(), res, data);
+            return;
+        } else {
+            lock.lock();
+            long spaceNeeded;
+            SegmentPointer lastOffset = null;
+
+            // the bytes written from the data input
+            long consumedBytes = 0;
+            do {
+                final Segment currentSegment = headSegment.get();
+                spaceNeeded = currentSegment.bytesAfter(currentHeadPtr.get());
+            } while (spaceNeeded != 0 && ((lastOffset = spinningMove(spaceNeeded)) == null));
+
+            SegmentPointer newSegmentPointer = null;
+            if (spaceNeeded != 0) {
+                LOG.trace("Writing partial data to offset {} for {} bytes", lastOffset, spaceNeeded);
+                final int copySize = (int) (spaceNeeded - LENGTH_HEADER_SIZE);
+                byte[] copy = new byte[copySize];
+                System.arraycopy(data, 0, copy, 0, copySize);
+                writeData(headSegment.get(), lastOffset, data.length, copy);
+                consumedBytes += copySize;
+                newSegmentPointer = new SegmentPointer(headSegment.get(), currentHeadPtr.get().offset() + spaceNeeded);
+            }
+
+            Segment newSegment = null;
+            try {
+                while (consumedBytes < data.length) {
+                    newSegment = allocator.nextFreeSegment();
+                    //notify segment creation for queue in queue pool
+                    action.segmentedCreated(name, newSegment);
+
+                    int copySize = (int) Math.min(data.length - consumedBytes, Segment.SIZE);
+
+                    byte[] copy = new byte[copySize];
+                    System.arraycopy(data, (int) consumedBytes, copy, 0, copySize);
+                    consumedBytes += copySize;
+                    newSegmentPointer = new SegmentPointer(newSegment, newSegment.begin.offset() + (copySize + LENGTH_HEADER_SIZE) - 1);
+
+                    // if not first write of data
+                    if (consumedBytes > 0) {
+                        writeDataNoHeader(newSegment, newSegment.begin, copy);
+                    } else {
+                        writeData(newSegment, newSegment.begin, copy);
+                    }
+                }
+
+                // publish the last segment created and the pointer to head.
+                if (newSegment != null) {
+                    headSegment.set(newSegment);
+                }
+                if (newSegmentPointer != null) {
+                    currentHeadPtr.set(newSegmentPointer);
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+
+    private void writeDataNoHeader(Segment segment, SegmentPointer start, byte[] data) {
+        ByteBuffer content = ByteBuffer.allocate(data.length);
+        content
+            .put(data) // put the payload
+            .flip();
+
+        segment.write(start, content);
+    }
+
+    /**
+     * Writes data and size to the current Head segment starting from start pointer.
+     * */
+    private void writeData(Segment segment, SegmentPointer start, byte[] data) {
+        ByteBuffer content = ByteBuffer.allocate(LENGTH_HEADER_SIZE + data.length);
+        content
+            .putInt(data.length) // put 4 bytes header
+            .put(data) // put the payload
+            .flip();
+
+        segment.write(start, content);
+    }
+
+    private void writeData(Segment segment, SegmentPointer start, int totalSize, byte[] data) {
+        ByteBuffer content = ByteBuffer.allocate(LENGTH_HEADER_SIZE + data.length);
+        content
+            .putInt(totalSize) // put 4 bytes header
+            .put(data) // put the payload
+            .flip();
+
+        segment.write(start, content);
+    }
+
+    /**
+     * Move forward the currentHead pointer of size bytes, using CAS operation.
+     * @return null if the head segment doesn't have enough space or the offset used as start of the move.
+     * */
+    private SegmentPointer spinningMove(long size) {
+        SegmentPointer currentHeadPtr;
+        SegmentPointer newHead;
+        do {
+            currentHeadPtr = this.currentHeadPtr.get();
+            if (!headSegment.get().hasSpace(currentHeadPtr, size)) {
+                return null;
+            }
+            newHead = currentHeadPtr.moveForward(size);
+        } while (!this.currentHeadPtr.compareAndSet(currentHeadPtr, newHead));
+        // the start position must the be the first free position, while the previous head reference
+        // keeps the last occupied position, move .forward by 1
+        return currentHeadPtr.plus(1);
+    }
+
+    /**
+     * Used in test
+     * */
+    void force() {
+        headSegment.get().force();
+    }
+
+    SegmentPointer currentHead() {
+        return this.currentHeadPtr.get();
+    }
+}

--- a/broker/src/main/java/io/moquette/broker/queue/QueueException.java
+++ b/broker/src/main/java/io/moquette/broker/queue/QueueException.java
@@ -1,0 +1,12 @@
+package io.moquette.broker.queue;
+
+import java.io.FileNotFoundException;
+
+public class QueueException extends Exception {
+
+    private static final long serialVersionUID = -4782799401089093829L;
+
+    public QueueException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/broker/src/main/java/io/moquette/broker/queue/QueueException.java
+++ b/broker/src/main/java/io/moquette/broker/queue/QueueException.java
@@ -1,12 +1,14 @@
 package io.moquette.broker.queue;
 
-import java.io.FileNotFoundException;
-
 public class QueueException extends Exception {
 
     private static final long serialVersionUID = -4782799401089093829L;
 
     public QueueException(String message, Throwable cause) {
         super(message, cause);
+    }
+
+    public QueueException(String message) {
+        super(message);
     }
 }

--- a/broker/src/main/java/io/moquette/broker/queue/QueuePool.java
+++ b/broker/src/main/java/io/moquette/broker/queue/QueuePool.java
@@ -80,7 +80,7 @@ public class QueuePool {
         this.dataPath = dataPath;
     }
 
-    private static class SegmentAllocationCallback implements PagedFilesAllocator.AllocationAction {
+    private static class SegmentAllocationCallback implements PagedFilesAllocator.AllocationListener {
 
         private final QueuePool queuePool;
 

--- a/broker/src/main/java/io/moquette/broker/queue/QueuePool.java
+++ b/broker/src/main/java/io/moquette/broker/queue/QueuePool.java
@@ -1,0 +1,249 @@
+package io.moquette.broker.queue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+public class QueuePool {
+
+    private static final Logger LOG = LoggerFactory.getLogger(QueuePool.class);
+    private static SegmentAllocationCallback callback;
+
+    private static class SegmentRef {
+        final int pageId;
+        final int offset;
+
+        private SegmentRef(int pageId, int offset) {
+            this.pageId = pageId;
+            this.offset = offset;
+        }
+
+        public SegmentRef(Segment segment) {
+            this.pageId = segment.begin.pageId();
+            this.offset = segment.begin.offset();
+        }
+
+        @Override
+        public String toString() {
+            return String.format("(%d, %d)", pageId, offset);
+        }
+    }
+    private static class QueueName {
+        final String name;
+
+        private QueueName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            QueueName queueName = (QueueName) o;
+            return Objects.equals(name, queueName.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name);
+        }
+    }
+
+    private final SegmentAllocator allocator;
+    private final Path dataPath;
+    private final Map<QueueName, List<SegmentRef>> queueSegments = new HashMap<>();
+    private final Map<QueueName, Queue> queues = new HashMap<>();
+
+    private QueuePool(SegmentAllocator allocator, Path dataPath) {
+        this.allocator = allocator;
+        this.dataPath = dataPath;
+    }
+
+    private static class SegmentAllocationCallback implements PagedFilesAllocator.AllocationAction {
+
+        private final QueuePool queuePool;
+
+        private SegmentAllocationCallback(QueuePool queuePool) {
+            this.queuePool = queuePool;
+        }
+
+        @Override
+        public void segmentedCreated(String name, Segment segment) {
+            queuePool.segmentedCreated(name, segment);
+        }
+    }
+
+    private void segmentedCreated(String name, Segment segment) {
+        final QueueName queueName = new QueueName(name);
+        List<SegmentRef> segmentRefs = this.queueSegments.computeIfAbsent(queueName, k -> new ArrayList<>());
+
+        segmentRefs.add(new SegmentRef(segment));
+    }
+
+    public static QueuePool loadQueues(Path dataPath) throws QueueException {
+        // read in checkpoint.properties
+        final Properties checkpointProps = createOrLoadCheckpointFile(dataPath);
+
+        // load last references to segments and instantiate the allocator
+        final int lastPage = Integer.parseInt(checkpointProps.getProperty("segments.last_page", "0"));
+        final int lastSegment = Integer.parseInt(checkpointProps.getProperty("segments.last_segment", "0"));
+
+        final PagedFilesAllocator allocator = new PagedFilesAllocator(dataPath, (int) Segment.SIZE, lastPage, lastSegment);
+
+        final QueuePool queuePool = new QueuePool(allocator, dataPath);
+        callback = new SegmentAllocationCallback(queuePool);
+        queuePool.loadQueueDefinitions(checkpointProps);
+        return queuePool;
+    }
+
+    private static Properties createOrLoadCheckpointFile(Path dataPath) throws QueueException {
+        final Path checkpointPath = dataPath.resolve("checkpoint.properties");
+        if (!Files.exists(checkpointPath)) {
+            LOG.info("Can't find any file named 'checkpoint.properties' in path: {}, creating new one", dataPath);
+            final boolean notExisted;
+            try {
+                notExisted = checkpointPath.toFile().createNewFile();
+            } catch (IOException e) {
+                throw new QueueException("Reached an IO error during the bootstrapping of empty 'checkpoint.properties'", e);
+            }
+            if (!notExisted) {
+                LOG.warn("Found a checkpoint file while bootstrapping {}", checkpointPath);
+            }
+        }
+
+        final FileReader fileReader;
+        try {
+            fileReader = new FileReader(checkpointPath.toFile());
+        } catch (FileNotFoundException e) {
+            throw new QueueException("Can't find any file named 'checkpoint.properties' in path: " + dataPath, e);
+        }
+        final Properties checkpointProps = new Properties();
+        try {
+            checkpointProps.load(fileReader);
+        } catch (IOException e) {
+            throw new QueueException("if an error occurred when reading from: " + checkpointPath, e);
+        }
+        return checkpointProps;
+    }
+
+    private void loadQueueDefinitions(Properties checkpointProps) throws QueueException {
+        // structure of queues definitions in properties file:
+        // queues.0.name = bla bla
+        // queues.0.segments = head (id_page, offset), (id_page, offset), ... tail
+        // queues.0.head_offset = bytes offset from the start of the page where last data was written
+        boolean noMoreQueues = false;
+        int queueId = 0;
+        while (!noMoreQueues) {
+            final String queueKey = String.format("queues.%d.name", queueId);
+            if (!checkpointProps.containsKey(queueKey)) {
+                noMoreQueues = true;
+                continue;
+            }
+            final QueueName queueName = new QueueName(checkpointProps.getProperty(queueKey));
+            List<SegmentRef> segmentRefs = decodeSegments(checkpointProps.getProperty(String.format("queues.%d.segments", queueId)));
+            queueSegments.put(queueName, segmentRefs);
+
+            final long headOffset = Long.parseLong(checkpointProps.getProperty(String.format("queues.%d.head_offset", queueId)));
+
+            final SegmentRef headSegmentRef = segmentRefs.get(0);
+            final SegmentPointer currentHead = new SegmentPointer(headSegmentRef.pageId, headOffset);
+            // TODO this reopen could be done in lazy way during getOrCreate method.
+            Segment headSegment = allocator.reopenSegment(headSegmentRef.pageId, headSegmentRef.offset);
+
+            final Queue queue = new Queue(queueName.name, headSegment, currentHead, allocator, callback);
+            queues.put(queueName, queue);
+
+            queueId++;
+        }
+    }
+
+    private List<SegmentRef> decodeSegments(String s) {
+        final String[] segments = s.substring(s.indexOf("(") + 1, s.lastIndexOf(")"))
+                .split("\\), \\(");
+
+        List<SegmentRef> acc = new ArrayList<>();
+        for (String segment : segments) {
+            final String[] split = segment.split(",");
+            final int idPage = Integer.parseInt(split[0].trim());
+            final int offset = Integer.parseInt(split[1].trim());
+
+            acc.add(new SegmentRef(idPage, offset));
+        }
+        return acc;
+    }
+
+    public Queue getOrCreate(String queueName) throws QueueException {
+        final QueueName queueN = new QueueName(queueName);
+        if (queues.containsKey(queueN)) {
+            return queues.get(queueN);
+        } else {
+            // create new queue with first empty segment
+            final Segment segment = allocator.nextFreeSegment();
+            //notify segment creation for queue in queue pool
+            segmentedCreated(queueName, segment);
+
+            // When a segment is freshly created the head must the last occupied byte,
+            // so can't be the begin of a segment, but one position before, or in case
+            // of a new page, -1
+            final Queue queue = new Queue(queueName, segment, segment.begin.plus(-1), this.allocator, callback);
+            queues.put(queueN, queue);
+            return queue;
+        }
+    }
+
+    /**
+     * Free mapped files
+     * */
+    public void close() throws QueueException {
+        allocator.close();
+
+        //save all into the checkpoint file
+        Properties checkpoint = new Properties();
+        allocator.dumpState(checkpoint);
+
+        int queueCounter = 0;
+        for (Map.Entry<QueueName, List<SegmentRef>> entry : queueSegments.entrySet()) {
+            // queues.0.name = bla bla
+            final QueueName queueName = entry.getKey();
+            checkpoint.setProperty("queues." + queueCounter + ".name", queueName.name);
+
+            // queues.0.segments = head (id_page, offset), (id_page, offset), ... tail
+            final List<SegmentRef> segmentRefs = entry.getValue();
+            final String segmentsDef = segmentRefs.stream()
+                .map(SegmentRef::toString)
+                .collect(Collectors.joining(", "));
+            checkpoint.setProperty("queues." + queueCounter + ".segments", segmentsDef);
+
+            // queues.0.head_offset = bytes offset from the start of the page where last data was written
+            final Queue queue = queues.get(queueName);
+            checkpoint.setProperty("queues." + queueCounter + ".head_offset", String.valueOf(queue.currentHead().offset()));
+        }
+
+        final File propertiesFile = dataPath.resolve("checkpoint.properties").toFile();
+        final FileWriter fileWriter;
+        try {
+            fileWriter = new FileWriter(propertiesFile);
+        } catch (IOException ex) {
+            throw new QueueException("Problem opening checkpoint.properties file", ex);
+        }
+        try {
+            checkpoint.store(fileWriter, "DON'T EDIT, AUTOGENERATED");
+        } catch (IOException ex) {
+            throw new QueueException("Problem writing checkpoint.properties file", ex);
+        }
+    }
+}

--- a/broker/src/main/java/io/moquette/broker/queue/Segment.java
+++ b/broker/src/main/java/io/moquette/broker/queue/Segment.java
@@ -1,0 +1,43 @@
+package io.moquette.broker.queue;
+
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+
+final class Segment {
+    final static long SIZE = 4 * 1024 * 1024;
+
+    final SegmentPointer begin;
+    final SegmentPointer end;
+
+    private final MappedByteBuffer mappedBuffer;
+
+    Segment(MappedByteBuffer page, SegmentPointer begin, SegmentPointer end) {
+        assert begin.samePage(end);
+        this.begin = begin;
+        this.end = end;
+        this.mappedBuffer = page;
+    }
+
+    boolean hasSpace(SegmentPointer mark, long length) {
+        return mark.samePage(this.end) &&
+// TODO            <= 0 > mark has t0 be <= end
+            mark.moveForward(length).compareTo(this.end) <= 0;
+    }
+
+    public long bytesAfter(SegmentPointer mark) {
+        assert mark.samePage(this.end);
+        return end.distance(mark);
+    }
+
+    void write(SegmentPointer offset, ByteBuffer content) {
+        final ByteBuffer buffer = (ByteBuffer) mappedBuffer.position(offset.offset());
+        buffer.put(content);
+    }
+
+    /**
+     * Force flush of memory mapper buffer to disk
+     * */
+    void force() {
+        mappedBuffer.force();
+    }
+}

--- a/broker/src/main/java/io/moquette/broker/queue/Segment.java
+++ b/broker/src/main/java/io/moquette/broker/queue/Segment.java
@@ -26,6 +26,7 @@ final class Segment {
 
     /**
      * @return number of bytes in segment after the pointer.
+     * The pointer slot is not counted.
      * */
     public long bytesAfter(SegmentPointer mark) {
         assert mark.samePage(this.end);

--- a/broker/src/main/java/io/moquette/broker/queue/Segment.java
+++ b/broker/src/main/java/io/moquette/broker/queue/Segment.java
@@ -71,4 +71,14 @@ final class Segment {
     public String toString() {
         return "Segment{page=" + begin.pageId() + ", begin=" + begin.offset() + ", end=" + end.offset() + "}";
     }
+
+    ByteBuffer readAllBytesAfter(SegmentPointer start) {
+        // WARN, dataStart points to a byte position to read
+        // if currentSegment.end is at offset 1023, and data start is 1020, the bytes after are 4 and
+        // not 1023 - 1020.
+        final long availableDataLength = bytesAfter(start) + 1;
+        final ByteBuffer buffer = read(start, (int) availableDataLength);
+        buffer.rewind();
+        return buffer;
+    }
 }

--- a/broker/src/main/java/io/moquette/broker/queue/Segment.java
+++ b/broker/src/main/java/io/moquette/broker/queue/Segment.java
@@ -50,8 +50,7 @@ final class Segment {
      *
      * @param pointer*/
     int readHeader(SegmentPointer pointer) {
-        final int res = mappedBuffer.getInt(pointer.offset());
-        return res;
+        return mappedBuffer.getInt(pointer.offset());
     }
 
     public ByteBuffer read(SegmentPointer start, int length) {

--- a/broker/src/main/java/io/moquette/broker/queue/SegmentAllocator.java
+++ b/broker/src/main/java/io/moquette/broker/queue/SegmentAllocator.java
@@ -1,0 +1,21 @@
+package io.moquette.broker.queue;
+
+import java.util.Properties;
+
+interface SegmentAllocator {
+
+    /**
+     * Return the next free segment in the current page, or create a new Page if necessary.
+     *
+     * This method has to be invoked inside a lock, it's not thread safe.
+     *
+     * @throws QueueException if any IO error happens on the filesystem.
+     * */
+    Segment nextFreeSegment() throws QueueException;
+
+    Segment reopenSegment(int pageId, int beginOffset) throws QueueException;
+
+    void close() throws QueueException;
+
+    void dumpState(Properties checkpoint);
+}

--- a/broker/src/main/java/io/moquette/broker/queue/SegmentPointer.java
+++ b/broker/src/main/java/io/moquette/broker/queue/SegmentPointer.java
@@ -1,5 +1,7 @@
 package io.moquette.broker.queue;
 
+import java.util.Objects;
+
 final class SegmentPointer implements Comparable<SegmentPointer> {
     private final int idPage;
     private final long offset;
@@ -17,6 +19,13 @@ final class SegmentPointer implements Comparable<SegmentPointer> {
         this.offset = offset;
     }
 
+    /**
+     * Copy constructor
+     * */
+    public SegmentPointer(SegmentPointer original) {
+        this(original.idPage, original.offset);
+    }
+
     @Override
     public int compareTo(SegmentPointer other) {
         if (idPage == other.idPage) {
@@ -24,6 +33,19 @@ final class SegmentPointer implements Comparable<SegmentPointer> {
         } else {
             return Integer.compare(idPage, other.idPage);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SegmentPointer that = (SegmentPointer) o;
+        return idPage == that.idPage && offset == that.offset;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(idPage, offset);
     }
 
     boolean samePage(SegmentPointer other) {
@@ -52,7 +74,7 @@ final class SegmentPointer implements Comparable<SegmentPointer> {
     }
 
     public SegmentPointer plus(int delta) {
-        return new SegmentPointer(this.idPage, offset + delta);
+        return moveForward(delta);
     }
 
     int pageId() {

--- a/broker/src/main/java/io/moquette/broker/queue/SegmentPointer.java
+++ b/broker/src/main/java/io/moquette/broker/queue/SegmentPointer.java
@@ -1,0 +1,61 @@
+package io.moquette.broker.queue;
+
+final class SegmentPointer implements Comparable<SegmentPointer> {
+    private final int idPage;
+    private final long offset;
+
+    public SegmentPointer(int idPage, long offset) {
+        this.idPage = idPage;
+        this.offset = offset;
+    }
+
+    /**
+     * Construct using the segment, but changing the offset.
+     * */
+    public SegmentPointer(Segment segment, long offset) {
+        this.idPage = segment.begin.idPage;
+        this.offset = offset;
+    }
+
+    @Override
+    public int compareTo(SegmentPointer other) {
+        if (idPage == other.idPage) {
+            return Long.compare(offset, other.offset);
+        } else {
+            return Integer.compare(idPage, other.idPage);
+        }
+    }
+
+    boolean samePage(SegmentPointer other) {
+        return idPage == other.idPage;
+    }
+
+    SegmentPointer moveForward(long length) {
+        return new SegmentPointer(idPage, offset + length);
+    }
+
+    @Override
+    public String toString() {
+        return "SegmentPointer{idPage=" + idPage + ", offset=" + offset + '}';
+    }
+
+    /**
+     * Calculate the distance in bytes inside the same segment
+     * */
+    public long distance(SegmentPointer other) {
+        assert idPage == other.idPage;
+        return offset - other.offset;
+    }
+
+    int offset() {
+        return (int) offset;
+    }
+
+    public SegmentPointer plus(int delta) {
+        return new SegmentPointer(this.idPage, offset + delta);
+    }
+
+    int pageId() {
+        return this.idPage;
+    }
+}

--- a/broker/src/main/java/io/moquette/broker/queue/SegmentPointer.java
+++ b/broker/src/main/java/io/moquette/broker/queue/SegmentPointer.java
@@ -35,10 +35,6 @@ final class SegmentPointer implements Comparable<SegmentPointer> {
         }
     }
 
-    public boolean isGreaterThan(SegmentPointer other) {
-        return this.compareTo(other) > 0;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/broker/src/main/java/io/moquette/broker/queue/SegmentPointer.java
+++ b/broker/src/main/java/io/moquette/broker/queue/SegmentPointer.java
@@ -22,8 +22,8 @@ final class SegmentPointer implements Comparable<SegmentPointer> {
     /**
      * Copy constructor
      * */
-    public SegmentPointer(SegmentPointer original) {
-        this(original.idPage, original.offset);
+    public SegmentPointer copy() {
+        return new SegmentPointer(idPage, offset);
     }
 
     @Override
@@ -33,6 +33,10 @@ final class SegmentPointer implements Comparable<SegmentPointer> {
         } else {
             return Integer.compare(idPage, other.idPage);
         }
+    }
+
+    public boolean isGreaterThan(SegmentPointer other) {
+        return this.compareTo(other) > 0;
     }
 
     @Override

--- a/broker/src/main/java/io/moquette/broker/queue/VirtualPointer.java
+++ b/broker/src/main/java/io/moquette/broker/queue/VirtualPointer.java
@@ -1,0 +1,51 @@
+package io.moquette.broker.queue;
+
+public class VirtualPointer implements Comparable<VirtualPointer> {
+    final long logicalOffset;
+
+    public static VirtualPointer buildUntouched() {
+        return new VirtualPointer(-1);
+    }
+
+    public VirtualPointer(long logicalOffset) {
+        this.logicalOffset = logicalOffset;
+    }
+
+    @Override
+    public int compareTo(VirtualPointer other) {
+        return Long.compare(logicalOffset, other.logicalOffset);
+    }
+
+    public long segmentOffset() {
+        return logicalOffset % Segment.SIZE;
+    }
+
+    public long logicalOffset() {
+        return logicalOffset;
+    }
+
+    public VirtualPointer moveForward(long delta) {
+        return new VirtualPointer(logicalOffset + delta);
+    }
+
+    public VirtualPointer plus(int i) {
+        return new VirtualPointer(logicalOffset + i);
+    }
+
+    public boolean isGreaterThan(VirtualPointer other) {
+        return this.compareTo(other) > 0;
+    }
+
+    public boolean isUntouched() {
+        return logicalOffset == -1;
+    }
+
+    public VirtualPointer copy() {
+        return new VirtualPointer(this.logicalOffset);
+    }
+
+    @Override
+    public String toString() {
+        return "VirtualPointer{logicalOffset=" + logicalOffset + '}';
+    }
+}

--- a/broker/src/test/java/io/moquette/broker/queue/DummySegmentAllocator.java
+++ b/broker/src/test/java/io/moquette/broker/queue/DummySegmentAllocator.java
@@ -1,0 +1,44 @@
+package io.moquette.broker.queue;
+
+import java.io.IOException;
+import java.nio.MappedByteBuffer;
+import java.util.Properties;
+
+public class DummySegmentAllocator implements SegmentAllocator {
+
+    @Override
+    public Segment nextFreeSegment() {
+        final MappedByteBuffer pageBuffer = createFreshPageTmpTile();
+        final SegmentPointer begin = new SegmentPointer(0, 0);
+        final SegmentPointer end = new SegmentPointer(0, Segment.SIZE);
+        return new Segment(pageBuffer, begin, end);
+    }
+
+    @Override
+    public Segment reopenSegment(int pageId, int beginOffset) throws QueueException {
+        final MappedByteBuffer pageBuffer = createFreshPageTmpTile();
+        final SegmentPointer begin = new SegmentPointer(pageId, beginOffset);
+        final SegmentPointer end = new SegmentPointer(pageId, beginOffset + Segment.SIZE);
+        return new Segment(pageBuffer, begin, end);
+    }
+
+    private MappedByteBuffer createFreshPageTmpTile() {
+        final MappedByteBuffer pageBuffer;
+        try {
+            pageBuffer = Utils.createPageFile();
+        } catch (IOException ex) {
+            // used only in tests, so it's safe to fail the test with an untyped exception
+            throw new RuntimeException(ex);
+        }
+        return pageBuffer;
+    }
+
+    @Override
+    public void close() throws QueueException {
+        // TODO, maybe
+    }
+
+    @Override
+    public void dumpState(Properties checkpoint) {
+    }
+}

--- a/broker/src/test/java/io/moquette/broker/queue/QueuePoolTest.java
+++ b/broker/src/test/java/io/moquette/broker/queue/QueuePoolTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Properties;
@@ -21,7 +22,7 @@ class QueuePoolTest {
     public void checkpointFileContainsCorrectReferences() throws QueueException, IOException {
         final QueuePool queuePool = QueuePool.loadQueues(tempQueueFolder);
         final Queue queue = queuePool.getOrCreate("test");
-        queue.enqueue("AAAA".getBytes(StandardCharsets.UTF_8));
+        queue.enqueue((ByteBuffer)ByteBuffer.wrap("AAAA".getBytes(StandardCharsets.UTF_8)));
         queue.force();
         queuePool.close();
 
@@ -51,14 +52,14 @@ class QueuePoolTest {
     public void reloadQueuePoolAndCheckRestartFromWhereItLeft() throws QueueException, IOException {
         QueuePool queuePool = QueuePool.loadQueues(tempQueueFolder);
         Queue queue = queuePool.getOrCreate("test");
-        queue.enqueue("AAAA".getBytes(StandardCharsets.UTF_8));
+        queue.enqueue(ByteBuffer.wrap("AAAA".getBytes(StandardCharsets.UTF_8)));
         queue.force();
         queuePool.close();
 
         // reload
         queuePool = QueuePool.loadQueues(tempQueueFolder);
         queue = queuePool.getOrCreate("test");
-        queue.enqueue("BBBB".getBytes(StandardCharsets.UTF_8));
+        queue.enqueue(ByteBuffer.wrap("BBBB".getBytes(StandardCharsets.UTF_8)));
         queue.force();
         queuePool.close();
 

--- a/broker/src/test/java/io/moquette/broker/queue/QueuePoolTest.java
+++ b/broker/src/test/java/io/moquette/broker/queue/QueuePoolTest.java
@@ -216,4 +216,9 @@ class QueuePoolTest {
         // Verify
         assertEquals((PagedFilesAllocator.PAGE_SIZE - Segment.SIZE) / Segment.SIZE, holes.size());
     }
+
+    @Test
+    public void verifySingleReaderSingleWriterOnSingleQueuePool() {
+        throw new IllegalStateException("Not yet implemented");
+    }
 }

--- a/broker/src/test/java/io/moquette/broker/queue/QueuePoolTest.java
+++ b/broker/src/test/java/io/moquette/broker/queue/QueuePoolTest.java
@@ -158,5 +158,33 @@ class QueuePoolTest {
         final int holesInLastPage = 3;
         final int expectedHolesCount = holesInFirstPage + holesInEmptyPage + holesInLastPage;
         assertEquals(expectedHolesCount, holes.size());
+
+        // first page hole
+        int i = 0;
+        int expectedOffset = Segment.SIZE;
+        for (; i < holesInFirstPage; i++) {
+            final QueuePool.SegmentRef hole = holes.get(i);
+            assertEquals(0, hole.pageId);
+            assertEquals(expectedOffset, hole.offset);
+            expectedOffset += Segment.SIZE;
+        }
+
+        // central empty pages
+        expectedOffset = 0;
+        for (; i < holesInFirstPage + holesInEmptyPage; i++) {
+            final QueuePool.SegmentRef hole = holes.get(i);
+            assertEquals(1, hole.pageId);
+            assertEquals(expectedOffset, hole.offset);
+            expectedOffset += Segment.SIZE;
+        }
+
+        // tail page hole
+        expectedOffset = 0;
+        for (; i < expectedHolesCount; i++) {
+            final QueuePool.SegmentRef hole = holes.get(i);
+            assertEquals(2, hole.pageId);
+            assertEquals(expectedOffset, hole.offset);
+            expectedOffset += Segment.SIZE;
+        }
     }
 }

--- a/broker/src/test/java/io/moquette/broker/queue/QueuePoolTest.java
+++ b/broker/src/test/java/io/moquette/broker/queue/QueuePoolTest.java
@@ -1,0 +1,79 @@
+package io.moquette.broker.queue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class QueuePoolTest {
+
+    @TempDir
+    Path tempQueueFolder;
+
+    @Test
+    public void checkpointFileContainsCorrectReferences() throws QueueException, IOException {
+        final QueuePool queuePool = QueuePool.loadQueues(tempQueueFolder);
+        final Queue queue = queuePool.getOrCreate("test");
+        queue.enqueue("AAAA".getBytes(StandardCharsets.UTF_8));
+        queue.force();
+        queuePool.close();
+
+        // verify
+        final Path checkpointPath = tempQueueFolder.resolve("checkpoint.properties");
+        final File checkpointFile = checkpointPath.toFile();
+        assertTrue(checkpointFile.exists(), "Checkpoint file must be created");
+
+        final Properties checkpoint = loadCheckpoint(checkpointPath);
+        final int lastPage = Integer.parseInt(checkpoint.get("segments.last_page").toString());
+        assertEquals(0, lastPage);
+        final int lastSegment = Integer.parseInt(checkpoint.get("segments.last_segment").toString());
+        assertEquals(1, lastSegment);
+
+        assertEquals("test", checkpoint.get("queues.0.name"), "Queue name must match");
+    }
+
+    private Properties loadCheckpoint(Path checkpointPath) throws IOException {
+        final FileReader fileReader;
+        fileReader = new FileReader(checkpointPath.toFile());
+        final Properties checkpointProps = new Properties();
+        checkpointProps.load(fileReader);
+        return checkpointProps;
+    }
+
+    @Test
+    public void reloadQueuePoolAndCheckRestartFromWhereItLeft() throws QueueException, IOException {
+        QueuePool queuePool = QueuePool.loadQueues(tempQueueFolder);
+        Queue queue = queuePool.getOrCreate("test");
+        queue.enqueue("AAAA".getBytes(StandardCharsets.UTF_8));
+        queue.force();
+        queuePool.close();
+
+        // reload
+        queuePool = QueuePool.loadQueues(tempQueueFolder);
+        queue = queuePool.getOrCreate("test");
+        queue.enqueue("BBBB".getBytes(StandardCharsets.UTF_8));
+        queue.force();
+        queuePool.close();
+
+        // verify
+        final Path checkpointPath = tempQueueFolder.resolve("checkpoint.properties");
+        final File checkpointFile = checkpointPath.toFile();
+        assertTrue(checkpointFile.exists(), "Checkpoint file must be created");
+
+        final Properties checkpoint = loadCheckpoint(checkpointPath);
+        final int lastPage = Integer.parseInt(checkpoint.get("segments.last_page").toString());
+        assertEquals(0, lastPage);
+        final int lastSegment = Integer.parseInt(checkpoint.get("segments.last_segment").toString());
+        assertEquals(1, lastSegment);
+
+        assertEquals("test", checkpoint.get("queues.0.name"), "Queue name must match");
+        assertEquals("15", checkpoint.get("queues.0.head_offset"), "Queue head must be 16 bytes over the start");
+    }
+}

--- a/broker/src/test/java/io/moquette/broker/queue/QueueTest.java
+++ b/broker/src/test/java/io/moquette/broker/queue/QueueTest.java
@@ -1,0 +1,200 @@
+package io.moquette.broker.queue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class QueueTest {
+
+    @TempDir
+    Path tempQueueFolder;
+
+    private void assertContainsOnly(char expectedChar, byte[] verify) {
+        for (int i = 0; i < verify.length; i++) {
+            if (verify[i] != expectedChar) {
+                fail(String.format("Expected %c but found %c in %c%c%c", expectedChar, verify[i], verify[i-1], verify[i], verify[i+1]));
+            }
+        }
+    }
+
+    private byte[] generatePayload(int numBytes) {
+        return generatePayload(numBytes, (byte) 'A');
+    }
+
+    private byte[] generatePayload(int numBytes, byte c) {
+        final byte[] payload = new byte[numBytes];
+        for (int i = 0; i < numBytes; i++) {
+            payload[i] = c;
+        }
+        return payload;
+    }
+
+    @Test
+    public void basicNoBlockEnqueue() throws QueueException, IOException {
+        final MappedByteBuffer pageBuffer = Utils.createPageFile();
+
+        final Segment head = new Segment(pageBuffer, new SegmentPointer(0,0), new SegmentPointer(0, 1024));
+        final SegmentPointer currentHead = new SegmentPointer(0, 0);
+        final Queue queue = new Queue("test", head, currentHead, new DummySegmentAllocator(), (name, segment) -> {
+            // NOOP
+        });
+
+        // generate byte array to insert.
+        byte[] payload = new byte[128];
+        new Random().nextBytes(payload);
+
+        queue.enqueue(payload);
+    }
+
+    @Test
+    public void insertSomeDataIntoNewQueue() throws QueueException, IOException {
+        final QueuePool queuePool = QueuePool.loadQueues(tempQueueFolder);
+        final Queue queue = queuePool.getOrCreate("test");
+        queue.enqueue("AAAA".getBytes(StandardCharsets.UTF_8));
+
+        // verify
+        final HashSet<String> fileset = new HashSet<>(Arrays.asList(tempQueueFolder.toFile().list()));
+        assertEquals(2, fileset.size());
+        assertTrue(fileset.contains("checkpoint.properties"), "Checkpoint file must be created");
+        assertTrue(fileset.contains("0.page"), "One page file must be created");
+
+        final Path pageFile = tempQueueFolder.resolve("0.page");
+        verifyFile(pageFile, 9, rawContent -> {
+            assertEquals(4, rawContent.getInt(), "First 4 bytes contains the length");
+            assertEquals('A', rawContent.get());
+            assertEquals('A', rawContent.get());
+            assertEquals('A', rawContent.get());
+            assertEquals('A', rawContent.get());
+            assertEquals(0, rawContent.get());
+        });
+    }
+
+    private void verifyFile(Path file, int bytesToRead, Consumer<ByteBuffer> verifier) throws IOException {
+        final FileChannel fc = FileChannel.open(file, StandardOpenOption.READ);
+        final ByteBuffer rawContent = ByteBuffer.allocate(bytesToRead);
+        final int read = fc.read(rawContent);
+        assertEquals(bytesToRead, read);
+        rawContent.flip();
+
+        verifier.accept(rawContent);
+    }
+
+    @Test
+    public void insertDataTriggerCreationOfNewPageFile() throws QueueException {
+        final QueuePool queuePool = QueuePool.loadQueues(tempQueueFolder);
+        final Queue queue = queuePool.getOrCreate("test");
+
+        // one page is 64 MB so the loop count to fill it is 64 * 1024
+
+       // 4 bytes are left for length so that each time are inserted 1024 bytes, 4 header and 1020 payload
+        byte[] payload = generatePayload(1024 - 4);
+        for (int i = 0; i < 64; i++) {
+            System.out.println("loop " + i);
+            for (int j = 0; j < 1024; j++) {
+//                System.out.print("outer: " + i + ", inner: " + j);
+                queue.enqueue(payload);
+            }
+        }
+
+        // check the 2 files are created
+        HashSet<String> fileset = new HashSet<>(Arrays.asList(tempQueueFolder.toFile().list()));
+        assertEquals(2, fileset.size());
+        assertTrue(fileset.contains("checkpoint.properties"), "Checkpoint file must be created");
+        assertTrue(fileset.contains("0.page"),
+             "One page file must be created");
+
+        // Exercise
+        // some data to force create a new page
+        queue.enqueue(generatePayload(10, (byte) 'B'));
+
+        // Verify
+        fileset = new HashSet<>(Arrays.asList(tempQueueFolder.toFile().list()));
+        assertEquals(3, fileset.size());
+        assertTrue(fileset.contains("checkpoint.properties"), "Checkpoint file must be created");
+        assertTrue(fileset.contains("0.page"), "First page file must be created");
+        assertTrue(fileset.contains("1.page"), "Second page file must be created");
+    }
+
+    @Test
+    public void insertDataCrossingSegmentBoundary() throws QueueException, IOException {
+        final QueuePool queuePool = QueuePool.loadQueues(tempQueueFolder);
+        final Queue queue = queuePool.getOrCreate("test");
+
+        // one segment is 4MB 4 * 1024 * payload
+        // so send (4 * 1024) - 1 payloads of 1024 and then send
+        // a payload of 1028 (4 bytes over remaining space)
+
+        // 4 bytes are left for length so that each time are inserted 1024 bytes, 4 header and 1020 payload
+        byte[] payload = generatePayload(1024 - 4);
+        for (int i = 0; i < (4 * 1024) - 1; i++) {
+            queue.enqueue(payload);
+        }
+
+        // Experiment
+        byte[] crossingPayload = generatePayload(1028 - 4, (byte) 'B');
+        queue.enqueue(crossingPayload);
+        queue.force();
+        queuePool.close();
+
+        // Verify
+        final MappedByteBuffer page = Utils.openPageFile(tempQueueFolder.resolve("0.page"));
+        final int beforeLastMessage = ((4 * 1024) - 1) * 1024;
+        final ByteBuffer crossingSegment = (ByteBuffer) page.position(beforeLastMessage);
+        final int msgLength = crossingSegment.getInt();
+
+        assertEquals(1028 - 4, msgLength);
+        byte[] probe = new byte[msgLength];
+        crossingSegment.get(probe);
+        assertContainsOnly('B', probe);
+    }
+
+    @Test
+    public void insertDataBiggerThanASegment() throws QueueException, IOException {
+        final QueuePool queuePool = QueuePool.loadQueues(tempQueueFolder);
+        final Queue queue = queuePool.getOrCreate("test");
+
+        // one segment is 4MB 4 * 1024 * payload
+        // so send (4 * 1024) - 1 payloads of 1024 and then send
+        // a payload of 1028 (4 bytes over remaining space)
+
+        // 4 bytes are left for length so that each time are inserted 1024 bytes, 4 header and 1020 payload
+        byte[] payload = generatePayload(1024 - 4);
+        for (int i = 0; i < (4 * 1024) - 1; i++) {
+            queue.enqueue(payload);
+        }
+
+        // Experiment
+        // 1024 + 4 * 1024 * 1024 + 16 bytes
+        int moreThanOneSegment = 1024 + 4*1024*1024 + 16;
+        byte[] crossingMultipleSegmentPayload = generatePayload(moreThanOneSegment, (byte) 'B');
+        queue.enqueue(crossingMultipleSegmentPayload);
+        queue.force();
+        queuePool.close();
+
+        // Verify
+        final MappedByteBuffer page = Utils.openPageFile(tempQueueFolder.resolve("0.page"));
+        final int beforeLastMessage = ((4 * 1024) - 1) * 1024;
+        final ByteBuffer crossingSegment = (ByteBuffer) page.position(beforeLastMessage);
+        final int msgLength = crossingSegment.getInt();
+
+        assertEquals(moreThanOneSegment, msgLength);
+        byte[] probe = new byte[msgLength];
+        crossingSegment.get(probe);
+        assertContainsOnly('B', probe);
+    }
+}

--- a/broker/src/test/java/io/moquette/broker/queue/QueueTest.java
+++ b/broker/src/test/java/io/moquette/broker/queue/QueueTest.java
@@ -149,7 +149,7 @@ class QueueTest {
     }
 
     @Test
-    public void insertWithHeaderCrossingSegments() throws QueueException, IOException {
+    public void insertWithAnHeaderThatCrossSegments() throws QueueException, IOException {
         final QueuePool queuePool = QueuePool.loadQueues(tempQueueFolder);
         final Queue queue = queuePool.getOrCreate("test");
 

--- a/broker/src/test/java/io/moquette/broker/queue/QueueTest.java
+++ b/broker/src/test/java/io/moquette/broker/queue/QueueTest.java
@@ -66,11 +66,11 @@ class QueueTest {
     }
 
 
-    private byte[] generatePayload(int numBytes) {
+    static byte[] generatePayload(int numBytes) {
         return generatePayload(numBytes, (byte) 'A');
     }
 
-    private byte[] generatePayload(int numBytes, byte c) {
+    static byte[] generatePayload(int numBytes, byte c) {
         final byte[] payload = new byte[numBytes];
         for (int i = 0; i < numBytes; i++) {
             payload[i] = c;

--- a/broker/src/test/java/io/moquette/broker/queue/SegmentPointerTest.java
+++ b/broker/src/test/java/io/moquette/broker/queue/SegmentPointerTest.java
@@ -1,0 +1,30 @@
+package io.moquette.broker.queue;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SegmentPointerTest {
+
+    @Test
+    public void testCompareInSameSegment() {
+        final SegmentPointer minor = new SegmentPointer(1, 10);
+        final SegmentPointer otherMinor = new SegmentPointer(1, 10);
+        final SegmentPointer major = new SegmentPointer(1, 12);
+
+        assertEquals(-1, minor.compareTo(major), "minor is less than major");
+        assertEquals(1, major.compareTo(minor), "major is greater than minor");
+        assertEquals(0, minor.compareTo(otherMinor), "minor equals itself");
+    }
+
+    @Test
+    public void testCompareInDifferentSegments() {
+        final SegmentPointer minor = new SegmentPointer(1, 10);
+        final SegmentPointer otherMinor = new SegmentPointer(1, 10);
+        final SegmentPointer major = new SegmentPointer(2, 4);
+
+        assertEquals(-1, minor.compareTo(major), "minor is less than major");
+        assertEquals(1, major.compareTo(minor), "major is greater than minor");
+        assertEquals(0, minor.compareTo(otherMinor), "minor equals itself");
+    }
+}

--- a/broker/src/test/java/io/moquette/broker/queue/SegmentTest.java
+++ b/broker/src/test/java/io/moquette/broker/queue/SegmentTest.java
@@ -22,4 +22,16 @@ public class SegmentTest {
         assertFalse(segment.hasSpace(current, 513));
         assertFalse(segment.hasSpace(otherCurrent, 513));
     }
+
+    @Test
+    public void testBytesAfter() throws IOException {
+        final MappedByteBuffer pageBuffer = Utils.createPageFile();
+
+        final SegmentPointer begin = new SegmentPointer(0, 0);
+        final SegmentPointer end = new SegmentPointer(0, 1023);
+        final Segment segment = new Segment(pageBuffer, begin, end);
+
+        assertEquals(0, segment.bytesAfter(end));
+        assertEquals(1023, segment.bytesAfter(begin));
+    }
 }

--- a/broker/src/test/java/io/moquette/broker/queue/SegmentTest.java
+++ b/broker/src/test/java/io/moquette/broker/queue/SegmentTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.MappedByteBuffer;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SegmentTest {
 
@@ -15,8 +17,8 @@ public class SegmentTest {
 
         final Segment segment = new Segment(pageBuffer, new SegmentPointer(0, 0), new SegmentPointer(0, 1023));
 
-        final SegmentPointer current = new SegmentPointer(0, 511);
-        final SegmentPointer otherCurrent = new SegmentPointer(1, 511);
+        final VirtualPointer current = new VirtualPointer(511);
+        final VirtualPointer otherCurrent = current.moveForward(pageBuffer.capacity()); // pointer in next page
 
         assertTrue(segment.hasSpace(current, 512));
         assertFalse(segment.hasSpace(current, 513));

--- a/broker/src/test/java/io/moquette/broker/queue/SegmentTest.java
+++ b/broker/src/test/java/io/moquette/broker/queue/SegmentTest.java
@@ -1,0 +1,25 @@
+package io.moquette.broker.queue;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.MappedByteBuffer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SegmentTest {
+
+    @Test
+    public void testHasSpace() throws IOException {
+        final MappedByteBuffer pageBuffer = Utils.createPageFile();
+
+        final Segment segment = new Segment(pageBuffer, new SegmentPointer(0, 0), new SegmentPointer(0, 1023));
+
+        final SegmentPointer current = new SegmentPointer(0, 511);
+        final SegmentPointer otherCurrent = new SegmentPointer(1, 511);
+
+        assertTrue(segment.hasSpace(current, 512));
+        assertFalse(segment.hasSpace(current, 513));
+        assertFalse(segment.hasSpace(otherCurrent, 513));
+    }
+}

--- a/broker/src/test/java/io/moquette/broker/queue/Utils.java
+++ b/broker/src/test/java/io/moquette/broker/queue/Utils.java
@@ -2,6 +2,7 @@ package io.moquette.broker.queue;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.OpenOption;
@@ -21,5 +22,12 @@ class Utils {
         final OpenOption[] openOptions = {StandardOpenOption.READ, StandardOpenOption.TRUNCATE_EXISTING};
         FileChannel fileChannel = FileChannel.open(pageFile, openOptions);
         return fileChannel.map(FileChannel.MapMode.READ_ONLY, 0, PagedFilesAllocator.PAGE_SIZE);
+    }
+
+    static String bufferToString(ByteBuffer buffer) {
+        byte[] data = new byte[buffer.remaining()];
+        buffer.get(data);
+
+        return new String(data);
     }
 }

--- a/broker/src/test/java/io/moquette/broker/queue/Utils.java
+++ b/broker/src/test/java/io/moquette/broker/queue/Utils.java
@@ -12,10 +12,14 @@ import java.nio.file.StandardOpenOption;
 class Utils {
 
     static MappedByteBuffer createPageFile() throws IOException {
+        return createPageFile(1024);
+    }
+
+    static MappedByteBuffer createPageFile(int size) throws IOException {
         final Path pageFile = File.createTempFile("test_queue", ".page").toPath();
         final OpenOption[] openOptions = {StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING};
         FileChannel fileChannel = FileChannel.open(pageFile, openOptions);
-        return fileChannel.map(FileChannel.MapMode.READ_WRITE, 0, 1024);
+        return fileChannel.map(FileChannel.MapMode.READ_WRITE, 0, size);
     }
 
     static MappedByteBuffer openPageFile(Path pageFile) throws IOException {

--- a/broker/src/test/java/io/moquette/broker/queue/Utils.java
+++ b/broker/src/test/java/io/moquette/broker/queue/Utils.java
@@ -1,0 +1,25 @@
+package io.moquette.broker.queue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.MappedByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+
+class Utils {
+
+    static MappedByteBuffer createPageFile() throws IOException {
+        final Path pageFile = File.createTempFile("test_queue", ".page").toPath();
+        final OpenOption[] openOptions = {StandardOpenOption.READ, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING};
+        FileChannel fileChannel = FileChannel.open(pageFile, openOptions);
+        return fileChannel.map(FileChannel.MapMode.READ_WRITE, 0, 1024);
+    }
+
+    static MappedByteBuffer openPageFile(Path pageFile) throws IOException {
+        final OpenOption[] openOptions = {StandardOpenOption.READ, StandardOpenOption.TRUNCATE_EXISTING};
+        FileChannel fileChannel = FileChannel.open(pageFile, openOptions);
+        return fileChannel.map(FileChannel.MapMode.READ_ONLY, 0, PagedFilesAllocator.PAGE_SIZE);
+    }
+}

--- a/broker/src/test/java/io/moquette/broker/queue/VirtualPointerTest.java
+++ b/broker/src/test/java/io/moquette/broker/queue/VirtualPointerTest.java
@@ -1,0 +1,18 @@
+package io.moquette.broker.queue;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class VirtualPointerTest {
+
+    @Test
+    public void testCompare() {
+        final VirtualPointer lower = new VirtualPointer(100L);
+        final VirtualPointer higher = new VirtualPointer(200L);
+
+        assertEquals(1, higher.compareTo(lower), higher.logicalOffset + " must be greater than " + lower.logicalOffset);
+        assertEquals(-1, lower.compareTo(higher), lower.logicalOffset + " must be lower than " + higher.logicalOffset);
+        assertEquals(0, lower.compareTo(lower), "identity must be equal");
+    }
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with the release version and one of the following labels, depending on the scope of your change:
- bug
- enhancement
- breaking change
- doc
-->

## Release notes
Introduce new persistent queue implementation based on concurrent access to segmented queues.


## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
All queues are saved in segments, each segment in stored in a memory mapped region named page where each page can contains multiple segments of different queues. The access to the segment is based on CAS operator on such named `SegmentPointer` objects, when the CAS is not possible a retry is repeated until new `Segment` access is required, in which case the access is managed by a usual lock guarded section

## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

-->
