### PR TITLE
Update dependencies and CI fixes

### DIFF
--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-18.04, ubuntu-latest]
-                java: [11, 12, 15]
+                java: [11, 17]
                 arch: [x64] # when ARM will be present add aarch64
             fail-fast: false
             max-parallel: 4

--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -5,9 +5,9 @@ name: Java CI with Maven
 
 on:
     push:
-        branches: [ master ]
+        branches: [ main ]
     pull_request:
-        branches: [ master ]
+        branches: [ main ]
 
 jobs:
     test:

--- a/.github/workflows/maven_central_snapshot_version.yml
+++ b/.github/workflows/maven_central_snapshot_version.yml
@@ -4,7 +4,7 @@ name: Build and ship SNAPSHOT versions to Maven Central
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
     publish:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-![Java CI with Maven](https://github.com/moquette-io/moquette/workflows/Java%20CI%20with%20Maven/badge.svg?branch=master)
+ServerIntegrationOpenSSLTest![Java CI with Maven](https://github.com/moquette-io/moquette/workflows/Java%20CI%20with%20Maven/badge.svg?branch=main)
 
 ## Moquette Project
 
-[![Build Status](https://api.travis-ci.org/moquette-io/moquette.svg?branch=master)](https://travis-ci.org/moquette-io/moquette)
+[![Build Status](https://api.travis-ci.org/moquette-io/moquette.svg?branch=main)](https://travis-ci.org/moquette-io/moquette)
 
 * [Documentation reference guide](http://moquette-io.github.io/moquette/) Guide on how to use and configure Moquette
 * [Google Group](https://groups.google.com/forum/#!forum/moquette-mqtt) Google Group to participate in development discussions.
@@ -44,30 +44,13 @@ Or if you are on Windows shell
 
 ## Embedding in other projects
 
-To embed Moquette in another maven project is sufficient to include a repository and declare the dependency: 
-
-```
-<repositories>
-  <repository>
-    <id>bintray</id>
-    <url>https://jcenter.bintray.com</url>
-    <releases>
-      <enabled>true</enabled>
-    </releases>
-    <snapshots>
-      <enabled>false</enabled>
-    </snapshots>
-  </repository>
-</repositories>
-```
-
 Include dependency in your project: 
 
 ```
 <dependency>
       <groupId>io.moquette</groupId>
       <artifactId>moquette-broker</artifactId>
-      <version>0.14</version>
+      <version>0.15</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,17 +20,13 @@ Moquette is also used into [Atomize Spin](http://atomizesoftware.com/spin) a sof
 Part of moquette are used into the [Vertx MQTT module](https://github.com/giovibal/vertx-mqtt-broker-mod), into [MQTT spy](http://kamilfb.github.io/mqtt-spy/)
 and into [WSO2 Messge broker](http://techexplosives-pamod.blogspot.it/2014/05/mqtt-transport-architecture-wso2-mb-3x.html).
 
-## Try the demo instance
-
-Point your browser to [cloud instance](http://broker.moquette.io), request an account then use it from your MQTT clients.
-
 ## 1 minute set up
 
-Start play with it, download the self distribution tar from [BinTray](https://bintray.com/artifact/download/andsel/generic/moquette-0.14.tar.gz) ,
+Start play with it, download the self distribution tar from [BinTray](https://bintray.com/artifact/download/andsel/generic/moquette-0.15.tar.gz) ,
 the un untar and start the broker listening on `1883` port and enjoy!
 
 ```
-tar xvf moquette-distribution-0.14.tar.gz
+tar xvf moquette-distribution-0.15.tar.gz
 cd bin
 ./moquette.sh
 ```
@@ -56,9 +52,7 @@ Include dependency in your project:
 
 ## Build from sources
 
+After a git clone of the repository, cd into the cloned sources and: `./gradlew package`, at the end the distribution 
+package is present at `distribution/target/distribution-0.16-SNAPSHOT-bundle.tar.gz`
 
-After a git clone of the repository, cd into the cloned sources and: `./gradlew clean moquette-distribution:distMoquetteTar` or
-`./gradlew clean moquette-distribution:distMoquetteZip`.
-
-
-In distribution/build directory will be produced the selfcontained file for the broker with all dependencies and a running script. 
+In distribution/target directory will be produced the selfcontained file for the broker with all dependencies and a running script. 

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -14,8 +14,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <netty.version>4.1.59.Final</netty.version>
-        <netty.tcnative.version>2.0.34.Final</netty.tcnative.version>
+        <netty.version>4.1.73.Final</netty.version>
+        <!-- Check Netty pom.xm to know the right version of tcnative, for example
+             https://github.com/netty/netty/blob/netty-4.1.73.Final/pom.xml#L545 -->
+        <netty.tcnative.version>2.0.46.Final</netty.tcnative.version>
         <paho.version>1.2.5</paho.version>
         <h2.version>1.4.199</h2.version>
     </properties>
@@ -24,14 +26,14 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.35</version>
         </dependency>
 
         <dependency>
             <!-- This is used to use log4j12 implementation -->
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.25</version>
+            <version>1.7.35</version>
             <scope>runtime</scope>
         </dependency>
 


### PR DESCRIPTION
Update project dependencies
- Netty `4.1.73.Final`
- Netty TC native `2.0.46.Final`
- slf4j `1.7.25`

Aligns CI:
- switch build branch from `master` to `main`
- update JDK matrix to test against 11 and 17

Update versions used in README
