### PR TITLE
Moquette broker kills parent application if embedded and broker port already used #641

### DIFF
--- a/broker/src/main/java/io/moquette/broker/NewNettyAcceptor.java
+++ b/broker/src/main/java/io/moquette/broker/NewNettyAcceptor.java
@@ -223,7 +223,7 @@ class NewNettyAcceptor {
         } catch (Exception ex) {
             if (ex instanceof BindException) {
                LOG.error("Cannot bind to port: " + port, ex);
-               System.exit(1);
+                throw new RuntimeException(ex);
             } else {
                 LOG.error("An interruptedException was caught while initializing integration. Protocol={}", protocol, ex);
                 throw new RuntimeException(ex);

--- a/broker/src/main/java/io/moquette/broker/NewNettyAcceptor.java
+++ b/broker/src/main/java/io/moquette/broker/NewNettyAcceptor.java
@@ -223,7 +223,7 @@ class NewNettyAcceptor {
         } catch (Exception ex) {
             if (ex instanceof BindException) {
                LOG.error("Cannot bind to port: " + port, ex);
-                throw new RuntimeException(ex);
+               throw new RuntimeException("Cannot bind to port: " + port, ex);
             } else {
                 LOG.error("An interruptedException was caught while initializing integration. Protocol={}", protocol, ex);
                 throw new RuntimeException(ex);

--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -55,7 +55,11 @@ public class Server {
 
     public static void main(String[] args) throws IOException {
         final Server server = new Server();
-        server.startServer();
+        try {
+            server.startServer();
+        } catch (RuntimeException e) {
+            System.exit(1);
+        }
         System.out.println("Server started, version 0.16-SNAPSHOT");
         //Bind a shutdown hook
         Runtime.getRuntime().addShutdownHook(new Thread(server::stopServer));


### PR DESCRIPTION
## Release notes
Avoid Server.startServer to exit the process it port is bound, just raise an error (#646)

[#641](https://github.com/moquette-io/moquette/issues/641)
just there was removed System.exit(1)