### PR TITLE
Fix session handling

### DIFF
--- a/broker/src/main/java/io/moquette/broker/IQueueRepository.java
+++ b/broker/src/main/java/io/moquette/broker/IQueueRepository.java
@@ -7,5 +7,7 @@ public interface IQueueRepository {
 
     Queue<SessionRegistry.EnqueuedMessage> createQueue(String cli, boolean clean);
 
+    void removeQueue(String cli);
+
     Map<String, Queue<SessionRegistry.EnqueuedMessage>> listAllQueues();
 }

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -230,7 +230,7 @@ final class MQTTConnection {
                     }
                 } else {
                     bindedSession.disconnect();
-                    sessionRegistry.remove(bindedSession);
+                    sessionRegistry.remove(bindedSession.getClientID());
                     LOG.error("CONNACK send failed, cleanup session and close the connection", future.cause());
                     channel.close();
                 }
@@ -317,7 +317,7 @@ final class MQTTConnection {
         }
         if (bindedSession.isClean()) {
             LOG.debug("Remove session for client");
-            sessionRegistry.remove(bindedSession);
+            sessionRegistry.remove(bindedSession.getClientID());
         } else {
             bindedSession.disconnect();
         }

--- a/broker/src/main/java/io/moquette/broker/MemoryQueueRepository.java
+++ b/broker/src/main/java/io/moquette/broker/MemoryQueueRepository.java
@@ -18,6 +18,11 @@ public class MemoryQueueRepository implements IQueueRepository {
     }
 
     @Override
+    public void removeQueue(String cli) {
+        queues.remove(cli);
+    }
+
+    @Override
     public Map<String, Queue<SessionRegistry.EnqueuedMessage>> listAllQueues() {
         return Collections.unmodifiableMap(queues);
     }

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -130,6 +130,10 @@ class Session {
         this.mqttConnection = mqttConnection;
     }
 
+    boolean isBoundTo(MQTTConnection mqttConnection) {
+        return this.mqttConnection == mqttConnection;
+    }
+
     public boolean disconnected() {
         return status.get() == SessionStatus.DISCONNECTED;
     }

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -116,7 +116,6 @@ public class SessionRegistry {
     private final ISubscriptionsDirectory subscriptionsDirectory;
     private final IQueueRepository queueRepository;
     private final Authorizator authorizator;
-    private final ConcurrentMap<String, Queue<SessionRegistry.EnqueuedMessage>> queues = new ConcurrentHashMap<>();
 
     SessionRegistry(ISubscriptionsDirectory subscriptionsDirectory,
                     IQueueRepository queueRepository,
@@ -124,98 +123,84 @@ public class SessionRegistry {
         this.subscriptionsDirectory = subscriptionsDirectory;
         this.queueRepository = queueRepository;
         this.authorizator = authorizator;
-        reloadPersistentQueues();
         recreateSessionPool();
     }
 
-    private void reloadPersistentQueues() {
-        final Map<String, Queue<EnqueuedMessage>> persistentQueues = queueRepository.listAllQueues();
-        persistentQueues.forEach(queues::put);
-    }
-
     private void recreateSessionPool() {
+        final Map<String, Queue<EnqueuedMessage>> queues = queueRepository.listAllQueues();
         for (String clientId : subscriptionsDirectory.listAllSessionIds()) {
             // if the subscriptions are present is obviously false
-            final Queue<EnqueuedMessage> persistentQueue = queues.get(clientId);
+            final Queue<EnqueuedMessage> persistentQueue = queues.remove(clientId);
             if (persistentQueue != null) {
                 Session rehydrated = new Session(clientId, false, persistentQueue);
                 pool.put(clientId, rehydrated);
             }
         }
+        if (!queues.isEmpty()) {
+            // This indicates a bug...
+            LOG.error("Recreating sessions left {} unused queues.", queues.size());
+        }
     }
 
     SessionCreationResult createOrReopenSession(MqttConnectMessage msg, String clientId, String username) {
         SessionCreationResult postConnectAction;
-        final Session newSession = createNewSession(msg, clientId);
-        final Session oldSession = pool.get(clientId);
+        //final Session newSession = createNewSession(msg, clientId);
+        final Session oldSession = retrieve(clientId);
         if (oldSession == null) {
-            // case 1
+            // case 1 no old session.
+            final Session newSession = createNewSession(msg, clientId);
             postConnectAction = new SessionCreationResult(newSession, CreationModeEnum.CREATED_CLEAN_NEW, false);
 
             // publish the session
-            final Session previous = pool.putIfAbsent(clientId, newSession);
-            final boolean success = previous == null;
-
-            if (success) {
-                LOG.trace("case 1, not existing session with CId {}", clientId);
-            } else {
-                postConnectAction = reopenExistingSession(msg, clientId, previous, newSession, username);
+            final Session previous = pool.put(clientId, newSession);
+            if (previous != null) {
+                LOG.error("Another Thread added a Session for our clientId {}, this is a bug!", clientId);
             }
+
+            LOG.trace("case 1, not existing session with CId {}", clientId);
         } else {
-            postConnectAction = reopenExistingSession(msg, clientId, oldSession, newSession, username);
+            postConnectAction = reopenExistingSession(msg, clientId, oldSession, username);
         }
         return postConnectAction;
     }
 
     private SessionCreationResult reopenExistingSession(MqttConnectMessage msg, String clientId,
-                                                        Session oldSession, Session newSession, String username) {
+                                                        Session oldSession, String username) {
         final boolean newIsClean = msg.variableHeader().isCleanSession();
         final SessionCreationResult creationResult;
-        if (oldSession.disconnected()) {
-            if (newIsClean) {
-                boolean result = oldSession.assignState(SessionStatus.DISCONNECTED, SessionStatus.CONNECTING);
-                if (!result) {
-                    throw new SessionCorruptedException("old session was already changed state");
-                }
-
-                // case 2
-                // publish new session
-                dropQueuesForClient(clientId);
-                unsubscribe(oldSession);
-                copySessionConfig(msg, oldSession);
-
-                LOG.trace("case 2, oldSession with same CId {} disconnected", clientId);
-                creationResult = new SessionCreationResult(oldSession, CreationModeEnum.CREATED_CLEAN_NEW, true);
-            } else {
-                final boolean connecting = oldSession.assignState(SessionStatus.DISCONNECTED, SessionStatus.CONNECTING);
-                if (!connecting) {
-                    throw new SessionCorruptedException("old session moved in connected state by other thread");
-                }
-                // case 3
-                reactivateSubscriptions(oldSession, username);
-
-                LOG.trace("case 3, oldSession with same CId {} disconnected", clientId);
-                creationResult = new SessionCreationResult(oldSession, CreationModeEnum.REOPEN_EXISTING, true);
-            }
-        } else {
-            // case 4
-            LOG.trace("case 4, oldSession with same CId {} still connected, force to close", clientId);
+        if (!oldSession.disconnected()) {
             oldSession.closeImmediately();
-            //remove(clientId);
-            creationResult = new SessionCreationResult(newSession, CreationModeEnum.DROP_EXISTING, true);
+            // TODO: Add a mechanism to avoid the old connection from influencing the session from this point on.
+            // Since the session has a link to the connection, check that?
         }
 
-        if (creationResult.mode == CreationModeEnum.DROP_EXISTING) {
-            LOG.debug("Drop session of already connected client with same id");
-            if (!pool.replace(clientId, oldSession, newSession)) {
-                //the other client was disconnecting and removed it's own session
-                pool.put(clientId, newSession);
+
+        if (newIsClean) {
+            boolean result = oldSession.assignState(SessionStatus.DISCONNECTED, SessionStatus.DESTROYED);
+            if (!result) {
+                throw new SessionCorruptedException("old session has already changed state");
             }
+
+            // case 2
+            // publish new session
+            unsubscribe(oldSession);
+            remove(clientId);
+            final Session newSession = createNewSession(msg, clientId);
+            pool.put(clientId, newSession);
+
+            LOG.trace("case 2, oldSession with same CId {} disconnected", clientId);
+            creationResult = new SessionCreationResult(newSession, CreationModeEnum.CREATED_CLEAN_NEW, true);
         } else {
-            LOG.debug("Replace session of client with same id");
-            if (!pool.replace(clientId, oldSession, oldSession)) {
-                throw new SessionCorruptedException("old session was already removed");
+            final boolean connecting = oldSession.assignState(SessionStatus.DISCONNECTED, SessionStatus.CONNECTING);
+            if (!connecting) {
+                throw new SessionCorruptedException("old session moved in connected state by other thread");
             }
+            // case 3
+            copySessionConfig(msg, oldSession);
+            reactivateSubscriptions(oldSession, username);
+
+            LOG.trace("case 3, oldSession with same CId {} disconnected", clientId);
+            creationResult = new SessionCreationResult(oldSession, CreationModeEnum.REOPEN_EXISTING, true);
         }
 
         // case not covered new session is clean true/false and old session not in CONNECTED/DISCONNECTED
@@ -243,14 +228,13 @@ public class SessionRegistry {
 
     private Session createNewSession(MqttConnectMessage msg, String clientId) {
         final boolean clean = msg.variableHeader().isCleanSession();
-        final Queue<SessionRegistry.EnqueuedMessage> sessionQueue =
-                    queues.computeIfAbsent(clientId, (String cli) -> queueRepository.createQueue(cli, clean));
         final Session newSession;
+        final Queue<EnqueuedMessage> queue = queueRepository.createQueue(clientId, clean);
         if (msg.variableHeader().isWillFlag()) {
             final Session.Will will = createWill(msg);
-            newSession = new Session(clientId, clean, will, sessionQueue);
+            newSession = new Session(clientId, clean, will, queue);
         } else {
-            newSession = new Session(clientId, clean, sessionQueue);
+            newSession = new Session(clientId, clean, queue);
         }
 
         newSession.markConnecting();
@@ -280,12 +264,11 @@ public class SessionRegistry {
         return pool.get(clientID);
     }
 
-    public void remove(Session session) {
-        pool.remove(session.getClientID(), session);
-    }
-
-    private void dropQueuesForClient(String clientId) {
-        queues.remove(clientId);
+    void remove(String clientID) {
+        final Session old = pool.remove(clientID);
+        if (old != null) {
+            old.cleanUp();
+        }
     }
 
     Collection<ClientDescriptor> listConnectedClients() {

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -170,8 +170,6 @@ public class SessionRegistry {
         final SessionCreationResult creationResult;
         if (!oldSession.disconnected()) {
             oldSession.closeImmediately();
-            // TODO: Add a mechanism to avoid the old connection from influencing the session from this point on.
-            // Since the session has a link to the connection, check that?
         }
 
 

--- a/broker/src/main/java/io/moquette/persistence/H2QueueRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/H2QueueRepository.java
@@ -41,6 +41,11 @@ public class H2QueueRepository implements IQueueRepository {
     }
 
     @Override
+    public void removeQueue(String cli) {
+        H2PersistentQueue.dropQueue(mvStore, cli);
+    }
+
+    @Override
     public Map<String, Queue<EnqueuedMessage>> listAllQueues() {
         Map<String, Queue<EnqueuedMessage>> result = new HashMap<>();
         mvStore.getMapNames().stream()


### PR DESCRIPTION
See discussion in #608.

- Add a remove method to IQueueRepository, so queues can actually be removed when no longer needed.
- Make the Session the only place where the Queue lives outside of the repository by removing the queues field from SessionRegistry.
- Tie a Queue and a Session in a 1-to-1 way.
- Remove and clean the old Session and Queue before creating a new pair for a ClientId.
- Clean Session and Queue when they are no longer needed.
- In case a new Connection takes over a Session from an existing, connected connection, ensure the old session can not influence the Session any more after the Session was taken over.

