### PR TITLE
Fix reference's leak in fast publish of Qos0 and slow subscriber use case

### DIFF
--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -415,9 +415,8 @@ final class MQTTConnection {
         switch (qos) {
             case AT_MOST_ONCE:
                 return postOffice.receivedPublishQos0(topic, username, clientId, msg);
-            case AT_LEAST_ONCE: {
+            case AT_LEAST_ONCE:
                 return postOffice.receivedPublishQos1(this, topic, username, messageID, msg);
-            }
             case EXACTLY_ONCE: {
                 final CompletableFuture<PostOffice.RouteResult> firstStepFuture = postOffice.routeCommand(clientId, () -> {
                     bindedSession.receivedPublishQos2(messageID, msg);

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -318,7 +318,7 @@ class PostOffice {
             }
 
             interceptor.notifyTopicPublished(msg, clientID, username);
-            // ? ReferenceCountUtil.release(msg);
+            ReferenceCountUtil.release(msg);
         });
     }
 

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -318,6 +318,7 @@ class PostOffice {
             }
 
             interceptor.notifyTopicPublished(msg, clientID, username);
+            // ? ReferenceCountUtil.release(msg);
         });
     }
 

--- a/broker/src/test/java/io/moquette/integration/AbstractIntegration.java
+++ b/broker/src/test/java/io/moquette/integration/AbstractIntegration.java
@@ -1,0 +1,22 @@
+package io.moquette.integration;
+
+import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
+import org.eclipse.paho.client.mqttv3.MqttClientPersistence;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+abstract class AbstractIntegration {
+
+    String dbPath;
+    MqttAsyncClient publisher;
+
+    protected MqttAsyncClient createClient(String clientName, Path tempFolder) throws IOException, MqttException {
+        final String dataPath = IntegrationUtils.newFolder(tempFolder, clientName).getAbsolutePath();
+        MqttClientPersistence clientDataStore = new MqttDefaultFilePersistence(dataPath);
+        return new MqttAsyncClient("tcp://localhost:1883", clientName, clientDataStore);
+    }
+}

--- a/broker/src/test/java/io/moquette/integration/FastPublisherSlowSubscriberTest.java
+++ b/broker/src/test/java/io/moquette/integration/FastPublisherSlowSubscriberTest.java
@@ -79,7 +79,7 @@ public class FastPublisherSlowSubscriberTest extends AbstractIntegration {
             }
         }, 1000, 100, TimeUnit.MILLISECONDS);
 
-        slowSubscribe();
+        slowSubscribe(1);
 
         stopTest.await();
     }
@@ -104,13 +104,13 @@ public class FastPublisherSlowSubscriberTest extends AbstractIntegration {
         };
         publisherTask.start();
 
-        slowSubscribe();
+        slowSubscribe(2);
 
         publisherTask.join();
     }
 
-    private void slowSubscribe() throws MqttException {
-        subscriber.subscribe("/temperature", 1, new IMqttMessageListener() {
+    private void slowSubscribe(int qos) throws MqttException {
+        subscriber.subscribe("/temperature", qos, new IMqttMessageListener() {
             @Override
             public void messageArrived(String topic, MqttMessage message) throws Exception {
                 Thread.currentThread().sleep(500);

--- a/broker/src/test/java/io/moquette/integration/FastPublisherSlowSubscriberTest.java
+++ b/broker/src/test/java/io/moquette/integration/FastPublisherSlowSubscriberTest.java
@@ -1,0 +1,119 @@
+package io.moquette.integration;
+
+import io.moquette.broker.Server;
+import io.moquette.broker.config.MemoryConfig;
+import jdk.nashorn.internal.ir.annotations.Ignore;
+import org.eclipse.paho.client.mqttv3.IMqttMessageListener;
+import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.security.SecureRandom;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Fast publisher sending to slow ACK subscriber which alternates between clean session true/false
+ * Inspired by issue https://github.com/moquette-io/moquette/issues/608.
+ * */
+public class FastPublisherSlowSubscriberTest extends AbstractIntegration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FastPublisherSlowSubscriberTest.class);
+
+    @TempDir
+    Path tempFolder;
+    private String dbPath;
+    private Server broker;
+    private MqttAsyncClient subscriber;
+    private ScheduledExecutorService publisherPool;
+
+//    protected void startServer(String dbPath) throws IOException {
+//        broker = new Server();
+//        final Properties configProps = IntegrationUtils.prepareTestProperties(dbPath);
+//        broker.startServer(new MemoryConfig(configProps));
+//    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+//        dbPath = IntegrationUtils.tempH2Path(tempFolder);
+//        startServer(dbPath);
+
+        publisher = createClient("publisher", tempFolder);
+        publisher.connect().waitForCompletion(1_000);
+
+        subscriber = createClient("slow_subscriber", tempFolder);
+        subscriber.connect().waitForCompletion(1_000);
+        publisherPool = Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors() * 2);
+    }
+
+    @Ignore
+    @Test
+    public void executeUseCase() throws MqttException, InterruptedException {
+        final SecureRandom random = new SecureRandom();
+        CountDownLatch stopTest = new CountDownLatch(1);
+        publisherPool.scheduleAtFixedRate(new Runnable() {
+            @Override
+            public void run() {
+                final int delta = random.nextInt(10);
+                int temp = 15 + delta;
+                try {
+                    publisher.publish("/temperature", (temp + "°C").getBytes(UTF_8), 0, false);
+                } catch (MqttException e) {
+                    e.printStackTrace();
+                    stopTest.countDown();
+                    throw new RuntimeException(e);
+                }
+            }
+        }, 1000, 100, TimeUnit.MILLISECONDS);
+
+//        final Thread publisherTask = new Thread() {
+//            @Override
+//            public void run() {
+//                while(!isInterrupted()) {
+//                    final int delta = random.nextInt(10);
+//                    int temp = 15 + delta;
+//                    try {
+//                        publisher.publish("/temperature", (temp + "°C").getBytes(UTF_8), 0, false);
+//                    } catch (MqttException e) {
+//                        e.printStackTrace();
+//                        interrupt();
+//                    }
+//                }
+//            }
+//        };
+//        publisherTask.start();
+
+        subscriber.subscribe("/temperature", 1, new IMqttMessageListener() {
+            @Override
+            public void messageArrived(String topic, MqttMessage message) throws Exception {
+                Thread.currentThread().sleep(500);
+                final String temp = new String(message.getPayload(), UTF_8);
+                LOG.info("Received temp: {}", temp);
+            }
+        });
+
+        stopTest.await();
+//        publisherTask.join();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        IntegrationUtils.disconnectClient(this.publisher);
+        IntegrationUtils.disconnectClient(this.subscriber);
+
+//        this.broker.stopServer();
+    }
+}


### PR DESCRIPTION
## Release notes

Fix a message leak in handling PUB qos0 message.


## What does this PR do?

Handling PUB message is a multistep process, it regards forwarding the payload/message to appropriate target sessions event queues and notify the registered interceptors.
When the front processing of the message is terminated, i has to free appropriately the message, decrementing the reference count. This PR fixes a missed decrement.

## Why is it important/What is the impact to the user?

It fixes a bug that happens when a fast puglisher send QoS0 messagges to a slow subscriber.

## How to test this PR locally

To prove run  the only test method in `FastPublisherSlowSubscriberTest.asFastAsItCan`.
