### PR TITLE
Fix 653 retained messages publishing

### DIFF
--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -535,17 +535,30 @@ final class MQTTConnection {
 
     // TODO move this method in Session
     void sendPublishQos0(Topic topic, MqttQoS qos, ByteBuf payload, boolean retained) {
-        MqttPublishMessage publishMsg = createPublishMessage(topic.toString(), qos, payload, retained);
+        MqttPublishMessage publishMsg = createPublishMessage(topic.toString(), qos, payload, 0, retained);
         sendPublish(publishMsg);
     }
 
-    static MqttPublishMessage createPublishMessage(String topic, MqttQoS qos, ByteBuf message,
-                                                   boolean retained) {
-        return createPublishMessage(topic, qos, message, 0, retained);
+    static MqttPublishMessage createRetainedPublishMessage(String topic, MqttQoS qos, ByteBuf message) {
+        return createPublishMessage(topic, qos, message, 0, true);
     }
 
-    static MqttPublishMessage createPublishMessage(String topic, MqttQoS qos, ByteBuf message,
-                                                   int messageId, boolean retained) {
+    static MqttPublishMessage createNonRetainedPublishMessage(String topic, MqttQoS qos, ByteBuf message) {
+        return createPublishMessage(topic, qos, message, 0, false);
+    }
+
+    static MqttPublishMessage createRetainedPublishMessage(String topic, MqttQoS qos, ByteBuf message,
+                                                           int messageId) {
+        return createPublishMessage(topic, qos, message, messageId, true);
+    }
+
+    static MqttPublishMessage createNonRetainedPublishMessage(String topic, MqttQoS qos, ByteBuf message,
+                                                              int messageId) {
+        return createPublishMessage(topic, qos, message, messageId, false);
+    }
+
+    private static MqttPublishMessage createPublishMessage(String topic, MqttQoS qos, ByteBuf message,
+                                                           int messageId, boolean retained) {
         MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.PUBLISH, false, qos, retained, 0);
         MqttPublishVariableHeader varHeader = new MqttPublishVariableHeader(topic, messageId);
         return new MqttPublishMessage(fixedHeader, varHeader, message);

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -527,41 +527,26 @@ final class MQTTConnection {
         return NettyUtils.userName(channel);
     }
 
-    public void sendPublishRetainedQos0(Topic topic, MqttQoS qos, ByteBuf payload) {
-        MqttPublishMessage publishMsg = retainedPublish(topic.toString(), qos, payload);
-        sendPublish(publishMsg);
-    }
-
-    public void sendPublishRetainedWithPacketId(Topic topic, MqttQoS qos, ByteBuf payload) {
+    public void sendPublishWithPacketId(Topic topic, MqttQoS qos, ByteBuf payload, boolean retained) {
         final int packetId = nextPacketId();
-        MqttPublishMessage publishMsg = retainedPublishWithMessageId(topic.toString(), qos, payload, packetId);
+        MqttPublishMessage publishMsg = createPublishMessage(topic.toString(), qos, payload, packetId, retained);
         sendPublish(publishMsg);
-    }
-
-    private static MqttPublishMessage retainedPublish(String topic, MqttQoS qos, ByteBuf message) {
-        return retainedPublishWithMessageId(topic, qos, message, 0);
-    }
-
-    private static MqttPublishMessage retainedPublishWithMessageId(String topic, MqttQoS qos, ByteBuf message,
-                                                                   int messageId) {
-        MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.PUBLISH, false, qos, true, 0);
-        MqttPublishVariableHeader varHeader = new MqttPublishVariableHeader(topic, messageId);
-        return new MqttPublishMessage(fixedHeader, varHeader, message);
     }
 
     // TODO move this method in Session
-    void sendPublishNotRetainedQos0(Topic topic, MqttQoS qos, ByteBuf payload) {
-        MqttPublishMessage publishMsg = notRetainedPublish(topic.toString(), qos, payload);
+    void sendPublishQos0(Topic topic, MqttQoS qos, ByteBuf payload, boolean retained) {
+        MqttPublishMessage publishMsg = createPublishMessage(topic.toString(), qos, payload, retained);
         sendPublish(publishMsg);
     }
 
-    static MqttPublishMessage notRetainedPublish(String topic, MqttQoS qos, ByteBuf message) {
-        return notRetainedPublishWithMessageId(topic, qos, message, 0);
+    static MqttPublishMessage createPublishMessage(String topic, MqttQoS qos, ByteBuf message,
+                                                   boolean retained) {
+        return createPublishMessage(topic, qos, message, 0, retained);
     }
 
-    static MqttPublishMessage notRetainedPublishWithMessageId(String topic, MqttQoS qos, ByteBuf message,
-                                                              int messageId) {
-        MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.PUBLISH, false, qos, false, 0);
+    static MqttPublishMessage createPublishMessage(String topic, MqttQoS qos, ByteBuf message,
+                                                   int messageId, boolean retained) {
+        MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.PUBLISH, false, qos, retained, 0);
         MqttPublishVariableHeader varHeader = new MqttPublishVariableHeader(topic, messageId);
         return new MqttPublishMessage(fixedHeader, varHeader, message);
     }

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -552,7 +552,7 @@ final class MQTTConnection {
         return createPublishMessage(topic, qos, message, messageId, true);
     }
 
-    static MqttPublishMessage createNonRetainedPublishMessage(String topic, MqttQoS qos, ByteBuf message,
+    static MqttPublishMessage createNotRetainedPublishMessage(String topic, MqttQoS qos, ByteBuf message,
                                                               int messageId) {
         return createPublishMessage(topic, qos, message, messageId, false);
     }

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -475,7 +475,7 @@ class PostOffice {
         if (isSessionPresent) {
             LOG.debug("Sending PUBLISH message to active subscriber CId: {}, topicFilter: {}, qos: {}",
                       sub.getClientId(), sub.getTopicFilter(), qos);
-            targetSession.sendNonRetainedPublishOnSessionAtQos(topic, qos, payload);
+            targetSession.sendNotRetainedPublishOnSessionAtQos(topic, qos, payload);
         } else {
             // If we are, the subscriber disconnected after the subscriptions tree selected that session as a
             // destination.

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -249,7 +249,7 @@ class PostOffice {
                 MqttQoS qos = lowerQosToTheSubscriptionDesired(subscription, retainedQos);
 
                 final ByteBuf payloadBuf = Unpooled.wrappedBuffer(retainedMsg.getPayload());
-                targetSession.sendPublishOnSessionAtQos(retainedMsg.getTopic(), qos, payloadBuf, true);
+                targetSession.sendRetainedPublishOnSessionAtQos(retainedMsg.getTopic(), qos, payloadBuf);
                 // We made the buffer, we must release it.
                 payloadBuf.release();
             }
@@ -475,7 +475,7 @@ class PostOffice {
         if (isSessionPresent) {
             LOG.debug("Sending PUBLISH message to active subscriber CId: {}, topicFilter: {}, qos: {}",
                       sub.getClientId(), sub.getTopicFilter(), qos);
-            targetSession.sendPublishOnSessionAtQos(topic, qos, payload, false);
+            targetSession.sendNonRetainedPublishOnSessionAtQos(topic, qos, payload);
         } else {
             // If we are, the subscriber disconnected after the subscriptions tree selected that session as a
             // destination.

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -249,7 +249,7 @@ class PostOffice {
                 MqttQoS qos = lowerQosToTheSubscriptionDesired(subscription, retainedQos);
 
                 final ByteBuf payloadBuf = Unpooled.wrappedBuffer(retainedMsg.getPayload());
-                targetSession.sendRetainedPublishOnSessionAtQos(retainedMsg.getTopic(), qos, payloadBuf);
+                targetSession.sendPublishOnSessionAtQos(retainedMsg.getTopic(), qos, payloadBuf, true);
                 // We made the buffer, we must release it.
                 payloadBuf.release();
             }
@@ -475,7 +475,7 @@ class PostOffice {
         if (isSessionPresent) {
             LOG.debug("Sending PUBLISH message to active subscriber CId: {}, topicFilter: {}, qos: {}",
                       sub.getClientId(), sub.getTopicFilter(), qos);
-            targetSession.sendPublishOnSessionAtQos(topic, qos, payload);
+            targetSession.sendPublishOnSessionAtQos(topic, qos, payload, false);
         } else {
             // If we are, the subscriber disconnected after the subscriptions tree selected that session as a
             // destination.

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -229,7 +229,15 @@ class Session {
 //                m_interceptor.notifyMessageAcknowledged(interceptAckMsg);
     }
 
-    public void sendPublishOnSessionAtQos(Topic topic, MqttQoS qos, ByteBuf payload, boolean retained) {
+    public void sendRetainedPublishOnSessionAtQos(Topic topic, MqttQoS qos, ByteBuf payload) {
+        sendPublishOnSessionAtQos(topic, qos, payload, true);
+    }
+
+    public void sendNonRetainedPublishOnSessionAtQos(Topic topic, MqttQoS qos, ByteBuf payload) {
+        sendPublishOnSessionAtQos(topic, qos, payload, true);
+    }
+
+    private void sendPublishOnSessionAtQos(Topic topic, MqttQoS qos, ByteBuf payload, boolean retained) {
         switch (qos) {
             case AT_MOST_ONCE:
                 if (connected()) {
@@ -268,8 +276,8 @@ class Session {
             }
             inflightTimeouts.add(new InFlightPacket(packetId, FLIGHT_BEFORE_RESEND_MS));
 
-            MqttPublishMessage publishMsg = MQTTConnection.createPublishMessage(topic.toString(), qos,
-                                                                                payload, packetId, false);
+            MqttPublishMessage publishMsg = MQTTConnection.createNonRetainedPublishMessage(topic.toString(), qos,
+                                                                                           payload, packetId);
             localMqttConnectionRef.sendPublish(publishMsg);
             LOG.debug("Write direct to the peer, inflight slots: {}", inflightSlots.get());
             if (inflightSlots.get() == 0) {
@@ -302,8 +310,8 @@ class Session {
             }
             inflightTimeouts.add(new InFlightPacket(packetId, FLIGHT_BEFORE_RESEND_MS));
 
-            MqttPublishMessage publishMsg = MQTTConnection.createPublishMessage(topic.toString(), qos,
-                                                                                payload, packetId, false);
+            MqttPublishMessage publishMsg = MQTTConnection.createNonRetainedPublishMessage(topic.toString(), qos,
+                                                                                           payload, packetId);
             localMqttConnectionRef.sendPublish(publishMsg);
 
             drainQueueToConnection();
@@ -413,10 +421,10 @@ class Session {
             }
             inflightTimeouts.add(new InFlightPacket(sendPacketId, FLIGHT_BEFORE_RESEND_MS));
             final SessionRegistry.PublishedMessage msgPub = (SessionRegistry.PublishedMessage) msg;
-            MqttPublishMessage publishMsg = MQTTConnection.createPublishMessage(
+            MqttPublishMessage publishMsg = MQTTConnection.createNonRetainedPublishMessage(
                 msgPub.topic.toString(),
                 msgPub.publishingQos,
-                msgPub.payload, sendPacketId, false);
+                msgPub.payload, sendPacketId);
             mqttConnection.sendPublish(publishMsg);
 
             // we fetched msg from a map, but the release is cancelled out by the above retain

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -234,7 +234,7 @@ class Session {
     }
 
     public void sendNonRetainedPublishOnSessionAtQos(Topic topic, MqttQoS qos, ByteBuf payload) {
-        sendPublishOnSessionAtQos(topic, qos, payload, true);
+        sendPublishOnSessionAtQos(topic, qos, payload, false);
     }
 
     private void sendPublishOnSessionAtQos(Topic topic, MqttQoS qos, ByteBuf payload, boolean retained) {

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -229,25 +229,25 @@ class Session {
 //                m_interceptor.notifyMessageAcknowledged(interceptAckMsg);
     }
 
-    public void sendPublishOnSessionAtQos(Topic topic, MqttQoS qos, ByteBuf payload) {
+    public void sendPublishOnSessionAtQos(Topic topic, MqttQoS qos, ByteBuf payload, boolean retained) {
         switch (qos) {
             case AT_MOST_ONCE:
                 if (connected()) {
-                    mqttConnection.sendPublishNotRetainedQos0(topic, qos, payload);
+                    mqttConnection.sendPublishQos0(topic, qos, payload, retained);
                 }
                 break;
             case AT_LEAST_ONCE:
-                sendPublishQos1(topic, qos, payload);
+                sendPublishQos1(topic, qos, payload, retained);
                 break;
             case EXACTLY_ONCE:
-                sendPublishQos2(topic, qos, payload);
+                sendPublishQos2(topic, qos, payload, retained);
                 break;
             case FAILURE:
                 LOG.error("Not admissible");
         }
     }
 
-    private void sendPublishQos1(Topic topic, MqttQoS qos, ByteBuf payload) {
+    private void sendPublishQos1(Topic topic, MqttQoS qos, ByteBuf payload, boolean retained) {
         if (!connected() && isClean()) {
             //pushing messages to disconnected not clean session
             return;
@@ -260,7 +260,7 @@ class Session {
 
             // Adding to a map, retain.
             payload.retain();
-            EnqueuedMessage old = inflightWindow.put(packetId, new PublishedMessage(topic, qos, payload));
+            EnqueuedMessage old = inflightWindow.put(packetId, new PublishedMessage(topic, qos, payload, retained));
             // If there already was something, release it.
             if (old != null) {
                 old.release();
@@ -268,8 +268,8 @@ class Session {
             }
             inflightTimeouts.add(new InFlightPacket(packetId, FLIGHT_BEFORE_RESEND_MS));
 
-            MqttPublishMessage publishMsg = MQTTConnection.notRetainedPublishWithMessageId(topic.toString(), qos,
-                                                                                           payload, packetId);
+            MqttPublishMessage publishMsg = MQTTConnection.createPublishMessage(topic.toString(), qos,
+                                                                                payload, packetId, false);
             localMqttConnectionRef.sendPublish(publishMsg);
             LOG.debug("Write direct to the peer, inflight slots: {}", inflightSlots.get());
             if (inflightSlots.get() == 0) {
@@ -278,7 +278,7 @@ class Session {
 
             // TODO drainQueueToConnection();?
         } else {
-            final SessionRegistry.PublishedMessage msg = new SessionRegistry.PublishedMessage(topic, qos, payload);
+            final SessionRegistry.PublishedMessage msg = new SessionRegistry.PublishedMessage(topic, qos, payload, retained);
             // Adding to a queue, retain.
             msg.retain();
             sessionQueue.add(msg);
@@ -286,7 +286,7 @@ class Session {
         }
     }
 
-    private void sendPublishQos2(Topic topic, MqttQoS qos, ByteBuf payload) {
+    private void sendPublishQos2(Topic topic, MqttQoS qos, ByteBuf payload, boolean retained) {
         final MQTTConnection localMqttConnectionRef = mqttConnection;
         if (canSkipQueue(localMqttConnectionRef)) {
             inflightSlots.decrementAndGet();
@@ -294,7 +294,7 @@ class Session {
 
             // Retain before adding to map
             payload.retain();
-            EnqueuedMessage old = inflightWindow.put(packetId, new SessionRegistry.PublishedMessage(topic, qos, payload));
+            EnqueuedMessage old = inflightWindow.put(packetId, new SessionRegistry.PublishedMessage(topic, qos, payload, retained));
             // If there already was something, release it.
             if (old != null) {
                 old.release();
@@ -302,13 +302,13 @@ class Session {
             }
             inflightTimeouts.add(new InFlightPacket(packetId, FLIGHT_BEFORE_RESEND_MS));
 
-            MqttPublishMessage publishMsg = MQTTConnection.notRetainedPublishWithMessageId(topic.toString(), qos,
-                                                                                           payload, packetId);
+            MqttPublishMessage publishMsg = MQTTConnection.createPublishMessage(topic.toString(), qos,
+                                                                                payload, packetId, false);
             localMqttConnectionRef.sendPublish(publishMsg);
 
             drainQueueToConnection();
         } else {
-            final SessionRegistry.PublishedMessage msg = new SessionRegistry.PublishedMessage(topic, qos, payload);
+            final SessionRegistry.PublishedMessage msg = new SessionRegistry.PublishedMessage(topic, qos, payload, retained);
             // Adding to a queue, retain.
             msg.retain();
             sessionQueue.add(msg);
@@ -413,10 +413,10 @@ class Session {
             }
             inflightTimeouts.add(new InFlightPacket(sendPacketId, FLIGHT_BEFORE_RESEND_MS));
             final SessionRegistry.PublishedMessage msgPub = (SessionRegistry.PublishedMessage) msg;
-            MqttPublishMessage publishMsg = MQTTConnection.notRetainedPublishWithMessageId(
+            MqttPublishMessage publishMsg = MQTTConnection.createPublishMessage(
                 msgPub.topic.toString(),
                 msgPub.publishingQos,
-                msgPub.payload, sendPacketId);
+                msgPub.payload, sendPacketId, false);
             mqttConnection.sendPublish(publishMsg);
 
             // we fetched msg from a map, but the release is cancelled out by the above retain
@@ -430,15 +430,6 @@ class Session {
     public void sendQueuedMessagesWhileOffline() {
         LOG.trace("Republishing all saved messages for session {}", this);
         drainQueueToConnection();
-    }
-
-    void sendRetainedPublishOnSessionAtQos(Topic topic, MqttQoS qos, ByteBuf payload) {
-        if (qos != MqttQoS.AT_MOST_ONCE) {
-            // QoS 1 or 2
-            mqttConnection.sendPublishRetainedWithPacketId(topic, qos, payload);
-        } else {
-            mqttConnection.sendPublishRetainedQos0(topic, qos, payload);
-        }
     }
 
     public void receivedPublishQos2(int messageID, MqttPublishMessage msg) {

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -233,7 +233,7 @@ class Session {
         sendPublishOnSessionAtQos(topic, qos, payload, true);
     }
 
-    public void sendNonRetainedPublishOnSessionAtQos(Topic topic, MqttQoS qos, ByteBuf payload) {
+    public void sendNotRetainedPublishOnSessionAtQos(Topic topic, MqttQoS qos, ByteBuf payload) {
         sendPublishOnSessionAtQos(topic, qos, payload, false);
     }
 
@@ -276,7 +276,7 @@ class Session {
             }
             inflightTimeouts.add(new InFlightPacket(packetId, FLIGHT_BEFORE_RESEND_MS));
 
-            MqttPublishMessage publishMsg = MQTTConnection.createNonRetainedPublishMessage(topic.toString(), qos,
+            MqttPublishMessage publishMsg = MQTTConnection.createNotRetainedPublishMessage(topic.toString(), qos,
                                                                                            payload, packetId);
             localMqttConnectionRef.sendPublish(publishMsg);
             LOG.debug("Write direct to the peer, inflight slots: {}", inflightSlots.get());
@@ -310,7 +310,7 @@ class Session {
             }
             inflightTimeouts.add(new InFlightPacket(packetId, FLIGHT_BEFORE_RESEND_MS));
 
-            MqttPublishMessage publishMsg = MQTTConnection.createNonRetainedPublishMessage(topic.toString(), qos,
+            MqttPublishMessage publishMsg = MQTTConnection.createNotRetainedPublishMessage(topic.toString(), qos,
                                                                                            payload, packetId);
             localMqttConnectionRef.sendPublish(publishMsg);
 
@@ -421,7 +421,7 @@ class Session {
             }
             inflightTimeouts.add(new InFlightPacket(sendPacketId, FLIGHT_BEFORE_RESEND_MS));
             final SessionRegistry.PublishedMessage msgPub = (SessionRegistry.PublishedMessage) msg;
-            MqttPublishMessage publishMsg = MQTTConnection.createNonRetainedPublishMessage(
+            MqttPublishMessage publishMsg = MQTTConnection.createNotRetainedPublishMessage(
                 msgPub.topic.toString(),
                 msgPub.publishingQos,
                 msgPub.payload, sendPacketId);

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -57,11 +57,13 @@ public class SessionRegistry {
         final Topic topic;
         final MqttQoS publishingQos;
         final ByteBuf payload;
+        final boolean retained;
 
-        public PublishedMessage(Topic topic, MqttQoS publishingQos, ByteBuf payload) {
+        public PublishedMessage(Topic topic, MqttQoS publishingQos, ByteBuf payload, boolean retained) {
             this.topic = topic;
             this.publishingQos = publishingQos;
             this.payload = payload;
+            this.retained = false;
         }
 
         public Topic getTopic() {

--- a/broker/src/main/java/io/moquette/persistence/EnqueuedMessageValueType.java
+++ b/broker/src/main/java/io/moquette/persistence/EnqueuedMessageValueType.java
@@ -82,7 +82,7 @@ public final class EnqueuedMessageValueType implements org.h2.mvstore.type.DataT
             final MqttQoS qos = MqttQoS.valueOf(buff.get());
             final String topicStr = topicDataType.read(buff);
             final ByteBuf payload = payloadDataType.read(buff);
-            return new SessionRegistry.PublishedMessage(Topic.asTopic(topicStr), qos, payload);
+            return new SessionRegistry.PublishedMessage(Topic.asTopic(topicStr), qos, payload, false);
         } else {
             throw new IllegalArgumentException("Can't recognize record of type: " + messageType);
         }

--- a/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
@@ -154,7 +154,7 @@ public class SessionRegistryTest {
 
         final ByteBuf payload = Unpooled.wrappedBuffer("Hello World!".getBytes(StandardCharsets.UTF_8));
         SessionRegistry.PublishedMessage msg = new SessionRegistry.PublishedMessage(Topic.asTopic("/say"),
-            MqttQoS.AT_LEAST_ONCE, payload);
+            MqttQoS.AT_LEAST_ONCE, payload, false);
         try {
             // store a message in the MVStore
             final String mapName = "test_map";

--- a/broker/src/test/java/io/moquette/broker/SessionTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionTest.java
@@ -60,7 +60,7 @@ public class SessionTest {
 
     private void sendQoS1To(Session client, Topic destinationTopic, String message) {
         final ByteBuf payload = ByteBufUtil.writeUtf8(UnpooledByteBufAllocator.DEFAULT, message);
-        client.sendNonRetainedPublishOnSessionAtQos(destinationTopic, MqttQoS.AT_LEAST_ONCE, payload);
+        client.sendNotRetainedPublishOnSessionAtQos(destinationTopic, MqttQoS.AT_LEAST_ONCE, payload);
     }
 
     @Test

--- a/broker/src/test/java/io/moquette/broker/SessionTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionTest.java
@@ -49,7 +49,7 @@ public class SessionTest {
 
         // Verify
         assertTrue(queuedMessages.isEmpty(), "Messages should be drained");
-        
+
         // release the rest, to avoid leaking buffers
         for (int i = 2; i <= 11; i++) {
             client.pubAckReceived(i);
@@ -60,7 +60,7 @@ public class SessionTest {
 
     private void sendQoS1To(Session client, Topic destinationTopic, String message) {
         final ByteBuf payload = ByteBufUtil.writeUtf8(UnpooledByteBufAllocator.DEFAULT, message);
-        client.sendPublishOnSessionAtQos(destinationTopic, MqttQoS.AT_LEAST_ONCE, payload);
+        client.sendPublishOnSessionAtQos(destinationTopic, MqttQoS.AT_LEAST_ONCE, payload, false);
     }
 
     @Test

--- a/broker/src/test/java/io/moquette/broker/SessionTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionTest.java
@@ -60,7 +60,7 @@ public class SessionTest {
 
     private void sendQoS1To(Session client, Topic destinationTopic, String message) {
         final ByteBuf payload = ByteBufUtil.writeUtf8(UnpooledByteBufAllocator.DEFAULT, message);
-        client.sendPublishOnSessionAtQos(destinationTopic, MqttQoS.AT_LEAST_ONCE, payload, false);
+        client.sendNonRetainedPublishOnSessionAtQos(destinationTopic, MqttQoS.AT_LEAST_ONCE, payload);
     }
 
     @Test

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationRetainTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationRetainTest.java
@@ -126,7 +126,7 @@ public class ServerIntegrationRetainTest {
         clientPublisher.publish(topic, messageString.getBytes(UTF_8), qosPub, true);
         // Wait for the publish to finish
         Awaitility.await().until(() -> callbackPublisher.isMessageReceived());
-        callbackPublisher.getMessageImmediate();
+        validateRetainedFlagNotSet(callbackPublisher.getMessageImmediate());
 
         callbackSubscriber.reinit();
         clientSubscriber.subscribe(topic, qosSub);
@@ -148,7 +148,7 @@ public class ServerIntegrationRetainTest {
         clientPublisher.publish(topic, new byte[0], qosPub, true);
         // Wait for the publish to finish
         Awaitility.await().until(() -> callbackPublisher.isMessageReceived());
-        callbackPublisher.getMessageImmediate();
+        validateRetainedFlagNotSet(callbackPublisher.getMessageImmediate());
 
         callbackSubscriber.reinit();
         clientSubscriber.subscribe(topic, qosSub);
@@ -157,6 +157,10 @@ public class ServerIntegrationRetainTest {
         } catch (ConditionTimeoutException ex) {
             // This may be fine.
         }
+    }
+
+    private void validateRetainedFlagNotSet(MqttMessage message) {
+        Assertions.assertFalse(message.isRetained(), "Directly published version of messages should not have the retained flag set");
     }
 
     private void validateMustReceive(int qosPub, int qosSub) {

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationRetainTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationRetainTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 The original author or authors
+ * Copyright (c) 2012-2022 The original author or authors
  * ------------------------------------------------------
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -27,7 +27,6 @@ import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationRetainTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationRetainTest.java
@@ -41,8 +41,9 @@ import org.awaitility.core.ConditionTimeoutException;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -162,12 +163,12 @@ public class ServerIntegrationRetainTest {
     }
 
     private void validateRetainedFlagNotSet(MqttMessage message) {
-        Assertions.assertFalse(message.isRetained(), "Directly published version of messages should not have the retained flag set");
+        assertFalse(message.isRetained(), "Directly published version of messages should not have the retained flag set");
     }
 
     private void validateMustReceive(int qosPub, int qosSub) {
         final boolean messageReceived = callbackSubscriber.isMessageReceived();
-        Assertions.assertTrue(messageReceived, "Expected a message retained at QoS " + qosPub + ".");
+        assertTrue(messageReceived, "Expected a message retained at QoS " + qosPub + ".");
         MqttMessage message = callbackSubscriber.getMessageImmediate();
         String expectedMessage = createMessage(qosPub, qosSub);
         assertEquals(expectedMessage, message.toString());
@@ -177,7 +178,7 @@ public class ServerIntegrationRetainTest {
     private void validateMustNotReceive(int qosPub) {
         final boolean messageReceived = callbackSubscriber.isMessageReceived();
         MqttMessage message = callbackSubscriber.getMessageImmediate();
-        Assertions.assertFalse(messageReceived, "Received an unexpected message retained at QoS " + qosPub + ": " + message);
+        assertFalse(messageReceived, "Received an unexpected message retained at QoS " + qosPub + ": " + message);
     }
 
     static Stream<Arguments> notRetainedProvider() {

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationRetainTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationRetainTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.moquette.integration;
+
+import io.moquette.broker.Server;
+import io.moquette.broker.config.IConfig;
+import io.moquette.broker.config.MemoryConfig;
+import org.awaitility.Awaitility;
+import org.awaitility.Durations;
+import org.eclipse.paho.client.mqttv3.IMqttClient;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Properties;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import org.awaitility.core.ConditionTimeoutException;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class ServerIntegrationRetainTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ServerIntegrationRetainTest.class);
+
+    private static IConfig m_config;
+    private static Server m_server;
+
+    private IMqttClient clientSubscriber;
+    private IMqttClient clientPublisher;
+    private MessageCollector callbackPublisher;
+    private MessageCollector callbackSubscriber;
+
+    @TempDir
+    static Path tempFolder;
+
+    private static void startServer(String dbPath) throws IOException {
+        m_server = new Server();
+        final Properties configProps = IntegrationUtils.prepareTestProperties(dbPath);
+        m_config = new MemoryConfig(configProps);
+        m_server.startServer(m_config);
+    }
+
+    @BeforeAll
+    public static void beforeTests() throws IOException {
+        Awaitility.setDefaultTimeout(Durations.FIVE_SECONDS);
+        String dbPath = IntegrationUtils.tempH2Path(tempFolder);
+        startServer(dbPath);
+    }
+
+    @AfterAll
+    public static void afterTests() {
+        m_server.stopServer();
+        m_server = null;
+        m_config = null;
+    }
+
+    @BeforeEach
+    public void setUp() throws MqttException {
+        final MqttConnectOptions mqttConnectOptions = new MqttConnectOptions();
+        mqttConnectOptions.setCleanSession(true);
+
+        clientSubscriber = new MqttClient("tcp://localhost:1883", "Subscriber", new MemoryPersistence());
+        callbackSubscriber = new MessageCollector();
+        clientSubscriber.setCallback(callbackSubscriber);
+        clientSubscriber.connect(mqttConnectOptions);
+
+        clientPublisher = new MqttClient("tcp://localhost:1883", "Publisher", new MemoryPersistence());
+        callbackPublisher = new MessageCollector();
+        clientPublisher.setCallback(callbackPublisher);
+        clientPublisher.connect(mqttConnectOptions);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (clientPublisher.isConnected()) {
+            clientPublisher.disconnect();
+        }
+
+        if (clientSubscriber.isConnected()) {
+            clientSubscriber.disconnect();
+        }
+    }
+
+    public void checkRetained(int qosPub, int qosSub, boolean shouldReceive) throws Exception {
+        final String topic = "/topic" + qosPub + qosSub;
+        final String messageString = "Hello world MQTT " + qosPub + " " + qosSub;
+        clientPublisher.subscribe(topic);
+        clientPublisher.publish(topic, messageString.getBytes(UTF_8), qosPub, true);
+        // Wait for the publish to finish
+        Awaitility.await().until(() -> callbackPublisher.isMessageReceived());
+        callbackPublisher.getMessageImmediate();
+
+        clientSubscriber.subscribe(topic, qosSub);
+        try {
+            Awaitility.await().until(() -> callbackSubscriber.isMessageReceived());
+        } catch (ConditionTimeoutException ex) {
+            // This may be fine.
+        }
+        final boolean messageReceived = callbackSubscriber.isMessageReceived();
+        if (messageReceived) {
+            MqttMessage message = callbackSubscriber.retrieveMessage();
+            Assertions.assertTrue(shouldReceive, "QoS " + qosPub + " Messages should not be retained, received: " + message.toString());
+            assertEquals(messageString, message.toString());
+            assertEquals(Math.min(qosPub, qosSub), message.getQos());
+        } else {
+            Assertions.assertFalse(shouldReceive, "QoS " + qosPub + " Messages should be retained.");
+        }
+    }
+
+    @Test
+    public void checkSubscriberQoS0ReceiveQoS0Retained() throws Exception {
+        LOG.info("*** checkSubscriberQoS0ReceiveQoS0Retained ***");
+        checkRetained(0, 0, false);
+    }
+
+    @Test
+    public void checkSubscriberQoS1ReceiveQoS0Retained() throws Exception {
+        LOG.info("*** checkSubscriberQoS1ReceiveQoS0Retained ***");
+        checkRetained(0, 1, false);
+    }
+
+    @Test
+    public void checkSubscriberQoS2ReceiveQoS0Retained() throws Exception {
+        LOG.info("*** checkSubscriberQoS2ReceiveQoS0Retained ***");
+        checkRetained(0, 2, false);
+    }
+
+    @Test
+    public void checkSubscriberQoS0ReceiveQoS1Retained() throws Exception {
+        LOG.info("*** checkSubscriberQoS0ReceiveQoS1Retained ***");
+        checkRetained(1, 0, true);
+    }
+
+    @Test
+    public void checkSubscriberQoS1ReceiveQoS1Retained() throws Exception {
+        LOG.info("*** checkSubscriberQoS1ReceiveQoS1Retained ***");
+        checkRetained(1, 1, true);
+    }
+
+    @Test
+    public void checkSubscriberQoS2ReceiveQoS1Retained() throws Exception {
+        LOG.info("*** checkSubscriberQoS2ReceiveQoS1Retained ***");
+        checkRetained(1, 2, true);
+    }
+
+    @Test
+    public void checkSubscriberQoS0ReceiveQoS2Retained() throws Exception {
+        LOG.info("*** checkSubscriberQoS0ReceiveQoS2Retained ***");
+        checkRetained(2, 0, true);
+    }
+
+    @Test
+    public void checkSubscriberQoS1ReceiveQoS2Retained() throws Exception {
+        LOG.info("*** checkSubscriberQoS1ReceiveQoS2Retained ***");
+        checkRetained(2, 1, true);
+    }
+
+    @Test
+    public void checkSubscriberQoS2ReceiveQoS2Retained() throws Exception {
+        LOG.info("*** checkSubscriberQoS2ReceiveQoS2Retained ***");
+        checkRetained(2, 2, true);
+    }
+
+}

--- a/broker/src/test/java/io/moquette/persistence/H2PersistentQueueTest.java
+++ b/broker/src/test/java/io/moquette/persistence/H2PersistentQueueTest.java
@@ -67,7 +67,7 @@ public class H2PersistentQueueTest {
 
     private SessionRegistry.PublishedMessage createMessage(String name) {
         final ByteBuf payload = Unpooled.wrappedBuffer(name.getBytes(StandardCharsets.UTF_8));
-        return new SessionRegistry.PublishedMessage(Topic.asTopic(name), MqttQoS.AT_LEAST_ONCE, payload);
+        return new SessionRegistry.PublishedMessage(Topic.asTopic(name), MqttQoS.AT_LEAST_ONCE, payload, false);
     }
 
     @Test


### PR DESCRIPTION
This PR adds a test for, and fixes #653.

Retained messages used a difference code-path that skipped the Session, and thus did not properly set up in-flight status. 
To fix this, this PR:
- Adds a test for retained messages at different QoS levels
- Makes the retained messages use the same code path as non-retained messages
- Removes the retained-specific code.
- Adds a `retained` flag to this code-path
- Adds a `retained` flag to `SessionRegistry.PublishedMessage` so the flag is stored for queued messages