### PR TITLE
Fix #659: use buffer.toString(Charset) to directly get a String

### DIFF
--- a/broker/src/main/java/io/moquette/broker/DebugUtils.java
+++ b/broker/src/main/java/io/moquette/broker/DebugUtils.java
@@ -23,17 +23,7 @@ import java.nio.charset.StandardCharsets;
 public final class DebugUtils {
 
     public static String payload2Str(ByteBuf content) {
-        final ByteBuf copy = content.copy();
-        final byte[] bytesContent;
-        if (copy.isDirect()) {
-            final int size = copy.readableBytes();
-            bytesContent = new byte[size];
-            copy.readBytes(bytesContent);
-            copy.release();
-        } else {
-            bytesContent = copy.array();
-        }
-        return new String(bytesContent, StandardCharsets.UTF_8);
+        return content.copy().toString(StandardCharsets.UTF_8);
     }
 
     private DebugUtils() {

--- a/embedding_moquette/src/main/java/io/moquette/testembedded/EmbeddedLauncher.java
+++ b/embedding_moquette/src/main/java/io/moquette/testembedded/EmbeddedLauncher.java
@@ -48,7 +48,7 @@ public final class EmbeddedLauncher {
 
         @Override
         public void onPublish(InterceptPublishMessage msg) {
-            final String decodedPayload = new String(msg.getPayload().array(), UTF_8);
+            final String decodedPayload = msg.getPayload().toString(UTF_8);
             System.out.println("Received on topic: " + msg.getTopicName() + " content: " + decodedPayload);
         }
     }


### PR DESCRIPTION
When the goal is to turn the contents of a buffer into a String it is
more efficient and simpler to directly use the toString(Charset) method
of ByteBuf instead of fetching the byte data and manually creating a
string.

This PR replaces the two spots where buffers are turned into Strings using the "old" way.