### PR TITLE
Made RoutingResults public

### DIFF
--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -122,45 +122,6 @@ class PostOffice {
         }
     }
 
-    static class RoutingResults {
-
-        private final List<String> successedRoutings;
-        private final List<String> failedRoutings;
-        private final CompletableFuture<Void> mergedAction;
-
-        public RoutingResults(List<String> successedRoutings, List<String> failedRoutings, CompletableFuture<Void> mergedAction) {
-            this.successedRoutings = successedRoutings;
-            this.failedRoutings = failedRoutings;
-            this.mergedAction = mergedAction;
-        }
-
-        public boolean isAllSuccess() {
-            return failedRoutings.isEmpty();
-        }
-
-        public boolean isAllFailed() {
-            return successedRoutings.isEmpty() && !failedRoutings.isEmpty();
-        }
-
-        public CompletableFuture<Void> completableFuture() {
-            return mergedAction;
-        }
-
-        public static RoutingResults preroutingError() {
-            // WARN this is a special case failed is empty, but this result is to be considered as error.
-            return new RoutingResults(Collections.emptyList(), Collections.emptyList(), CompletableFuture.completedFuture(null));
-        }
-
-        @Override
-        public String toString() {
-            return "RoutingResults{" +
-                "successedRoutings=" + successedRoutings +
-                ", failedRoutings=" + failedRoutings +
-                ", mergedAction=" + mergedAction +
-                '}';
-        }
-    }
-
     static class RouteResult {
         private final String clientId;
         private final Status status;

--- a/broker/src/main/java/io/moquette/broker/RoutingResults.java
+++ b/broker/src/main/java/io/moquette/broker/RoutingResults.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.moquette.broker;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * The results of routing a publish message to all clients.
+ */
+public class RoutingResults {
+
+    final List<String> successedRoutings;
+    final List<String> failedRoutings;
+    private final CompletableFuture<Void> mergedAction;
+
+    public RoutingResults(List<String> successedRoutings, List<String> failedRoutings, CompletableFuture<Void> mergedAction) {
+        this.successedRoutings = successedRoutings;
+        this.failedRoutings = failedRoutings;
+        this.mergedAction = mergedAction;
+    }
+
+    public boolean isAllSuccess() {
+        return failedRoutings.isEmpty();
+    }
+
+    public boolean isAllFailed() {
+        return successedRoutings.isEmpty() && !failedRoutings.isEmpty();
+    }
+
+    public CompletableFuture<Void> completableFuture() {
+        return mergedAction;
+    }
+
+    public static RoutingResults preroutingError() {
+        // WARN this is a special case failed is empty, but this result is to be considered as error.
+        return new RoutingResults(Collections.emptyList(), Collections.emptyList(), CompletableFuture.completedFuture(null));
+    }
+
+    @Override
+    public String toString() {
+        return "RoutingResults{" + "successedRoutings=" + successedRoutings + ", failedRoutings=" + failedRoutings + ", mergedAction=" + mergedAction + '}';
+    }
+
+}

--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -306,7 +306,7 @@ public class Server {
      * @throws IllegalStateException if the integration is not yet started
      * @return
      */
-    public PostOffice.RoutingResults internalPublish(MqttPublishMessage msg, final String clientId) {
+    public RoutingResults internalPublish(MqttPublishMessage msg, final String clientId) {
         final int messageID = msg.variableHeader().packetId();
         if (!initialized) {
             LOG.error("Moquette is not started, internal message cannot be published. CId: {}, messageId: {}", clientId,
@@ -314,7 +314,7 @@ public class Server {
             throw new IllegalStateException("Can't publish on a integration is not yet started");
         }
         LOG.trace("Internal publishing message CId: {}, messageId: {}", clientId, messageID);
-        final PostOffice.RoutingResults routingResults = dispatcher.internalPublish(msg);
+        final RoutingResults routingResults = dispatcher.internalPublish(msg);
         msg.payload().release();
         return routingResults;
     }

--- a/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
@@ -108,7 +108,7 @@ public class PostOfficeInternalPublishTest {
             .retained(retained)
             .qos(qos)
             .payload(Unpooled.copiedBuffer(PAYLOAD.getBytes(UTF_8))).build();
-        final PostOffice.RoutingResults res = sut.internalPublish(publish);
+        final RoutingResults res = sut.internalPublish(publish);
         try {
             res.completableFuture().get(5, TimeUnit.SECONDS);
         } catch (Exception ex) {


### PR DESCRIPTION
Server.internalPublish returns the RoutingResults, but PostOffice.RoutingResults was not public.
Since PostOffice itself is not public either, RoutingResults had to be moved out of this class to its own file.