### PR TITLE
Fixed #667: NPE in InterceptConnectMessage.getPassword

### DIFF
--- a/broker/src/main/java/io/moquette/interception/messages/InterceptConnectMessage.java
+++ b/broker/src/main/java/io/moquette/interception/messages/InterceptConnectMessage.java
@@ -18,8 +18,6 @@ package io.moquette.interception.messages;
 
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 
-import java.nio.charset.StandardCharsets;
-
 public class InterceptConnectMessage extends InterceptAbstractMessage {
 
     private final MqttConnectMessage msg;
@@ -82,6 +80,6 @@ public class InterceptConnectMessage extends InterceptAbstractMessage {
     }
 
     public byte[] getWillMessage() {
-        return msg.payload().willMessage().getBytes(StandardCharsets.UTF_8);
+        return msg.payload().willMessageInBytes();
     }
 }

--- a/broker/src/main/java/io/moquette/interception/messages/InterceptConnectMessage.java
+++ b/broker/src/main/java/io/moquette/interception/messages/InterceptConnectMessage.java
@@ -74,7 +74,7 @@ public class InterceptConnectMessage extends InterceptAbstractMessage {
     }
 
     public byte[] getPassword() {
-        return msg.payload().password().getBytes(StandardCharsets.UTF_8);
+        return msg.payload().passwordInBytes();
     }
 
     public String getWillTopic() {


### PR DESCRIPTION
InterceptConnectMessage.getPassword used msg.payload().password().getBytes but msg.payload() could return null. Additionally, msg.payload() is depricated.
Instead, InterceptConnectMessage.getPassword now directly returns msg.payload().passwordInBytes() and thus never throws an NPE and avoids two re-coding steps.