### PR TITLE
feat: peer cert as username

### DIFF
--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -49,6 +49,7 @@ public final class BrokerConstants {
     public static final String KEY_STORE_PASSWORD_PROPERTY_NAME = "key_store_password";
     public static final String KEY_MANAGER_PASSWORD_PROPERTY_NAME = "key_manager_password";
     public static final String ALLOW_ANONYMOUS_PROPERTY_NAME = "allow_anonymous";
+    public static final String PEER_CERTIFICATE_AS_USERNAME = "peer_certificate_as_username";
     public static final String REAUTHORIZE_SUBSCRIPTIONS_ON_CONNECT = "reauthorize_subscriptions_on_connect";
     public static final String ALLOW_ZERO_BYTE_CLIENT_ID_PROPERTY_NAME = "allow_zero_byte_client_id";
     public static final String ACL_FILE_PROPERTY_NAME = "acl_file";

--- a/broker/src/main/java/io/moquette/broker/BrokerConfiguration.java
+++ b/broker/src/main/java/io/moquette/broker/BrokerConfiguration.java
@@ -24,20 +24,30 @@ class BrokerConfiguration {
     private final boolean allowZeroByteClientId;
     private final boolean reauthorizeSubscriptionsOnConnect;
     private final boolean immediateBufferFlush;
+    private final boolean peerCertificateAsUsername;
 
     BrokerConfiguration(IConfig props) {
         allowAnonymous = props.boolProp(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, true);
         allowZeroByteClientId = props.boolProp(BrokerConstants.ALLOW_ZERO_BYTE_CLIENT_ID_PROPERTY_NAME, false);
         reauthorizeSubscriptionsOnConnect = props.boolProp(BrokerConstants.REAUTHORIZE_SUBSCRIPTIONS_ON_CONNECT, false);
         immediateBufferFlush = props.boolProp(BrokerConstants.IMMEDIATE_BUFFER_FLUSH_PROPERTY_NAME, false);
+        peerCertificateAsUsername = props.boolProp(BrokerConstants.PEER_CERTIFICATE_AS_USERNAME, false);
     }
 
     public BrokerConfiguration(boolean allowAnonymous, boolean allowZeroByteClientId,
                                boolean reauthorizeSubscriptionsOnConnect, boolean immediateBufferFlush) {
+        this(allowAnonymous, allowZeroByteClientId,
+            reauthorizeSubscriptionsOnConnect, immediateBufferFlush, false);
+    }
+
+    public BrokerConfiguration(boolean allowAnonymous, boolean allowZeroByteClientId,
+                               boolean reauthorizeSubscriptionsOnConnect, boolean immediateBufferFlush,
+                               boolean peerCertificateAsUsername) {
         this.allowAnonymous = allowAnonymous;
         this.allowZeroByteClientId = allowZeroByteClientId;
         this.reauthorizeSubscriptionsOnConnect = reauthorizeSubscriptionsOnConnect;
         this.immediateBufferFlush = immediateBufferFlush;
+        this.peerCertificateAsUsername = peerCertificateAsUsername;
     }
 
     public boolean isAllowAnonymous() {
@@ -54,5 +64,9 @@ class BrokerConfiguration {
 
     public boolean isImmediateBufferFlush() {
         return immediateBufferFlush;
+    }
+
+    public boolean peerCertificateAsUsername() {
+        return peerCertificateAsUsername;
     }
 }

--- a/broker/src/main/java/io/moquette/broker/BrokerConfiguration.java
+++ b/broker/src/main/java/io/moquette/broker/BrokerConfiguration.java
@@ -66,7 +66,7 @@ class BrokerConfiguration {
         return immediateBufferFlush;
     }
 
-    public boolean peerCertificateAsUsername() {
+    public boolean isPeerCertificateAsUsername() {
         return peerCertificateAsUsername;
     }
 }

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -17,6 +17,7 @@ package io.moquette.broker;
 
 import io.moquette.broker.subscriptions.Topic;
 import io.moquette.broker.security.IAuthenticator;
+import io.moquette.broker.security.PemUtils;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.Channel;
@@ -24,11 +25,16 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.mqtt.*;
+import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import javax.net.ssl.SSLPeerUnverifiedException;
 import java.net.InetSocketAddress;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -274,25 +280,46 @@ final class MQTTConnection {
     }
 
     private boolean login(MqttConnectMessage msg, final String clientId) {
-        // handle user authentication
+        String userName = null;
+        byte[] pwd = null;
+
         if (msg.variableHeader().hasUserName()) {
-            byte[] pwd = null;
+            userName = msg.payload().userName();
+            // MQTT 3.1.2.9 does not mandate that there is a password - let the authenticator determine if it's needed
             if (msg.variableHeader().hasPassword()) {
                 pwd = msg.payload().passwordInBytes();
-            } else if (!brokerConfig.isAllowAnonymous()) {
-                LOG.info("Client didn't supply any password and MQTT anonymous mode is disabled CId={}", clientId);
+            }
+        }
+
+        if (brokerConfig.peerCertificateAsUsername()) {
+            try {
+                // Use peer cert as username
+                SslHandler sslhandler = (SslHandler) channel.pipeline().get("ssl");
+                if (sslhandler != null) {
+                    Certificate[] certificateChain = sslhandler.engine().getSession().getPeerCertificates();
+                    userName = PemUtils.certificatesToPem(certificateChain);
+                }
+            } catch (SSLPeerUnverifiedException e) {
+                LOG.debug("No peer cert provided. CId={}", clientId);
+            } catch (CertificateEncodingException | IOException e) {
+                LOG.warn("Unable to decode client certificate. CId={}", clientId);
+            }
+        }
+
+        if (userName == null || userName.isEmpty()) {
+            if (brokerConfig.isAllowAnonymous()) {
+                return true;
+            } else {
+                LOG.info("Client didn't supply any credentials and MQTT anonymous mode is disabled. CId={}", clientId);
                 return false;
             }
-            final String login = msg.payload().userName();
-            if (!authenticator.checkValid(clientId, login, pwd)) {
-                LOG.info("Authenticator has rejected the MQTT credentials CId={}, username={}", clientId, login);
-                return false;
-            }
-            NettyUtils.userName(channel, login);
-        } else if (!brokerConfig.isAllowAnonymous()) {
-            LOG.info("Client didn't supply any credentials and MQTT anonymous mode is disabled. CId={}", clientId);
+        }
+
+        if (!authenticator.checkValid(clientId, userName, pwd)) {
+            LOG.info("Authenticator has rejected the MQTT credentials CId={}, username={}", clientId, userName);
             return false;
         }
+        NettyUtils.userName(channel, userName);
         return true;
     }
 

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -291,7 +291,7 @@ final class MQTTConnection {
             }
         }
 
-        if (brokerConfig.peerCertificateAsUsername()) {
+        if (brokerConfig.isPeerCertificateAsUsername()) {
             try {
                 // Use peer cert as username
                 SslHandler sslhandler = (SslHandler) channel.pipeline().get("ssl");

--- a/broker/src/main/java/io/moquette/broker/security/PemUtils.java
+++ b/broker/src/main/java/io/moquette/broker/security/PemUtils.java
@@ -20,7 +20,6 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.util.Base64;

--- a/broker/src/main/java/io/moquette/broker/security/PemUtils.java
+++ b/broker/src/main/java/io/moquette/broker/security/PemUtils.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.moquette.broker.security;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.util.Base64;
+
+public final class PemUtils {
+    private static final String certificateBoundaryType = "CERTIFICATE";
+
+    public static String certificatesToPem(Certificate... certificates)
+        throws CertificateEncodingException, IOException {
+        try (StringWriter str = new StringWriter();
+             PemWriter pemWriter = new PemWriter(str)) {
+            for (Certificate certificate : certificates) {
+                pemWriter.writeObject(certificateBoundaryType, certificate.getEncoded());
+            }
+            pemWriter.close();
+            return str.toString();
+        }
+    }
+
+    /**
+     * Copyright (c) 2000 - 2021 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+     * SPDX-License-Identifier: MIT
+     *
+     * <p>A generic PEM writer, based on RFC 1421
+     * From: https://javadoc.io/static/org.bouncycastle/bcprov-jdk15on/1.62/org/bouncycastle/util/io/pem/PemWriter.html</p>
+     */
+    public static class PemWriter extends BufferedWriter {
+        private static final int LINE_LENGTH = 64;
+        private final char[] buf = new char[LINE_LENGTH];
+        /**
+         * Base constructor.
+         *
+         * @param out output stream to use.
+         */
+        public PemWriter(Writer out) {
+            super(out);
+        }
+        /**
+         * Writes a pem encoded string.
+         *
+         * @param type  key type.
+         * @param bytes encoded string
+         * @throws IOException IO Exception
+         */
+        public void writeObject(String type, byte[] bytes) throws IOException {
+            writePreEncapsulationBoundary(type);
+            writeEncoded(bytes);
+            writePostEncapsulationBoundary(type);
+        }
+        private void writeEncoded(byte[] bytes) throws IOException {
+            bytes = Base64.getEncoder().encode(bytes);
+            for (int i = 0; i < bytes.length; i += buf.length) {
+                int index = 0;
+                while (index != buf.length) {
+                    if ((i + index) >= bytes.length) {
+                        break;
+                    }
+                    buf[index] = (char) bytes[i + index];
+                    index++;
+                }
+                this.write(buf, 0, index);
+                this.newLine();
+            }
+        }
+        private void writePreEncapsulationBoundary(String type) throws IOException {
+            this.write("-----BEGIN " + type + "-----");
+            this.newLine();
+        }
+        private void writePostEncapsulationBoundary(String type) throws IOException {
+            this.write("-----END " + type + "-----");
+            this.newLine();
+        }
+    }
+}

--- a/broker/src/test/java/io/moquette/broker/BrokerConfigurationTest.java
+++ b/broker/src/test/java/io/moquette/broker/BrokerConfigurationTest.java
@@ -33,6 +33,7 @@ public class BrokerConfigurationTest {
         assertFalse(brokerConfiguration.isAllowZeroByteClientId());
         assertFalse(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
         assertFalse(brokerConfiguration.isImmediateBufferFlush());
+        assertFalse(brokerConfiguration.isPeerCertificateAsUsername());
     }
 
     @Test
@@ -45,6 +46,7 @@ public class BrokerConfigurationTest {
         assertFalse(brokerConfiguration.isAllowZeroByteClientId());
         assertFalse(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
         assertFalse(brokerConfiguration.isImmediateBufferFlush());
+        assertFalse(brokerConfiguration.isPeerCertificateAsUsername());
     }
 
     @Test
@@ -57,6 +59,7 @@ public class BrokerConfigurationTest {
         assertTrue(brokerConfiguration.isAllowZeroByteClientId());
         assertFalse(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
         assertFalse(brokerConfiguration.isImmediateBufferFlush());
+        assertFalse(brokerConfiguration.isPeerCertificateAsUsername());
     }
 
     @Test
@@ -69,6 +72,7 @@ public class BrokerConfigurationTest {
         assertFalse(brokerConfiguration.isAllowZeroByteClientId());
         assertTrue(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
         assertFalse(brokerConfiguration.isImmediateBufferFlush());
+        assertFalse(brokerConfiguration.isPeerCertificateAsUsername());
     }
 
     @Test
@@ -81,5 +85,19 @@ public class BrokerConfigurationTest {
         assertFalse(brokerConfiguration.isAllowZeroByteClientId());
         assertFalse(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
         assertTrue(brokerConfiguration.isImmediateBufferFlush());
+        assertFalse(brokerConfiguration.isPeerCertificateAsUsername());
+    }
+
+    @Test
+    public void configurePeerCertificateAsUsername() {
+        Properties properties = new Properties();
+        properties.put(BrokerConstants.PEER_CERTIFICATE_AS_USERNAME, "true");
+        MemoryConfig config = new MemoryConfig(properties);
+        BrokerConfiguration brokerConfiguration = new BrokerConfiguration(config);
+        assertTrue(brokerConfiguration.isAllowAnonymous());
+        assertFalse(brokerConfiguration.isAllowZeroByteClientId());
+        assertFalse(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
+        assertFalse(brokerConfiguration.isImmediateBufferFlush());
+        assertTrue(brokerConfiguration.isPeerCertificateAsUsername());
     }
 }

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
@@ -15,20 +15,34 @@
  */
 package io.moquette.broker;
 
+import io.moquette.broker.security.PemUtils;
 import io.moquette.broker.security.PermitAllAuthorizatorPolicy;
 import io.moquette.broker.subscriptions.CTrieSubscriptionDirectory;
 import io.moquette.broker.subscriptions.ISubscriptionsDirectory;
 import io.moquette.broker.security.IAuthenticator;
 import io.moquette.persistence.MemorySubscriptionsRepository;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttMessageBuilders;
 import io.netty.handler.codec.mqtt.MqttVersion;
+import io.netty.handler.ssl.SslHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLSession;
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.util.HashMap;
 import java.util.concurrent.ExecutionException;
 
 import static io.moquette.broker.NettyChannelAssertions.assertEqualsConnAck;
@@ -39,6 +53,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class MQTTConnectionConnectTest {
 
@@ -90,6 +105,17 @@ public class MQTTConnectionConnectTest {
 
     private MQTTConnection createMQTTConnection(BrokerConfiguration config, Channel channel, PostOffice postOffice) {
         return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, postOffice);
+    }
+
+    private SslHandler createFakeSslHandler(Certificate peerCert) throws SSLPeerUnverifiedException {
+        SSLEngine mockSslEngine = mock(SSLEngine.class);
+        SslHandler sslHandler = new FakeSslHandler(mockSslEngine);
+
+        SSLSession mockSslSession = mock(SSLSession.class);
+        when(mockSslEngine.getSession()).thenReturn(mockSslSession);
+        when(mockSslSession.getPeerCertificates()).thenReturn(new Certificate[]{peerCert});
+
+        return sslHandler;
     }
 
     @Test
@@ -201,6 +227,57 @@ public class MQTTConnectionConnectTest {
         sut.processConnect(msg);
 
         // Verify
+        assertEqualsConnAck(CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD, channel.readOutbound());
+        assertFalse(channel.isOpen(), "Connection must be closed by the broker");
+    }
+
+    @Test
+    public void peerCertAsUsernameAuthentication() throws CertificateEncodingException, IOException, InterruptedException {
+        final byte[] PEER_CERT_BYTES = "PEER_CERT".getBytes(StandardCharsets.UTF_8);
+        MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID).build();
+        BrokerConfiguration config = new BrokerConfiguration(false, false, false, false, true);
+        Certificate peerCertificate = mock(Certificate.class);
+
+        // Add SslHandler to channel
+        sut = createMQTTConnection(config);
+        channel = (EmbeddedChannel) sut.channel;
+        channel.pipeline().addFirst("ssl", createFakeSslHandler(peerCertificate));
+
+        when(peerCertificate.getEncoded()).thenReturn(PEER_CERT_BYTES);
+        mockAuthenticator = new MockAuthenticator(singleton(FAKE_CLIENT_ID),
+            singletonMap(PemUtils.certificatesToPem(peerCertificate), null));
+
+        // Exercise
+        final MQTTConnection sslConnection = createMQTTConnection(config, sut.channel, postOffice);
+        sslConnection.processConnect(msg);
+
+        // Verify
+        Thread.sleep(100);
+        assertEqualsConnAck(CONNECTION_ACCEPTED, channel.readOutbound());
+        assertTrue(channel.isOpen(), "Connection is accepted and therefore must remain open");
+    }
+
+    @Test
+    public void peerCertAsUsernameAuthentication_badCert() throws CertificateEncodingException, IOException, InterruptedException {
+        final byte[] PEER_CERT_BYTES = "BAD_PEER_CERT".getBytes(StandardCharsets.UTF_8);
+        MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID).build();
+        BrokerConfiguration config = new BrokerConfiguration(false, false, false, false, true);
+        Certificate peerCertificate = mock(Certificate.class);
+
+        // Add SslHandler to channel
+        sut = createMQTTConnection(config);
+        channel = (EmbeddedChannel) sut.channel;
+        channel.pipeline().addFirst("ssl", createFakeSslHandler(peerCertificate));
+
+        when(peerCertificate.getEncoded()).thenReturn(PEER_CERT_BYTES);
+        mockAuthenticator = new MockAuthenticator(singleton(FAKE_CLIENT_ID), new HashMap<>());
+
+        // Exercise
+        final MQTTConnection sslConnection = createMQTTConnection(config, sut.channel, postOffice);
+        sslConnection.processConnect(msg);
+
+        // Verify
+        Thread.sleep(100);
         assertEqualsConnAck(CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD, channel.readOutbound());
         assertFalse(channel.isOpen(), "Connection must be closed by the broker");
     }
@@ -329,6 +406,55 @@ public class MQTTConnectionConnectTest {
             int nextPacketId = sut.nextPacketId();
             assertTrue(nextPacketId > 0, "Packet ID must be > 0");
             assertTrue(nextPacketId <= 65_535, "Packet ID must be <= 65_535");
+        }
+    }
+
+    class FakeSslHandler extends SslHandler {
+        private ChannelOutboundHandlerAdapter outboundAdapter;
+
+        public FakeSslHandler(SSLEngine engine) {
+            super(engine);
+            outboundAdapter = new ChannelOutboundHandlerAdapter();
+        }
+
+        @Override
+        public void bind(ChannelHandlerContext ctx, SocketAddress localAddress, ChannelPromise promise) throws Exception {
+            outboundAdapter.bind(ctx, localAddress, promise);
+        }
+
+        @Override
+        public void connect(ChannelHandlerContext ctx, SocketAddress remoteAddress, SocketAddress localAddress, ChannelPromise promise) throws Exception {
+            outboundAdapter.connect(ctx, remoteAddress, localAddress, promise);
+        }
+
+        @Override
+        public void deregister(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+            outboundAdapter.deregister(ctx, promise);
+        }
+
+        @Override
+        public void disconnect(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+            outboundAdapter.disconnect(ctx, promise);
+        }
+
+        @Override
+        public void close(ChannelHandlerContext ctx, ChannelPromise promise) throws Exception {
+            outboundAdapter.close(ctx, promise);
+        }
+
+        @Override
+        public void read(ChannelHandlerContext ctx) throws Exception {
+            outboundAdapter.read(ctx);
+        }
+
+        @Override
+        public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+            outboundAdapter.write(ctx, msg, promise);
+        }
+
+        @Override
+        public void flush(ChannelHandlerContext ctx) throws Exception {
+            outboundAdapter.flush(ctx);
         }
     }
 }

--- a/broker/src/test/java/io/moquette/broker/MockAuthenticator.java
+++ b/broker/src/test/java/io/moquette/broker/MockAuthenticator.java
@@ -43,10 +43,11 @@ public class MockAuthenticator implements IAuthenticator {
         if (!m_userPwds.containsKey(username)) {
             return false;
         }
-        if (password == null) {
-            return false;
+        if (password != null) {
+            return m_userPwds.get(username).equals(new String(password, UTF_8));
+        } else {
+            return m_userPwds.get(username) == null;
         }
-        return m_userPwds.get(username).equals(new String(password, UTF_8));
     }
 
 }


### PR DESCRIPTION
This PR adds enables authenticating clients based on their peer certificates without changing the existing authentication interface. This functionality is enabled by the addition of a new configuration option which passes the client certificate PEM in place of `username`. The EMQx broker also has the same configuration option.

There is also a very small change to behavior with this PR. Previously, clients that did not provide a password were immediately rejected if anonymous sessions were disabled. As far as I can tell, the spec allows username without a password. The code will now allow this and pass the username and empty password to the authenticator.

_Why is this needed?_
The existing auth interfaces are insufficient when clients need to be identified based on their client certificate. The problem arises if an MQTT client connects with a duplicate client ID, and then an authorization request for that client ID is made. At that point, there is a period of time when the authorizer cannot know if the request is for the old session or the new session. This is problematic since there is no graceful way to handle this.

If the authorizer allows the operation, then a malicious client could exploit this to publish (or subscribe) to topics it should not normally be authorized on.

If the authorizer assumes that the operation is coming from the old client and denies the operation, then it is possible for operations which should be allowed to be be silently rejected (as Moquette does not disconnect clients after authZ failures).

By passing in the client certificate as username, this allows the authorizer to uniquely identify clients.

_Alternative solutions_
Alternatively, we could pass additional context along with authorization requests to enable a custom authorizer to uniquely identify clients. This extra context could be an opaque object provided by the Authenticator/Authorizer itself. Or it could be as simple as monotonically increasing "connection ID" which is tied to the `MQTTConnection` itself. However, this approach is trickier since it would likely break existing custom authenticators / authorizers (or involves introducing a new interface)