### PR TITLE
fix: close mvstore in unit tests (#97)

### DIFF
--- a/broker/src/test/java/io/moquette/persistence/H2PersistentQueueTest.java
+++ b/broker/src/test/java/io/moquette/persistence/H2PersistentQueueTest.java
@@ -46,6 +46,7 @@ public class H2PersistentQueueTest {
 
     @AfterEach
     public void tearDown() {
+        this.mvStore.close();
         File dbFile = new File(BrokerConstants.DEFAULT_PERSISTENT_PATH);
         if (dbFile.exists()) {
             dbFile.delete();


### PR DESCRIPTION
Failure to close the mvStore between test runs results in failures on
Windows due to locked files.