### PR TITLE
Bump versions of H2, Netty, Slf4J and Commons-codec

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -14,10 +14,10 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <netty.version>4.1.73.Final</netty.version>
+        <netty.version>4.1.77.Final</netty.version>
         <!-- Check Netty pom.xm to know the right version of tcnative, for example
-             https://github.com/netty/netty/blob/netty-4.1.73.Final/pom.xml#L545 -->
-        <netty.tcnative.version>2.0.46.Final</netty.tcnative.version>
+             https://github.com/netty/netty/blob/netty-4.1.73.Final/pom.xml#L531 -->
+        <netty.tcnative.version>2.0.52.Final</netty.tcnative.version>
         <paho.version>1.2.5</paho.version>
         <h2.version>2.1.212</h2.version>
     </properties>

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -19,7 +19,7 @@
              https://github.com/netty/netty/blob/netty-4.1.73.Final/pom.xml#L545 -->
         <netty.tcnative.version>2.0.46.Final</netty.tcnative.version>
         <paho.version>1.2.5</paho.version>
-        <h2.version>1.4.199</h2.version>
+        <h2.version>2.1.212</h2.version>
     </properties>
 
     <dependencies>

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.10</version>
+            <version>1.15</version>
         </dependency>
 
         <dependency>

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -26,14 +26,14 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.35</version>
+            <version>1.7.36</version>
         </dependency>
 
         <dependency>
             <!-- This is used to use log4j12 implementation -->
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.35</version>
+            <artifactId>slf4j-reload4j</artifactId>
+            <version>1.7.36</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -26,14 +26,14 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.36</version>
+            <version>${slf4j.version}</version>
         </dependency>
 
         <dependency>
             <!-- This is used to use log4j12 implementation -->
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-reload4j</artifactId>
-            <version>1.7.36</version>
+            <version>${slf4j.version}</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/broker/src/main/java/io/moquette/persistence/ByteBufDataType.java
+++ b/broker/src/main/java/io/moquette/persistence/ByteBufDataType.java
@@ -21,35 +21,22 @@ import org.h2.mvstore.DataUtils;
 import org.h2.mvstore.WriteBuffer;
 
 import java.nio.ByteBuffer;
+import org.h2.mvstore.type.BasicDataType;
 
-public final class ByteBufDataType implements org.h2.mvstore.type.DataType {
+public final class ByteBufDataType extends BasicDataType<ByteBuf> {
 
     @Override
-    public int compare(Object a, Object b) {
-        return 0;
+    public int compare(ByteBuf a, ByteBuf b) {
+        throw DataUtils.newUnsupportedOperationException("Can not compare");
     }
 
     @Override
-    public int getMemory(Object obj) {
+    public int getMemory(ByteBuf obj) {
         if (!(obj instanceof ByteBuf)) {
             throw new IllegalArgumentException("Expected instance of ByteBuf but found " + obj.getClass());
         }
         final int payloadSize = ((ByteBuf) obj).readableBytes();
         return 4 + payloadSize;
-    }
-
-    @Override
-    public void read(ByteBuffer buff, Object[] obj, int len, boolean key) {
-        for (int i = 0; i < len; i++) {
-            obj[i] = read(buff);
-        }
-    }
-
-    @Override
-    public void write(WriteBuffer buff, Object[] obj, int len, boolean key) {
-        for (int i = 0; i < len; i++) {
-            write(buff, obj[i]);
-        }
     }
 
     @Override
@@ -61,12 +48,17 @@ public final class ByteBufDataType implements org.h2.mvstore.type.DataType {
     }
 
     @Override
-    public void write(WriteBuffer buff, Object obj) {
-        final ByteBuf casted = (ByteBuf) obj;
-        final int payloadSize = casted.readableBytes();
+    public void write(WriteBuffer buff, ByteBuf obj) {
+        final int payloadSize = obj.readableBytes();
         byte[] rawBytes = new byte[payloadSize];
-        casted.copy().readBytes(rawBytes).release();
+        obj.copy().readBytes(rawBytes).release();
         buff.putInt(payloadSize);
         buff.put(rawBytes);
     }
+
+    @Override
+    public ByteBuf[] createStorage(int i) {
+        return new ByteBuf[i];
+    }
+
 }

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -23,8 +23,8 @@
         <dependency>
             <!-- This is used to use log4j12 implementation -->
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.25</version>
+            <artifactId>slf4j-reload4j</artifactId>
+            <version>${slf4j.version}</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
         <source.version>1.8</source.version>
         <target.version>1.8</target.version>
         <junit.version>5.7.0</junit.version>
+        <slf4j.version>1.7.36</slf4j.version>
     </properties>
 
     <groupId>io.moquette</groupId>
@@ -79,8 +80,8 @@
 
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.25</version>
+            <artifactId>slf4j-reload4j</artifactId>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
For your convenience, here is one PR to fix 4 versions.
The tricky one was H2, since the `DataType` interface changed. On the plus side, that interface now has a nice generic, and an abstract default implementation, so it does clean things up a bit.