### PR TITLE
Add test for Topic.isValid

### DIFF
--- a/broker/src/test/java/io/moquette/broker/MemoryRetainedRepositoryTest.java
+++ b/broker/src/test/java/io/moquette/broker/MemoryRetainedRepositoryTest.java
@@ -20,6 +20,7 @@ import io.moquette.broker.subscriptions.Topic;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.mqtt.MqttMessageBuilders;
 import io.netty.handler.codec.mqtt.MqttQoS;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -113,5 +114,31 @@ public class MemoryRetainedRepositoryTest {
 
         assertEquals(1, retainedMessages.size());
         assertEquals("foo/bar/baz", retainedMessages.get(0).getTopic().toString());
+    }
+
+    @Test
+    public void testIsValid() throws Exception {
+        MemoryRetainedRepository repository = new MemoryRetainedRepository();
+        Topic retainedTopic = new Topic("foo/bar/baz");
+        Topic otherRetainedTopic = new Topic("foo/bar/bazzz");
+
+        repository.retain(retainedTopic, MqttMessageBuilders
+            .publish()
+            .qos(MqttQoS.AT_LEAST_ONCE)
+            .topicName("foo/bar/baz")
+            .retained(true)
+            .payload(Unpooled.buffer(0))
+            .build());
+        repository.retain(otherRetainedTopic, MqttMessageBuilders
+            .publish()
+            .qos(MqttQoS.AT_LEAST_ONCE)
+            .topicName("foo/baz/bar")
+            .retained(true)
+            .payload(Unpooled.buffer(0))
+            .build());
+
+        List<RetainedMessage> retainedMessages = repository.retainedOnTopic("foo/bar/baz");
+
+        Assertions.assertTrue(retainedTopic.isValid());
     }
 }


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that `retainedTopic.isValid()` is true.
This tests the method [`Topic.isValid`](https://github.com/moquette-io/moquette/blob/3e6043be04b915879804f2740bd7d500331e2f24/broker/src/main/java/io/moquette/broker/subscriptions/Topic.java#L154).
This test is based on the test [`testRetainedOnTopicReturnsExactTopicMatch`](https://github.com/lacinoire/moquette/blob/3e6043be04b915879804f2740bd7d500331e2f24/broker/src/test/java/io/moquette/broker/MemoryRetainedRepositoryTest.java#L92).

Curious to hear what you think!

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))