### PR TITLE
Reshape QueueRepository API

### DIFF
--- a/broker/src/main/java/io/moquette/broker/IQueueRepository.java
+++ b/broker/src/main/java/io/moquette/broker/IQueueRepository.java
@@ -1,13 +1,13 @@
 package io.moquette.broker;
 
-import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 
 public interface IQueueRepository {
 
-    Queue<SessionRegistry.EnqueuedMessage> createQueue(String cli, boolean clean);
+    Set<String> listQueueNames();
 
-    void removeQueue(String cli);
+    boolean containsQueue(String clientId);
 
-    Map<String, Queue<SessionRegistry.EnqueuedMessage>> listAllQueues();
+    Queue<SessionRegistry.EnqueuedMessage> getOrCreateQueue(String clientId);
 }

--- a/broker/src/main/java/io/moquette/broker/MemoryQueueRepository.java
+++ b/broker/src/main/java/io/moquette/broker/MemoryQueueRepository.java
@@ -1,9 +1,6 @@
 package io.moquette.broker;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Queue;
+import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class MemoryQueueRepository implements IQueueRepository {
@@ -11,19 +8,23 @@ public class MemoryQueueRepository implements IQueueRepository {
     private Map<String, Queue<SessionRegistry.EnqueuedMessage>> queues = new HashMap<>();
 
     @Override
-    public Queue<SessionRegistry.EnqueuedMessage> createQueue(String cli, boolean clean) {
+    public Set<String> listQueueNames() {
+        return Collections.unmodifiableSet(queues.keySet());
+    }
+
+    @Override
+    public boolean containsQueue(String queueName) {
+        return queues.containsKey(queueName);
+    }
+
+    @Override
+    public Queue<SessionRegistry.EnqueuedMessage> getOrCreateQueue(String clientId) {
+        if (containsQueue(clientId)) {
+            return queues.get(clientId);
+        }
+
         final ConcurrentLinkedQueue<SessionRegistry.EnqueuedMessage> queue = new ConcurrentLinkedQueue<>();
-        queues.put(cli, queue);
+        queues.put(clientId, queue);
         return queue;
-    }
-
-    @Override
-    public void removeQueue(String cli) {
-        queues.remove(cli);
-    }
-
-    @Override
-    public Map<String, Queue<SessionRegistry.EnqueuedMessage>> listAllQueues() {
-        return Collections.unmodifiableMap(queues);
     }
 }


### PR DESCRIPTION
## What it does?
Changes signature and name IQueueRepository service to be more fine grained, avoid the full retrieval of queue to process externally.