### PR TITLE
Create custom abstraction for session's message queues

### DIFF
--- a/broker/src/main/java/io/moquette/broker/AbstractSessionMessageQueue.java
+++ b/broker/src/main/java/io/moquette/broker/AbstractSessionMessageQueue.java
@@ -1,0 +1,27 @@
+package io.moquette.broker;
+
+public abstract class AbstractSessionMessageQueue<T> implements SessionMessageQueue<T> {
+
+    protected boolean closed = false;
+
+    protected void checkEnqueuePreconditions(T t) {
+        if (t == null) {
+            throw new NullPointerException("Inserted element can't be null");
+        }
+        if (closed) {
+            throw new IllegalStateException("Can't push data in a closed queue");
+        }
+    }
+
+    protected void checkDequeuePreconditions() {
+        if (closed) {
+            throw new IllegalStateException("Can't read data from a closed queue");
+        }
+    }
+
+    protected void checkIsEmptyPreconditions() {
+        if (closed) {
+            throw new IllegalStateException("Can't state empty status in a closed queue");
+        }
+    }
+}

--- a/broker/src/main/java/io/moquette/broker/IQueueRepository.java
+++ b/broker/src/main/java/io/moquette/broker/IQueueRepository.java
@@ -9,5 +9,5 @@ public interface IQueueRepository {
 
     boolean containsQueue(String clientId);
 
-    Queue<SessionRegistry.EnqueuedMessage> getOrCreateQueue(String clientId);
+    SessionMessageQueue<SessionRegistry.EnqueuedMessage> getOrCreateQueue(String clientId);
 }

--- a/broker/src/main/java/io/moquette/broker/InMemoryQueue.java
+++ b/broker/src/main/java/io/moquette/broker/InMemoryQueue.java
@@ -1,0 +1,31 @@
+package io.moquette.broker;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+public class InMemoryQueue implements SessionMessageQueue<SessionRegistry.EnqueuedMessage> {
+
+    private Queue<SessionRegistry.EnqueuedMessage> queue = new ConcurrentLinkedQueue<>();
+
+    @Override
+    public void enqueue(SessionRegistry.EnqueuedMessage message) {
+        queue.add(message);
+    }
+
+    @Override
+    public SessionRegistry.EnqueuedMessage dequeue() {
+        return queue.poll();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return queue.isEmpty();
+    }
+
+    @Override
+    public void close() {
+        for (SessionRegistry.EnqueuedMessage msg : queue) {
+            msg.release();
+        }
+    }
+}

--- a/broker/src/main/java/io/moquette/broker/InMemoryQueue.java
+++ b/broker/src/main/java/io/moquette/broker/InMemoryQueue.java
@@ -3,29 +3,51 @@ package io.moquette.broker;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-public class InMemoryQueue implements SessionMessageQueue<SessionRegistry.EnqueuedMessage> {
+public class InMemoryQueue extends AbstractSessionMessageQueue<SessionRegistry.EnqueuedMessage> {
 
+    private final MemoryQueueRepository queueRepository;
+    private final String queueName;
     private Queue<SessionRegistry.EnqueuedMessage> queue = new ConcurrentLinkedQueue<>();
+
+    /**
+     * Constructor to create a repository untracked queue.
+     */
+    public InMemoryQueue() {
+        this(null, null);
+    }
+
+    public InMemoryQueue(MemoryQueueRepository queueRepository, String queueName) {
+        this.queueRepository = queueRepository;
+        this.queueName = queueName;
+    }
 
     @Override
     public void enqueue(SessionRegistry.EnqueuedMessage message) {
+        checkEnqueuePreconditions(message);
         queue.add(message);
     }
 
     @Override
     public SessionRegistry.EnqueuedMessage dequeue() {
+        checkDequeuePreconditions();
         return queue.poll();
     }
 
     @Override
     public boolean isEmpty() {
+        checkIsEmptyPreconditions();
         return queue.isEmpty();
     }
 
     @Override
-    public void close() {
+    public void closeAndPurge() {
         for (SessionRegistry.EnqueuedMessage msg : queue) {
             msg.release();
         }
+        if (queueRepository != null) {
+            // clean up the queue from the repository
+            queueRepository.dropQueue(this.queueName);
+        }
+        this.closed = true;
     }
 }

--- a/broker/src/main/java/io/moquette/broker/MemoryQueueRepository.java
+++ b/broker/src/main/java/io/moquette/broker/MemoryQueueRepository.java
@@ -5,7 +5,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 public class MemoryQueueRepository implements IQueueRepository {
 
-    private Map<String, Queue<SessionRegistry.EnqueuedMessage>> queues = new HashMap<>();
+    private Map<String, SessionMessageQueue<SessionRegistry.EnqueuedMessage>> queues = new HashMap<>();
 
     @Override
     public Set<String> listQueueNames() {
@@ -18,12 +18,12 @@ public class MemoryQueueRepository implements IQueueRepository {
     }
 
     @Override
-    public Queue<SessionRegistry.EnqueuedMessage> getOrCreateQueue(String clientId) {
+    public SessionMessageQueue<SessionRegistry.EnqueuedMessage> getOrCreateQueue(String clientId) {
         if (containsQueue(clientId)) {
             return queues.get(clientId);
         }
 
-        final ConcurrentLinkedQueue<SessionRegistry.EnqueuedMessage> queue = new ConcurrentLinkedQueue<>();
+        SessionMessageQueue<SessionRegistry.EnqueuedMessage> queue = new InMemoryQueue();
         queues.put(clientId, queue);
         return queue;
     }

--- a/broker/src/main/java/io/moquette/broker/MemoryQueueRepository.java
+++ b/broker/src/main/java/io/moquette/broker/MemoryQueueRepository.java
@@ -23,8 +23,12 @@ public class MemoryQueueRepository implements IQueueRepository {
             return queues.get(clientId);
         }
 
-        SessionMessageQueue<SessionRegistry.EnqueuedMessage> queue = new InMemoryQueue();
+        SessionMessageQueue<SessionRegistry.EnqueuedMessage> queue = new InMemoryQueue(this, clientId);
         queues.put(clientId, queue);
         return queue;
+    }
+
+    void dropQueue(String queueName) {
+        queues.remove(queueName);
     }
 }

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -473,7 +473,7 @@ class Session {
     public void cleanUp() {
         // in case of in memory session queues all contained messages
         // has to be released.
-        sessionQueue.close();
+        sessionQueue.closeAndPurge();
         for (EnqueuedMessage msg : inflightWindow.values()) {
             msg.release();
         }

--- a/broker/src/main/java/io/moquette/broker/SessionMessageQueue.java
+++ b/broker/src/main/java/io/moquette/broker/SessionMessageQueue.java
@@ -1,7 +1,11 @@
 package io.moquette.broker;
 
-import java.util.Optional;
-
+/**
+ * Queue definition used by the Session class.
+ * Due to the fact that Session's code is executed in a single thread, because the
+ * architecture is event loop based, the queue implementations doesn't need to be
+ * thread safe.
+ * */
 public interface SessionMessageQueue<T> {
     void enqueue(T message);
 
@@ -14,6 +18,7 @@ public interface SessionMessageQueue<T> {
 
     /**
      * Executes cleanup code to release the queue.
+     * A closed queue will not accept new items and will be removed from the repository
      * */
     void close();
 }

--- a/broker/src/main/java/io/moquette/broker/SessionMessageQueue.java
+++ b/broker/src/main/java/io/moquette/broker/SessionMessageQueue.java
@@ -1,0 +1,19 @@
+package io.moquette.broker;
+
+import java.util.Optional;
+
+public interface SessionMessageQueue<T> {
+    void enqueue(T message);
+
+    /**
+     * @return null if queue is empty.
+     * */
+    T dequeue();
+
+    boolean isEmpty();
+
+    /**
+     * Executes cleanup code to release the queue.
+     * */
+    void close();
+}

--- a/broker/src/main/java/io/moquette/broker/SessionMessageQueue.java
+++ b/broker/src/main/java/io/moquette/broker/SessionMessageQueue.java
@@ -18,7 +18,7 @@ public interface SessionMessageQueue<T> {
 
     /**
      * Executes cleanup code to release the queue.
-     * A closed queue will not accept new items and will be removed from the repository
+     * A closed queue will not accept new items and will be removed from the repository.
      * */
-    void close();
+    void closeAndPurge();
 }

--- a/broker/src/main/java/io/moquette/persistence/H2QueueRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/H2QueueRepository.java
@@ -16,6 +16,7 @@
 package io.moquette.persistence;
 
 import io.moquette.broker.IQueueRepository;
+import io.moquette.broker.SessionMessageQueue;
 import io.moquette.broker.SessionRegistry.EnqueuedMessage;
 import org.h2.mvstore.MVStore;
 
@@ -48,7 +49,7 @@ public class H2QueueRepository implements IQueueRepository {
     }
 
     @Override
-    public Queue<EnqueuedMessage> getOrCreateQueue(String clientId) {
+    public SessionMessageQueue<EnqueuedMessage> getOrCreateQueue(String clientId) {
         return new H2PersistentQueue(mvStore, clientId);
     }
 }

--- a/broker/src/test/java/io/moquette/broker/SessionTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionTest.java
@@ -9,9 +9,6 @@ import io.netty.handler.codec.mqtt.MqttQoS;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
-
 import static io.moquette.BrokerConstants.FLIGHT_BEFORE_RESEND_MS;
 import io.moquette.broker.subscriptions.Subscription;
 import java.util.Arrays;
@@ -24,12 +21,12 @@ public class SessionTest {
 
     private EmbeddedChannel testChannel;
     private Session client;
-    private Queue<SessionRegistry.EnqueuedMessage> queuedMessages;
+    private SessionMessageQueue<SessionRegistry.EnqueuedMessage> queuedMessages;
 
     @BeforeEach
     public void setUp() {
         testChannel = new EmbeddedChannel();
-        queuedMessages = new ConcurrentLinkedQueue<>();
+        queuedMessages = new InMemoryQueue();
         client = new Session(CLIENT_ID, true, null, queuedMessages);
         createConnection(client);
     }
@@ -43,7 +40,7 @@ public class SessionTest {
             sendQoS1To(client, destinationTopic, "Hello World " + i + "!");
         }
 
-        assertEquals(1, queuedMessages.size(), "Inflight zone must be full, and the 11th message must be queued");
+        assertFalse(queuedMessages.isEmpty(), "Inflight zone must be full, and the 11th message must be queued");
         // Exercise
         client.pubAckReceived(1);
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,8 @@
         <target.version>1.8</target.version>
         <junit.version>5.7.0</junit.version>
         <slf4j.version>1.7.36</slf4j.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <groupId>io.moquette</groupId>


### PR DESCRIPTION
## What it does?
Introduce a simplified abstraction for Session's message queues. Instead of using Java Collections' framework  Queue abstraction which has many operations not used, for example iteration without consuming (peek) or size retrieval this commit introduce a much simpler interface based on 4 methods:
- enqueue: to add messages
- dequeue: to retrieve messages or null it it's empty
- empty check method
- close: eventually cleanup method when a queue is not anymore used.