### PR TITLE
Modified the startup to collect some telemetry data and send to a cloud collector

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,7 +1,7 @@
 Version 0.16-SNAPSHOT:
    [build] drop generation of broker-test, removed distribution and embedding_moquette modules from deploy phase (#616)
    [fix] introduces sessions event processors to segregate changes to a session in one single thread, simplifying concurrency and code (#631)
-   [util] add collection of telemetry data (#TODO)
+   [util] add collection of telemetry data (#700)
 
 Version 0.15.1:
    [fix] avoid double subscription (#612)

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,6 +1,7 @@
 Version 0.16-SNAPSHOT:
    [build] drop generation of broker-test, removed distribution and embedding_moquette modules from deploy phase (#616)
    [fix] introduces sessions event processors to segregate changes to a session in one single thread, simplifying concurrency and code (#631)
+   [util] add collection of telemetry data (#TODO)
 
 Version 0.15.1:
    [fix] avoid double subscription (#612)

--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -78,6 +78,8 @@ public final class BrokerConstants {
     public static final String METRICS_LIBRATO_TOKEN_PROPERTY_NAME = "metrics.librato.token";
     public static final String METRICS_LIBRATO_SOURCE_PROPERTY_NAME = "metrics.librato.source";
 
+    public static final String ENABLE_TELEMETRY_NAME = "telemetry_enabled";
+
     public static final String BUGSNAG_ENABLE_PROPERTY_NAME = "use_bugsnag";
     public static final String BUGSNAG_TOKEN_PROPERTY_NAME = "bugsnag.token";
 

--- a/broker/src/test/java/io/moquette/integration/ConfigurationClassLoaderTest.java
+++ b/broker/src/test/java/io/moquette/integration/ConfigurationClassLoaderTest.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Properties;
 
+import static io.moquette.BrokerConstants.ENABLE_TELEMETRY_NAME;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConfigurationClassLoaderTest implements IAuthenticator, IAuthorizatorPolicy {
@@ -63,6 +64,7 @@ public class ConfigurationClassLoaderTest implements IAuthenticator, IAuthorizat
     public void loadAuthenticator() throws Exception {
         Properties props = new Properties(IntegrationUtils.prepareTestProperties(dbPath));
         props.setProperty(BrokerConstants.AUTHENTICATOR_CLASS_NAME, getClass().getName());
+        props.setProperty(BrokerConstants.ENABLE_TELEMETRY_NAME, "false");
         startServer(props);
         assertTrue(true);
     }
@@ -71,6 +73,7 @@ public class ConfigurationClassLoaderTest implements IAuthenticator, IAuthorizat
     public void loadAuthorizator() throws Exception {
         Properties props = new Properties(IntegrationUtils.prepareTestProperties(dbPath));
         props.setProperty(BrokerConstants.AUTHORIZATOR_CLASS_NAME, getClass().getName());
+        props.setProperty(BrokerConstants.ENABLE_TELEMETRY_NAME, "false");
         startServer(props);
         assertTrue(true);
     }

--- a/broker/src/test/java/io/moquette/integration/IntegrationUtils.java
+++ b/broker/src/test/java/io/moquette/integration/IntegrationUtils.java
@@ -16,6 +16,7 @@
 
 package io.moquette.integration;
 
+import io.moquette.BrokerConstants;
 import org.eclipse.paho.client.mqttv3.IMqttActionListener;
 import org.eclipse.paho.client.mqttv3.IMqttAsyncClient;
 import org.eclipse.paho.client.mqttv3.IMqttClient;
@@ -27,6 +28,7 @@ import java.nio.file.Path;
 import java.util.Properties;
 
 import static io.moquette.BrokerConstants.DEFAULT_MOQUETTE_STORE_H2_DB_FILENAME;
+import static io.moquette.BrokerConstants.ENABLE_TELEMETRY_NAME;
 import static io.moquette.BrokerConstants.PERSISTENT_STORE_PROPERTY_NAME;
 import static io.moquette.BrokerConstants.PORT_PROPERTY_NAME;
 
@@ -58,6 +60,7 @@ public final class IntegrationUtils {
         Properties testProperties = new Properties();
         testProperties.put(PERSISTENT_STORE_PROPERTY_NAME, dbPath);
         testProperties.put(PORT_PROPERTY_NAME, "1883");
+        testProperties.put(ENABLE_TELEMETRY_NAME, "false");
         return testProperties;
     }
 

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationOpenSSLTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationOpenSSLTest.java
@@ -56,6 +56,8 @@ public class ServerIntegrationOpenSSLTest extends ServerIntegrationSSLTest {
         sslProps.put(BrokerConstants.KEY_STORE_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
         sslProps.put(BrokerConstants.KEY_MANAGER_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
         sslProps.put(BrokerConstants.PERSISTENT_STORE_PROPERTY_NAME, dbPath);
+
+        sslProps.put(BrokerConstants.ENABLE_TELEMETRY_NAME, "false");
         m_server.startServer(sslProps);
     }
 }

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationPahoCanPublishOnReadBlockedTopicTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationPahoCanPublishOnReadBlockedTopicTest.java
@@ -77,6 +77,7 @@ public class ServerIntegrationPahoCanPublishOnReadBlockedTopicTest {
         m_server = new Server();
         final Properties configProps = IntegrationUtils.prepareTestProperties(dbPath);
         configProps.setProperty(BrokerConstants.REAUTHORIZE_SUBSCRIPTIONS_ON_CONNECT, "true");
+        configProps.setProperty(BrokerConstants.ENABLE_TELEMETRY_NAME, "false");
         m_config = new MemoryConfig(configProps);
         canRead = true;
 

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLClientAuthTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLClientAuthTest.java
@@ -183,6 +183,7 @@ public class ServerIntegrationSSLClientAuthTest {
         sslProps.put(BrokerConstants.KEY_MANAGER_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
         sslProps.put(BrokerConstants.PERSISTENT_STORE_PROPERTY_NAME, dbPath);
         sslProps.put(BrokerConstants.NEED_CLIENT_AUTH, "true");
+        sslProps.put(BrokerConstants.ENABLE_TELEMETRY_NAME, "false");
         m_server.startServer(sslProps);
     }
 

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLTest.java
@@ -114,6 +114,7 @@ public class ServerIntegrationSSLTest {
         sslProps.put(BrokerConstants.KEY_STORE_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
         sslProps.put(BrokerConstants.KEY_MANAGER_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
         sslProps.put(BrokerConstants.PERSISTENT_STORE_PROPERTY_NAME, dbPath);
+        sslProps.put(BrokerConstants.ENABLE_TELEMETRY_NAME, "false");
         m_server.startServer(sslProps);
     }
 

--- a/broker/src/test/resources/config/moquette.conf
+++ b/broker/src/test/resources/config/moquette.conf
@@ -22,3 +22,4 @@ key_manager_password passw0rdsrv
 allow_anonymous true
 
 reauthorize_subscriptions_on_connect false
+telemetry_enabled false

--- a/distribution/src/main/resources/moquette.conf
+++ b/distribution/src/main/resources/moquette.conf
@@ -161,3 +161,14 @@ password_file config/password_file.conf
 #*********************************************************************
 # use_bugsnag false
 # bugsnag.token wleifb8723784dbfeig74
+
+
+#*********************************************************************
+# Telemetry information sending
+#
+# telemetry_enabled:
+#         true or false to select if send or not telemetry data when
+#         starting up.
+# default: true
+#*********************************************************************
+# telemetry_enabled true


### PR DESCRIPTION
During startup are collected:
- OS
- cpu arch
- jvm version
- jvm vendor
- max heap (`Xmx`)
- broker's version
- uuid for the boker instance

and sent to a telemetry collector to understand how Moquette is used in the wild and provide some better features.

This functionality is enabled by default, but can always by disabled by setting 
```
telemetry_enabled false
```
in the config file or passing config properties with 
```java
configProps.setProperty(BrokerConstants.ENABLE_TELEMETRY_NAME, "false");
```
when launching in embedded mode.