### PR TITLE
Created adapter layer to use Segmented queues

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,6 @@
 Version 0.17-SNAPSHOT:
+   [enhancement] introduced new queue implementation based on segments in memory mapped files. The type of queue implementation
+   could be selected by setting `persistent_queue_type` (#691, #704).
 
 Version 0.16:
    [build] drop generation of broker-test, removed distribution and embedding_moquette modules from deploy phase (#616)

--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -23,6 +23,7 @@ public final class BrokerConstants {
     public static final String INTERCEPT_HANDLER_PROPERTY_NAME = "intercept.handler";
     public static final String BROKER_INTERCEPTOR_THREAD_POOL_SIZE = "intercept.thread_pool.size";
     public static final String PERSISTENT_STORE_PROPERTY_NAME = "persistent_store";
+    public static final String PERSISTENT_QUEUE_TYPE_PROPERTY_NAME = "persistent_queue_type"; // h2 or segmented, default h2
     public static final String AUTOSAVE_INTERVAL_PROPERTY_NAME = "autosave_interval";
     public static final String PASSWORD_FILE_PROPERTY_NAME = "password_file";
     public static final String PORT_PROPERTY_NAME = "port";

--- a/broker/src/main/java/io/moquette/broker/DebugUtils.java
+++ b/broker/src/main/java/io/moquette/broker/DebugUtils.java
@@ -23,7 +23,10 @@ import java.nio.charset.StandardCharsets;
 public final class DebugUtils {
 
     public static String payload2Str(ByteBuf content) {
-        return content.copy().toString(StandardCharsets.UTF_8);
+        final int readerPin = content.readableBytes();
+        final String result = content.toString(StandardCharsets.UTF_8);
+        content.readerIndex(readerPin);
+        return result;
     }
 
     private DebugUtils() {

--- a/broker/src/main/java/io/moquette/broker/IQueueRepository.java
+++ b/broker/src/main/java/io/moquette/broker/IQueueRepository.java
@@ -1,6 +1,5 @@
 package io.moquette.broker;
 
-import java.util.Queue;
 import java.util.Set;
 
 public interface IQueueRepository {

--- a/broker/src/main/java/io/moquette/broker/IQueueRepository.java
+++ b/broker/src/main/java/io/moquette/broker/IQueueRepository.java
@@ -9,4 +9,6 @@ public interface IQueueRepository {
     boolean containsQueue(String clientId);
 
     SessionMessageQueue<SessionRegistry.EnqueuedMessage> getOrCreateQueue(String clientId);
+
+    void close();
 }

--- a/broker/src/main/java/io/moquette/broker/MemoryQueueRepository.java
+++ b/broker/src/main/java/io/moquette/broker/MemoryQueueRepository.java
@@ -1,7 +1,9 @@
 package io.moquette.broker;
 
-import java.util.*;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 public class MemoryQueueRepository implements IQueueRepository {
 
@@ -26,6 +28,11 @@ public class MemoryQueueRepository implements IQueueRepository {
         SessionMessageQueue<SessionRegistry.EnqueuedMessage> queue = new InMemoryQueue(this, clientId);
         queues.put(clientId, queue);
         return queue;
+    }
+
+    @Override
+    public void close() {
+        queues.clear();
     }
 
     void dropQueue(String queueName) {

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -174,7 +174,6 @@ public class SessionRegistry {
             oldSession.closeImmediately();
         }
 
-
         if (newIsClean) {
             boolean result = oldSession.assignState(SessionStatus.DISCONNECTED, SessionStatus.DESTROYED);
             if (!result) {
@@ -289,5 +288,12 @@ public class SessionRegistry {
         final String clientID = s.getClientID();
         final Optional<InetSocketAddress> remoteAddressOpt = s.remoteAddress();
         return remoteAddressOpt.map(r -> new ClientDescriptor(clientID, r.getHostString(), r.getPort()));
+    }
+
+    /**
+     * Close all resources related to session management
+     * */
+    public void close() {
+        queueRepository.close();
     }
 }

--- a/broker/src/main/java/io/moquette/broker/unsafequeues/QueuePool.java
+++ b/broker/src/main/java/io/moquette/broker/unsafequeues/QueuePool.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
+import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -149,6 +150,10 @@ public class QueuePool {
         queuePool.loadRecycledSegments(checkpointProps);
         LOG.debug("Recyclable segments are: {}", queuePool.recycledSegments);
         return queuePool;
+    }
+
+    public Set<String> queueNames() {
+        return queues.keySet().stream().map(qn -> qn.name).collect(Collectors.toSet());
     }
 
     private static Properties createOrLoadCheckpointFile(Path dataPath) throws QueueException {

--- a/broker/src/main/java/io/moquette/broker/unsafequeues/QueuePool.java
+++ b/broker/src/main/java/io/moquette/broker/unsafequeues/QueuePool.java
@@ -164,6 +164,7 @@ public class QueuePool {
             try {
                 notExisted = checkpointPath.toFile().createNewFile();
             } catch (IOException e) {
+                LOG.error("IO Error creating the file {}", checkpointPath, e);
                 throw new QueueException("Reached an IO error during the bootstrapping of empty 'checkpoint.properties'", e);
             }
             if (!notExisted) {

--- a/broker/src/main/java/io/moquette/persistence/H2QueueRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/H2QueueRepository.java
@@ -20,11 +20,7 @@ import io.moquette.broker.SessionMessageQueue;
 import io.moquette.broker.SessionRegistry.EnqueuedMessage;
 import org.h2.mvstore.MVStore;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Collectors;
 
 public class H2QueueRepository implements IQueueRepository {
@@ -51,5 +47,10 @@ public class H2QueueRepository implements IQueueRepository {
     @Override
     public SessionMessageQueue<EnqueuedMessage> getOrCreateQueue(String clientId) {
         return new H2PersistentQueue(mvStore, clientId);
+    }
+
+    @Override
+    public void close() {
+        // No-op
     }
 }

--- a/broker/src/main/java/io/moquette/persistence/SegmentPersistentQueue.java
+++ b/broker/src/main/java/io/moquette/persistence/SegmentPersistentQueue.java
@@ -1,0 +1,158 @@
+package io.moquette.persistence;
+
+import io.moquette.broker.AbstractSessionMessageQueue;
+import io.moquette.broker.SessionRegistry;
+import io.moquette.broker.subscriptions.Topic;
+import io.moquette.broker.unsafequeues.Queue;
+import io.moquette.broker.unsafequeues.QueueException;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.mqtt.MqttQoS;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+public class SegmentPersistentQueue extends AbstractSessionMessageQueue<SessionRegistry.EnqueuedMessage> {
+
+    private static class SerDes {
+
+        private enum MessageType {PUB_REL_MARKER, PUBLISHED_MESSAGE}
+
+        public ByteBuffer toBytes(SessionRegistry.EnqueuedMessage message) {
+            final int memorySize = getMemory(message);
+            final ByteBuffer payload = ByteBuffer.allocate(memorySize);
+            payload.mark();
+            write(message, payload);
+            payload.reset();
+            return payload;
+        }
+
+        private void write(SessionRegistry.EnqueuedMessage obj, ByteBuffer buff) {
+            if (obj instanceof SessionRegistry.PublishedMessage) {
+                buff.put((byte) MessageType.PUBLISHED_MESSAGE.ordinal());
+
+                final SessionRegistry.PublishedMessage casted = (SessionRegistry.PublishedMessage) obj;
+                buff.put((byte) casted.getPublishingQos().value());
+
+                final String topic = casted.getTopic().toString();
+
+                writeTopic(buff, topic);
+                writePayload(buff, casted.getPayload());
+            } else if (obj instanceof SessionRegistry.PubRelMarker) {
+                buff.put((byte) MessageType.PUB_REL_MARKER.ordinal());
+            } else {
+                throw new IllegalArgumentException("Unrecognized message class " + obj.getClass());
+            }
+        }
+
+        private void writePayload(ByteBuffer buff, ByteBuf obj) {
+            final int payloadSize = obj.readableBytes();
+            byte[] rawBytes = new byte[payloadSize];
+            obj.copy().readBytes(rawBytes).release();
+            buff.putInt(payloadSize);
+            buff.put(rawBytes);
+        }
+
+        private void writeTopic(ByteBuffer buff, String topic) {
+            final byte[] topicBytes = topic.getBytes(StandardCharsets.UTF_8);
+            buff.putInt(topicBytes.length).put(topicBytes);
+        }
+
+        private int getMemory(SessionRegistry.EnqueuedMessage obj) {
+            if (obj instanceof SessionRegistry.PubRelMarker) {
+                return 1;
+            }
+            final SessionRegistry.PublishedMessage casted = (SessionRegistry.PublishedMessage) obj;
+            return 1 + // message type
+                1 + // qos
+                topicMemorySize(casted.getTopic()) +
+                payloadMemorySize(casted.getPayload());
+        }
+
+        private int payloadMemorySize(ByteBuf payload) {
+            return 4 + // size
+                payload.readableBytes();
+        }
+
+        private int topicMemorySize(Topic topic) {
+            return 4 + // size
+                topic.toString().getBytes(StandardCharsets.UTF_8).length;
+        }
+
+        public SessionRegistry.EnqueuedMessage fromBytes(ByteBuffer buff) {
+            final byte messageType = buff.get();
+            if (messageType == MessageType.PUB_REL_MARKER.ordinal()) {
+                return new SessionRegistry.PubRelMarker();
+            } else if (messageType == MessageType.PUBLISHED_MESSAGE.ordinal()) {
+                final MqttQoS qos = MqttQoS.valueOf(buff.get());
+                final String topicStr = readTopic(buff);
+                final ByteBuf payload = readPayload(buff);
+                return new SessionRegistry.PublishedMessage(Topic.asTopic(topicStr), qos, payload, false);
+            } else {
+                throw new IllegalArgumentException("Can't recognize record of type: " + messageType);
+            }
+        }
+
+        private String readTopic(ByteBuffer buff) {
+            final int stringLen = buff.getInt();
+            final byte[] rawString = new byte[stringLen];
+            buff.get(rawString);
+            return new String(rawString, StandardCharsets.UTF_8);
+        }
+
+        private ByteBuf readPayload(ByteBuffer buff) {
+            final int payloadSize = buff.getInt();
+            byte[] payload = new byte[payloadSize];
+            buff.get(payload);
+            return Unpooled.wrappedBuffer(payload);
+        }
+    }
+
+    private final Queue segmentedQueue;
+    private final SerDes serdes = new SerDes();
+
+    public SegmentPersistentQueue(Queue segmentedQueue) {
+        this.segmentedQueue = segmentedQueue;
+    }
+
+    @Override
+    public void enqueue(SessionRegistry.EnqueuedMessage message) {
+        checkEnqueuePreconditions(message);
+
+        final ByteBuffer payload = serdes.toBytes(message);
+        try {
+            segmentedQueue.enqueue(payload);
+        } catch (QueueException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public SessionRegistry.EnqueuedMessage dequeue() {
+        checkDequeuePreconditions();
+
+        final Optional<ByteBuffer> dequeue;
+        try {
+            dequeue = segmentedQueue.dequeue();
+        } catch (QueueException e) {
+            throw new RuntimeException(e);
+        }
+        if (!dequeue.isPresent()) {
+            return null;
+        }
+
+        final ByteBuffer content = dequeue.get();
+        return serdes.fromBytes(content);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return segmentedQueue.isEmpty();
+    }
+
+    @Override
+    public void closeAndPurge() {
+        closed = true;
+    }
+}

--- a/broker/src/main/java/io/moquette/persistence/SegmentPersistentQueue.java
+++ b/broker/src/main/java/io/moquette/persistence/SegmentPersistentQueue.java
@@ -46,12 +46,14 @@ public class SegmentPersistentQueue extends AbstractSessionMessageQueue<SessionR
             }
         }
 
-        private void writePayload(ByteBuffer buff, ByteBuf obj) {
-            final int payloadSize = obj.readableBytes();
+        private void writePayload(ByteBuffer target, ByteBuf source) {
+            final int payloadSize = source.readableBytes();
             byte[] rawBytes = new byte[payloadSize];
-            obj.copy().readBytes(rawBytes).release();
-            buff.putInt(payloadSize);
-            buff.put(rawBytes);
+            final int pinPoint = source.readerIndex();
+            source.readBytes(rawBytes).release();
+            source.readerIndex(pinPoint);
+            target.putInt(payloadSize);
+            target.put(rawBytes);
         }
 
         private void writeTopic(ByteBuffer buff, String topic) {

--- a/broker/src/main/java/io/moquette/persistence/SegmentQueueRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/SegmentQueueRepository.java
@@ -6,11 +6,15 @@ import io.moquette.broker.SessionRegistry;
 import io.moquette.broker.unsafequeues.Queue;
 import io.moquette.broker.unsafequeues.QueueException;
 import io.moquette.broker.unsafequeues.QueuePool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.file.Paths;
 import java.util.Set;
 
 public class SegmentQueueRepository implements IQueueRepository {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SegmentQueueRepository.class);
 
     private final QueuePool queuePool;
 
@@ -37,5 +41,14 @@ public class SegmentQueueRepository implements IQueueRepository {
             throw new RuntimeException(e);
         }
         return new SegmentPersistentQueue(segmentedQueue);
+    }
+
+    @Override
+    public void close() {
+        try {
+            queuePool.close();
+        } catch (QueueException e) {
+            LOG.error("Error saving state of the queue pool", e);
+        }
     }
 }

--- a/broker/src/main/java/io/moquette/persistence/SegmentQueueRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/SegmentQueueRepository.java
@@ -1,0 +1,41 @@
+package io.moquette.persistence;
+
+import io.moquette.broker.IQueueRepository;
+import io.moquette.broker.SessionMessageQueue;
+import io.moquette.broker.SessionRegistry;
+import io.moquette.broker.unsafequeues.Queue;
+import io.moquette.broker.unsafequeues.QueueException;
+import io.moquette.broker.unsafequeues.QueuePool;
+
+import java.nio.file.Paths;
+import java.util.Set;
+
+public class SegmentQueueRepository implements IQueueRepository {
+
+    private final QueuePool queuePool;
+
+    public SegmentQueueRepository(String path) throws QueueException {
+        queuePool = QueuePool.loadQueues(Paths.get(path));
+    }
+
+    @Override
+    public Set<String> listQueueNames() {
+        return queuePool.queueNames();
+    }
+
+    @Override
+    public boolean containsQueue(String clientId) {
+        return listQueueNames().contains(clientId);
+    }
+
+    @Override
+    public SessionMessageQueue<SessionRegistry.EnqueuedMessage> getOrCreateQueue(String clientId) {
+        final Queue segmentedQueue;
+        try {
+            segmentedQueue = queuePool.getOrCreate(clientId);
+        } catch (QueueException e) {
+            throw new RuntimeException(e);
+        }
+        return new SegmentPersistentQueue(segmentedQueue);
+    }
+}

--- a/broker/src/test/java/io/moquette/integration/IntegrationUtils.java
+++ b/broker/src/test/java/io/moquette/integration/IntegrationUtils.java
@@ -61,6 +61,7 @@ public final class IntegrationUtils {
         testProperties.put(PERSISTENT_STORE_PROPERTY_NAME, dbPath);
         testProperties.put(PORT_PROPERTY_NAME, "1883");
         testProperties.put(ENABLE_TELEMETRY_NAME, "false");
+        testProperties.put(BrokerConstants.PERSISTENT_QUEUE_TYPE_PROPERTY_NAME, "segmented");
         return testProperties;
     }
 

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationPahoCanPublishOnReadBlockedTopicTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationPahoCanPublishOnReadBlockedTopicTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Properties;
 
@@ -73,11 +74,12 @@ public class ServerIntegrationPahoCanPublishOnReadBlockedTopicTest {
         Awaitility.setDefaultTimeout(Durations.ONE_SECOND);
     }
 
-    protected void startServer(String dbPath) {
+    protected void startServer(String dbPath) throws IOException {
         m_server = new Server();
         final Properties configProps = IntegrationUtils.prepareTestProperties(dbPath);
         configProps.setProperty(BrokerConstants.REAUTHORIZE_SUBSCRIPTIONS_ON_CONNECT, "true");
         configProps.setProperty(BrokerConstants.ENABLE_TELEMETRY_NAME, "false");
+        configProps.setProperty(BrokerConstants.PERSISTENT_QUEUE_TYPE_PROPERTY_NAME, "segmented");
         m_config = new MemoryConfig(configProps);
         canRead = true;
 

--- a/broker/src/test/resources/log4j.properties
+++ b/broker/src/test/resources/log4j.properties
@@ -1,7 +1,7 @@
 #log4j.rootLogger=ERROR, stdout, file
 log4j.rootLogger=ERROR, stdout
 
-log4j.logger.io.moquette=INFO
+log4j.logger.io.moquette=WARN
 #log4j.logger.io.moquette.broker=DEBUG
 #log4j.logger.io.moquette.broker.MQTTConnection=DEBUG
 #log4j.logger.io.moquette.broker.SessionRegistry=DEBUG

--- a/distribution/src/main/resources/moquette.conf
+++ b/distribution/src/main/resources/moquette.conf
@@ -55,6 +55,15 @@ host 0.0.0.0
 #persistent_store ./moquette_store.h2
 
 #*********************************************************************
+# Persistent queues type
+#
+# persistent_queue_type:
+#       "h2" or "segmented"
+# default: h2
+#*********************************************************************
+# persistent_queue_type segmented
+
+#*********************************************************************
 # acl_file:
 #    defines the path to the ACL file relative to moquette home dir
 #    contained in the moquette.path system property


### PR DESCRIPTION
## What the PR does
Wraps the segmented queues into  session queues. This storage engine could b enabled with configuration `persistent_queue_type` setting, which accepts `h2` or `segmented`, defaulting to `segmented` if option is not specified.
Added `close` method to session registry to flush all the  meta information that compose checkpoint file of segmented queues.