### PR TITLE
Deprecate persistent_store setting

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,5 +1,5 @@
 Version 0.17-SNAPSHOT:
-   [break] deprecate `persistent_store` to separate the enablement of persistence with `persistence_enabled` and the path `data_path`.
+   [break] deprecate `persistent_store` to separate the enablement of persistence with `persistence_enabled` and the path `data_path` (#706).
    [enhancement] introduced new queue implementation based on segments in memory mapped files. The type of queue implementation
    could be selected by setting `persistent_queue_type` (#691, #704).
 

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.17-SNAPSHOT:
+   [break] deprecate `persistent_store` to separate the enablement of persistence with `persistence_enabled` and the path `data_path`.
    [enhancement] introduced new queue implementation based on segments in memory mapped files. The type of queue implementation
    could be selected by setting `persistent_queue_type` (#691, #704).
 

--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -22,8 +22,16 @@ public final class BrokerConstants {
 
     public static final String INTERCEPT_HANDLER_PROPERTY_NAME = "intercept.handler";
     public static final String BROKER_INTERCEPTOR_THREAD_POOL_SIZE = "intercept.thread_pool.size";
+    /**
+     * @deprecated use the DATA_PATH_PROPERTY_NAME to define the path where to store
+     * the broker files (es queues and subscriptions).
+     * Enable persistence with PERSISTENCE_ENABLED_PROPERTY_NAME
+     * */
+    @Deprecated
     public static final String PERSISTENT_STORE_PROPERTY_NAME = "persistent_store";
+    public static final String DATA_PATH_PROPERTY_NAME = "data_path";
     public static final String PERSISTENT_QUEUE_TYPE_PROPERTY_NAME = "persistent_queue_type"; // h2 or segmented, default h2
+    public static final String PERSISTENCE_ENABLED_PROPERTY_NAME = "persistence_enabled"; // true or false, default true
     public static final String AUTOSAVE_INTERVAL_PROPERTY_NAME = "autosave_interval";
     public static final String PASSWORD_FILE_PROPERTY_NAME = "password_file";
     public static final String PORT_PROPERTY_NAME = "port";

--- a/broker/src/main/java/io/moquette/broker/config/IConfig.java
+++ b/broker/src/main/java/io/moquette/broker/config/IConfig.java
@@ -31,7 +31,7 @@ public abstract class IConfig {
      * Same semantic of Properties
      *
      * @param name property name.
-     * @return property value.
+     * @return property value null if not found.
      * */
     public abstract String getProperty(String name);
 
@@ -39,7 +39,7 @@ public abstract class IConfig {
      * Same semantic of Properties
      *
      * @param name property name.
-     * @param defaultValue default value to return in case the property doesn't exists.
+     * @param defaultValue default value to return in case the property doesn't exist.
      * @return property value.
      * */
     public abstract String getProperty(String name, String defaultValue);
@@ -57,6 +57,9 @@ public abstract class IConfig {
         setProperty(BrokerConstants.AUTHORIZATOR_CLASS_NAME, "");
         setProperty(BrokerConstants.NETTY_MAX_BYTES_PROPERTY_NAME,
             String.valueOf(BrokerConstants.DEFAULT_NETTY_MAX_BYTES_IN_MESSAGE));
+        setProperty(BrokerConstants.PERSISTENT_QUEUE_TYPE_PROPERTY_NAME, "segmented");
+        setProperty(BrokerConstants.DATA_PATH_PROPERTY_NAME, "data/");
+        setProperty(BrokerConstants.PERSISTENCE_ENABLED_PROPERTY_NAME, Boolean.TRUE.toString());
     }
 
     public abstract IResourceLoader getResourceLoader();

--- a/broker/src/main/java/io/moquette/persistence/SegmentQueueRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/SegmentQueueRepository.java
@@ -9,6 +9,7 @@ import io.moquette.broker.unsafequeues.QueuePool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
 
@@ -20,6 +21,10 @@ public class SegmentQueueRepository implements IQueueRepository {
 
     public SegmentQueueRepository(String path) throws QueueException {
         queuePool = QueuePool.loadQueues(Paths.get(path));
+    }
+
+    public SegmentQueueRepository(Path path) throws QueueException {
+        queuePool = QueuePool.loadQueues(path);
     }
 
     @Override

--- a/broker/src/test/java/io/moquette/integration/IntegrationUtils.java
+++ b/broker/src/test/java/io/moquette/integration/IntegrationUtils.java
@@ -16,7 +16,6 @@
 
 package io.moquette.integration;
 
-import io.moquette.BrokerConstants;
 import org.eclipse.paho.client.mqttv3.IMqttActionListener;
 import org.eclipse.paho.client.mqttv3.IMqttAsyncClient;
 import org.eclipse.paho.client.mqttv3.IMqttClient;
@@ -27,9 +26,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Properties;
 
+import static io.moquette.BrokerConstants.DATA_PATH_PROPERTY_NAME;
 import static io.moquette.BrokerConstants.DEFAULT_MOQUETTE_STORE_H2_DB_FILENAME;
 import static io.moquette.BrokerConstants.ENABLE_TELEMETRY_NAME;
-import static io.moquette.BrokerConstants.PERSISTENT_STORE_PROPERTY_NAME;
+import static io.moquette.BrokerConstants.PERSISTENCE_ENABLED_PROPERTY_NAME;
+import static io.moquette.BrokerConstants.PERSISTENT_QUEUE_TYPE_PROPERTY_NAME;
 import static io.moquette.BrokerConstants.PORT_PROPERTY_NAME;
 
 /**
@@ -58,10 +59,11 @@ public final class IntegrationUtils {
 
     public static Properties prepareTestProperties(String dbPath) {
         Properties testProperties = new Properties();
-        testProperties.put(PERSISTENT_STORE_PROPERTY_NAME, dbPath);
+        testProperties.put(DATA_PATH_PROPERTY_NAME, dbPath);
+        testProperties.put(PERSISTENCE_ENABLED_PROPERTY_NAME, "true");
         testProperties.put(PORT_PROPERTY_NAME, "1883");
         testProperties.put(ENABLE_TELEMETRY_NAME, "false");
-        testProperties.put(BrokerConstants.PERSISTENT_QUEUE_TYPE_PROPERTY_NAME, "segmented");
+        testProperties.put(PERSISTENT_QUEUE_TYPE_PROPERTY_NAME, "segmented");
         return testProperties;
     }
 

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationOpenSSLTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationOpenSSLTest.java
@@ -55,7 +55,8 @@ public class ServerIntegrationOpenSSLTest extends ServerIntegrationSSLTest {
         sslProps.put(BrokerConstants.JKS_PATH_PROPERTY_NAME, "src/test/resources/serverkeystore.jks");
         sslProps.put(BrokerConstants.KEY_STORE_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
         sslProps.put(BrokerConstants.KEY_MANAGER_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
-        sslProps.put(BrokerConstants.PERSISTENT_STORE_PROPERTY_NAME, dbPath);
+        sslProps.put(BrokerConstants.DATA_PATH_PROPERTY_NAME, dbPath);
+        sslProps.put(BrokerConstants.PERSISTENCE_ENABLED_PROPERTY_NAME, "true");
 
         sslProps.put(BrokerConstants.ENABLE_TELEMETRY_NAME, "false");
         m_server.startServer(sslProps);

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLClientAuthTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLClientAuthTest.java
@@ -181,7 +181,8 @@ public class ServerIntegrationSSLClientAuthTest {
         sslProps.put(BrokerConstants.JKS_PATH_PROPERTY_NAME, "src/test/resources/serverkeystore.jks");
         sslProps.put(BrokerConstants.KEY_STORE_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
         sslProps.put(BrokerConstants.KEY_MANAGER_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
-        sslProps.put(BrokerConstants.PERSISTENT_STORE_PROPERTY_NAME, dbPath);
+        sslProps.put(BrokerConstants.DATA_PATH_PROPERTY_NAME, dbPath);
+        sslProps.put(BrokerConstants.PERSISTENCE_ENABLED_PROPERTY_NAME, "true");
         sslProps.put(BrokerConstants.NEED_CLIENT_AUTH, "true");
         sslProps.put(BrokerConstants.ENABLE_TELEMETRY_NAME, "false");
         m_server.startServer(sslProps);

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLTest.java
@@ -113,7 +113,8 @@ public class ServerIntegrationSSLTest {
         sslProps.put(BrokerConstants.JKS_PATH_PROPERTY_NAME, "src/test/resources/serverkeystore.jks");
         sslProps.put(BrokerConstants.KEY_STORE_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
         sslProps.put(BrokerConstants.KEY_MANAGER_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
-        sslProps.put(BrokerConstants.PERSISTENT_STORE_PROPERTY_NAME, dbPath);
+        sslProps.put(BrokerConstants.DATA_PATH_PROPERTY_NAME, dbPath);
+        sslProps.put(BrokerConstants.PERSISTENCE_ENABLED_PROPERTY_NAME, "true");
         sslProps.put(BrokerConstants.ENABLE_TELEMETRY_NAME, "false");
         m_server.startServer(sslProps);
     }

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationWebSocketTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationWebSocketTest.java
@@ -53,7 +53,8 @@ public class ServerIntegrationWebSocketTest {
         m_server = new Server();
         final Properties configProps = IntegrationUtils.prepareTestProperties(dbPath);
         configProps.put(BrokerConstants.WEB_SOCKET_PORT_PROPERTY_NAME, Integer.toString(BrokerConstants.WEBSOCKET_PORT));
-        configProps.put(BrokerConstants.PERSISTENT_STORE_PROPERTY_NAME, dbPath);
+        configProps.put(BrokerConstants.DATA_PATH_PROPERTY_NAME, dbPath);
+        configProps.put(BrokerConstants.PERSISTENCE_ENABLED_PROPERTY_NAME, "true");
         m_config = new MemoryConfig(configProps);
         m_server.startServer(m_config);
     }

--- a/distribution/src/main/resources/moquette.conf
+++ b/distribution/src/main/resources/moquette.conf
@@ -49,10 +49,15 @@ websocket_port 8080
 host 0.0.0.0
 
 #*********************************************************************
-# The file for the persistent store, if not specified, use just memory
-# no physical persistence
+# If enabled store queues and subscription data into data_path
 #*********************************************************************
-#persistent_store ./moquette_store.h2
+# persistence_enabled true
+
+#*********************************************************************
+# The path to store queues and subscriptions data. Used if
+# persistence_enabled is enabled.
+#*********************************************************************
+# data_path data/
 
 #*********************************************************************
 # Persistent queues type


### PR DESCRIPTION
## Release notes
Deprecate `persistent_store` to separate the enablement of persistence with `persistence_enabled` and the path `data_path`.


## What does this PR do?

Introduce `data_path` setting to refer the location where to save data files for subscription and queues stores; by default `data` folder under `$MOQUETTE_HOME`.
Introduces also, `persistence_enabled` boolean setting to explicitly enable persistent or in memory storage.


## Why is it important/What is the impact to the user?

The existing `persistent_store` setting pointed to a single H2 file. If the setting is not valued, implicitly mean to store in-memory.
With the introduction of `segmented` queues storage type, there is the need to define a directory where to store segmented pages, so a folder. Its default value is `data` folder under Moquette installation folder.
Given that the `data_path` has always a value there is the requirement for a flag to explicitly enable/disable the persistence.
