### PR TITLE
Sets clientId into Channel's attribute immediately after processing he CONNECT message

### DIFF
--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -194,6 +194,7 @@ final class MQTTConnection {
             abortConnection(CONNECTION_REFUSED_SERVER_UNAVAILABLE);
             return;
         }
+        NettyUtils.clientID(channel, clientId);
 
         final boolean msgCleanSessionFlag = msg.variableHeader().isCleanSession();
         boolean isSessionAlreadyPresent = !msgCleanSessionFlag && result.alreadyStored;
@@ -212,7 +213,6 @@ final class MQTTConnection {
                         channel.writeAndFlush(disconnectMsg).addListener(CLOSE);
                         LOG.warn("CONNACK is sent but the session created can't transition in CONNECTED state");
                     } else {
-                        NettyUtils.clientID(channel, clientIdUsed);
                         connected = true;
                         // OK continue with sending queued messages and normal flow
 


### PR DESCRIPTION
MQTT 3.1.1 specification, MQTT-3.1.4-5 says that Clients are allowed to send further Control Packets immediately after sending a CONNECT Packet. In this case a PUBLISH is could be sent immediately after the CONNECT, so it's processed serially by the same IO thread. The PUBLISH needs to accees the clientID attribute of the Channel, so it needs be set before the CONNACK in write&flush.

Fixes #705