### PR TITLE
Adds debug-enabled check for sessions loop assignments

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.17-SNAPSHOT:
+   [feature] add `moquette.session_loop.debug` property to enable session loop checking assignments (#714).
    [break] deprecate `persistent_store` to separate the enablement of persistence with `persistence_enabled` and the path `data_path` (#706).
    [enhancement] introduced new queue implementation based on segments in memory mapped files. The type of queue implementation
    could be selected by setting `persistent_queue_type` (#691, #704).


### PR DESCRIPTION
Adds a check to verify that current session loop thread is the expected one. This is useful to investigate eventual problems with session loops.

This feature could be explicitly enable setting the `moquette.session_loop.debug` environment variable with the `-D` JVM flag.