### PR TITLE
Use a copy of the buffer when reading for storing.

### DIFF
--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -32,6 +32,10 @@ public final class BrokerConstants {
     public static final String DATA_PATH_PROPERTY_NAME = "data_path";
     public static final String PERSISTENT_QUEUE_TYPE_PROPERTY_NAME = "persistent_queue_type"; // h2 or segmented, default h2
     public static final String PERSISTENCE_ENABLED_PROPERTY_NAME = "persistence_enabled"; // true or false, default true
+    public static final String SEGMENTED_QUEUE_PAGE_SIZE = "queue_page_size";
+    public static final int DEFAULT_SEGMENTED_QUEUE_PAGE_SIZE = 64 * 1024 * 1024;
+    public static final String SEGMENTED_QUEUE_SEGMENT_SIZE = "queue_segment_size";
+    public static final int DEFAULT_SEGMENTED_QUEUE_SEGMENT_SIZE = 4 * 1024 * 1024;
     public static final String AUTOSAVE_INTERVAL_PROPERTY_NAME = "autosave_interval";
     public static final String PASSWORD_FILE_PROPERTY_NAME = "password_file";
     public static final String PORT_PROPERTY_NAME = "port";

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -507,9 +507,10 @@ class PostOffice {
     }
 
     private void publishToSession(ByteBuf payload, Topic topic, Collection<Subscription> subscriptions, MqttQoS publishingQos) {
+        ByteBuf duplicate = payload.duplicate();
         for (Subscription sub : subscriptions) {
             MqttQoS qos = lowerQosToTheSubscriptionDesired(sub, publishingQos);
-            publishToSession(payload, topic, sub, qos);
+            publishToSession(duplicate, topic, sub, qos);
         }
     }
 

--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -265,8 +265,10 @@ public class Server {
             queueRepository = h2Builder.queueRepository();
         } else if ("segmented".equalsIgnoreCase(queueType)) {
             LOG.info("Configuring segmented queue store to {}", dataPath);
+            final int pageSize = config.intProp(BrokerConstants.SEGMENTED_QUEUE_PAGE_SIZE, BrokerConstants.DEFAULT_SEGMENTED_QUEUE_PAGE_SIZE);
+            final int segmentSize = config.intProp(BrokerConstants.SEGMENTED_QUEUE_SEGMENT_SIZE, BrokerConstants.DEFAULT_SEGMENTED_QUEUE_SEGMENT_SIZE);
             try {
-                queueRepository = new SegmentQueueRepository(dataPath);
+                queueRepository = new SegmentQueueRepository(dataPath, pageSize, segmentSize);
             } catch (QueueException e) {
                 throw new IOException("Problem in configuring persistent queue on path " + dataPath, e);
             }

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -187,6 +187,10 @@ class Session {
         return status.compareAndSet(expected, newState);
     }
 
+    boolean hasState(SessionStatus expectedStatus) {
+        return status.get() == expectedStatus;
+    }
+
     public void closeImmediately() {
         mqttConnection.dropConnection();
         mqttConnection = null;

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -264,7 +264,7 @@ public class SessionRegistry {
 
     void connectionClosed(Session session) {
         session.disconnect();
-        if (session.expireImmediately()) {
+        if (session.expireImmediately()&& !session.hasState(SessionStatus.DESTROYED)) {
             purgeSessionState(session);
             return;
         } else {

--- a/broker/src/main/java/io/moquette/broker/unsafequeues/Queue.java
+++ b/broker/src/main/java/io/moquette/broker/unsafequeues/Queue.java
@@ -26,6 +26,7 @@ public class Queue {
     private Segment tailSegment;
 
     private final QueuePool queuePool;
+    private final SegmentAllocator allocator;
     private final PagedFilesAllocator.AllocationListener allocationListener;
 //    private final ReentrantLock lock = new ReentrantLock();
 
@@ -37,6 +38,7 @@ public class Queue {
         this.currentHeadPtr = currentHeadPtr;
         this.currentTailPtr = currentTailPtr;
         this.tailSegment = tailSegment;
+        this.allocator = allocator;
         this.allocationListener = allocationListener;
         this.queuePool = queuePool;
     }
@@ -91,7 +93,7 @@ public class Queue {
             //notify segment creation for queue in queue pool
             allocationListener.segmentedCreated(name, newSegment);
 
-            int copySize = (int) Math.min(rawData.remaining(), Segment.SIZE);
+            int copySize = (int) Math.min(rawData.remaining(), allocator.getSegmentSize());
             ByteBuffer slice = rawData.slice();
             slice.limit(copySize);
 
@@ -291,7 +293,7 @@ public class Queue {
     }
 
     private int segmentCountFromSize(int remaining) {
-        return (int) Math.ceil((double) remaining / Segment.SIZE);
+        return (int) Math.ceil((double) remaining / allocator.getSegmentSize());
     }
 
     private boolean isTailFirstUsage(VirtualPointer tail) {

--- a/broker/src/main/java/io/moquette/broker/unsafequeues/Queue.java
+++ b/broker/src/main/java/io/moquette/broker/unsafequeues/Queue.java
@@ -166,6 +166,9 @@ public class Queue {
             // head and tail pointer are the same, the queue is empty
             return Optional.empty();
         }
+        if (tailSegment == null) {
+            tailSegment = queuePool.openNextTailSegment(name);
+        }
 
         LOG.debug("currentTail is {}", currentTailPtr);
         if (containsHeader(tailSegment, currentTailPtr)) {
@@ -258,10 +261,9 @@ public class Queue {
             createdBuffers.add(buffer);
             final boolean segmentCompletelyConsumed = (segment.bytesAfter(scan) + 1) == availableDataLength;
             scan = scan.moveForward(availableDataLength);
-            final boolean consumedQueue = scan.isGreaterThan(currentHead());
             remaining -= buffer.remaining();
 
-            if (remaining > 0 || (segmentCompletelyConsumed && !consumedQueue)) {
+            if (remaining > 0 || segmentCompletelyConsumed) {
                 queuePool.consumedTailSegment(name);
                 if (QueuePool.queueDebug) {
                     segment.fillWith((byte) 'D');

--- a/broker/src/main/java/io/moquette/broker/unsafequeues/QueuePool.java
+++ b/broker/src/main/java/io/moquette/broker/unsafequeues/QueuePool.java
@@ -32,7 +32,7 @@ public class QueuePool {
 
     static final boolean queueDebug = Boolean.parseBoolean(System.getProperty("moquette.queue.debug", "false"));
 
-    private static SegmentAllocationCallback callback;
+    private final SegmentAllocationCallback callback;
 
     // visible for testing
     static class SegmentRef implements Comparable<SegmentRef> {
@@ -103,6 +103,7 @@ public class QueuePool {
         this.allocator = allocator;
         this.dataPath = dataPath;
         this.segmentSize = segmentSize;
+        this.callback = new SegmentAllocationCallback(this);
     }
 
     private static class SegmentAllocationCallback implements PagedFilesAllocator.AllocationListener {
@@ -141,7 +142,6 @@ public class QueuePool {
         final PagedFilesAllocator allocator = new PagedFilesAllocator(dataPath, pageSize, segmentSize, lastPage, lastSegment);
 
         final QueuePool queuePool = new QueuePool(allocator, dataPath, segmentSize);
-        callback = new SegmentAllocationCallback(queuePool);
         queuePool.loadQueueDefinitions(checkpointProps);
         LOG.debug("Loaded queues definitions: {}", queuePool.queueSegments);
 

--- a/broker/src/main/java/io/moquette/broker/unsafequeues/QueuePool.java
+++ b/broker/src/main/java/io/moquette/broker/unsafequeues/QueuePool.java
@@ -435,8 +435,7 @@ public class QueuePool {
 
         final SegmentRef pollSegment = segmentRefs.peekLast();
         if (pollSegment == null) {
-            LOG.error("Queue segments is empty for queue {}, segment references: {}", queueName, segmentRefs);
-            throw new IllegalStateException("Opening tail segment can't never go in empty queue, because it's checked upfront in Queue");
+            return null;
         }
 
         final Path pageFile = dataPath.resolve(String.format("%d.page", pollSegment.pageId));

--- a/broker/src/main/java/io/moquette/broker/unsafequeues/Segment.java
+++ b/broker/src/main/java/io/moquette/broker/unsafequeues/Segment.java
@@ -52,9 +52,9 @@ final class Segment {
     // fill the segment with value bytes
     void fillWith(byte value) {
         LOG.debug("Wipe segment {}", this);
-        final ByteBuffer buffer = (ByteBuffer) mappedBuffer.position(this.begin.offset());
-        for (int i = 0; i < Segment.SIZE; i++) {
-            buffer.put(i, value);
+        final int target = begin.offset()+Segment.SIZE;
+        for (int i = begin.offset(); i < target; i++) {
+            mappedBuffer.put(i, value);
         }
     }
 

--- a/broker/src/main/java/io/moquette/broker/unsafequeues/Segment.java
+++ b/broker/src/main/java/io/moquette/broker/unsafequeues/Segment.java
@@ -44,9 +44,12 @@ final class Segment {
     }
 
     void write(SegmentPointer offset, ByteBuffer content) {
-        final ByteBuffer buffer = (ByteBuffer) mappedBuffer.position(offset.offset());
         checkContentStartWith(content);
-        buffer.put(content);
+        final int startPos = offset.offset();
+        final int endPos = startPos + content.remaining();
+        for (int i = startPos; i < endPos; i++) {
+            mappedBuffer.put(i, content.get());
+        }
     }
 
     // fill the segment with value bytes
@@ -66,9 +69,11 @@ final class Segment {
     }
 
     void write(VirtualPointer offset, ByteBuffer content) {
-        final int pageOffset = rebasedOffset(offset);
-        final ByteBuffer buffer = (ByteBuffer) mappedBuffer.position(pageOffset);
-        buffer.put(content);
+        final int startPos = rebasedOffset(offset);
+        final int endPos = startPos + content.remaining();
+        for (int i = startPos; i < endPos; i++) {
+            mappedBuffer.put(i, content.get());
+        }
     }
 
     /**

--- a/broker/src/main/java/io/moquette/broker/unsafequeues/SegmentAllocator.java
+++ b/broker/src/main/java/io/moquette/broker/unsafequeues/SegmentAllocator.java
@@ -18,4 +18,18 @@ interface SegmentAllocator {
     void close() throws QueueException;
 
     void dumpState(Properties checkpoint);
+
+    /**
+     * Get the size of a page that this allocator uses.
+     *
+     * @return the size of a page that this allocator uses.
+     */
+    int getPageSize();
+
+    /**
+     * Get the size of a segment that this allocator uses.
+     *
+     * @return the size of a segment that this allocator uses.
+     */
+    int getSegmentSize();
 }

--- a/broker/src/main/java/io/moquette/broker/unsafequeues/VirtualPointer.java
+++ b/broker/src/main/java/io/moquette/broker/unsafequeues/VirtualPointer.java
@@ -16,8 +16,8 @@ public class VirtualPointer implements Comparable<VirtualPointer> {
         return Long.compare(logicalOffset, other.logicalOffset);
     }
 
-    public long segmentOffset() {
-        return logicalOffset % Segment.SIZE;
+    public long segmentOffset(int segmentSize) {
+        return logicalOffset % segmentSize;
     }
 
     public long logicalOffset() {

--- a/broker/src/main/java/io/moquette/persistence/SegmentPersistentQueue.java
+++ b/broker/src/main/java/io/moquette/persistence/SegmentPersistentQueue.java
@@ -49,9 +49,7 @@ public class SegmentPersistentQueue extends AbstractSessionMessageQueue<SessionR
         private void writePayload(ByteBuffer target, ByteBuf source) {
             final int payloadSize = source.readableBytes();
             byte[] rawBytes = new byte[payloadSize];
-            final int pinPoint = source.readerIndex();
-            source.readBytes(rawBytes).release();
-            source.readerIndex(pinPoint);
+            source.duplicate().readBytes(rawBytes).release();
             target.putInt(payloadSize);
             target.put(rawBytes);
         }

--- a/broker/src/main/java/io/moquette/persistence/SegmentPersistentQueue.java
+++ b/broker/src/main/java/io/moquette/persistence/SegmentPersistentQueue.java
@@ -49,7 +49,9 @@ public class SegmentPersistentQueue extends AbstractSessionMessageQueue<SessionR
         private void writePayload(ByteBuffer target, ByteBuf source) {
             final int payloadSize = source.readableBytes();
             byte[] rawBytes = new byte[payloadSize];
-            source.duplicate().readBytes(rawBytes).release();
+            final int pinPoint = source.readerIndex();
+            source.readBytes(rawBytes).release();
+            source.readerIndex(pinPoint);
             target.putInt(payloadSize);
             target.put(rawBytes);
         }

--- a/broker/src/main/java/io/moquette/persistence/SegmentQueueRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/SegmentQueueRepository.java
@@ -19,12 +19,12 @@ public class SegmentQueueRepository implements IQueueRepository {
 
     private final QueuePool queuePool;
 
-    public SegmentQueueRepository(String path) throws QueueException {
-        queuePool = QueuePool.loadQueues(Paths.get(path));
+    public SegmentQueueRepository(String path, int pageSize, int segmentSize) throws QueueException {
+        queuePool = QueuePool.loadQueues(Paths.get(path), pageSize, segmentSize);
     }
 
-    public SegmentQueueRepository(Path path) throws QueueException {
-        queuePool = QueuePool.loadQueues(path);
+    public SegmentQueueRepository(Path path, int pageSize, int segmentSize) throws QueueException {
+        queuePool = QueuePool.loadQueues(path, pageSize, segmentSize);
     }
 
     @Override

--- a/broker/src/test/java/io/moquette/broker/unsafequeues/DummySegmentAllocator.java
+++ b/broker/src/test/java/io/moquette/broker/unsafequeues/DummySegmentAllocator.java
@@ -1,5 +1,6 @@
 package io.moquette.broker.unsafequeues;
 
+import io.moquette.BrokerConstants;
 import java.io.IOException;
 import java.nio.MappedByteBuffer;
 import java.util.Properties;
@@ -10,7 +11,7 @@ public class DummySegmentAllocator implements SegmentAllocator {
     public Segment nextFreeSegment() {
         final MappedByteBuffer pageBuffer = createFreshPageTmpTile();
         final SegmentPointer begin = new SegmentPointer(0, 0);
-        final SegmentPointer end = new SegmentPointer(0, Segment.SIZE);
+        final SegmentPointer end = new SegmentPointer(0, BrokerConstants.DEFAULT_SEGMENTED_QUEUE_SEGMENT_SIZE);
         return new Segment(pageBuffer, begin, end);
     }
 
@@ -18,7 +19,7 @@ public class DummySegmentAllocator implements SegmentAllocator {
     public Segment reopenSegment(int pageId, int beginOffset) throws QueueException {
         final MappedByteBuffer pageBuffer = createFreshPageTmpTile();
         final SegmentPointer begin = new SegmentPointer(pageId, beginOffset);
-        final SegmentPointer end = new SegmentPointer(pageId, beginOffset + Segment.SIZE);
+        final SegmentPointer end = new SegmentPointer(pageId, beginOffset + BrokerConstants.DEFAULT_SEGMENTED_QUEUE_SEGMENT_SIZE);
         return new Segment(pageBuffer, begin, end);
     }
 
@@ -40,5 +41,15 @@ public class DummySegmentAllocator implements SegmentAllocator {
 
     @Override
     public void dumpState(Properties checkpoint) {
+    }
+
+    @Override
+    public int getPageSize() {
+        return BrokerConstants.DEFAULT_SEGMENTED_QUEUE_PAGE_SIZE;
+    }
+
+    @Override
+    public int getSegmentSize() {
+        return BrokerConstants.DEFAULT_SEGMENTED_QUEUE_SEGMENT_SIZE;
     }
 }

--- a/broker/src/test/java/io/moquette/broker/unsafequeues/Utils.java
+++ b/broker/src/test/java/io/moquette/broker/unsafequeues/Utils.java
@@ -22,10 +22,10 @@ class Utils {
         return fileChannel.map(FileChannel.MapMode.READ_WRITE, 0, size);
     }
 
-    static MappedByteBuffer openPageFile(Path pageFile) throws IOException {
+    static MappedByteBuffer openPageFile(Path pageFile, int pageSize) throws IOException {
         final OpenOption[] openOptions = {StandardOpenOption.READ, StandardOpenOption.TRUNCATE_EXISTING};
         FileChannel fileChannel = FileChannel.open(pageFile, openOptions);
-        return fileChannel.map(FileChannel.MapMode.READ_ONLY, 0, PagedFilesAllocator.PAGE_SIZE);
+        return fileChannel.map(FileChannel.MapMode.READ_ONLY, 0, pageSize);
     }
 
     static String bufferToString(ByteBuffer buffer) {

--- a/broker/src/test/java/io/moquette/persistence/SegmentPersistentQueueTest.java
+++ b/broker/src/test/java/io/moquette/persistence/SegmentPersistentQueueTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+package io.moquette.persistence;
+
+import io.moquette.broker.SessionMessageQueue;
+import io.moquette.broker.SessionRegistry;
+import io.moquette.broker.SessionRegistry.EnqueuedMessage;
+import io.moquette.broker.subscriptions.Topic;
+import io.moquette.broker.unsafequeues.QueueException;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SegmentPersistentQueueTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SegmentPersistentQueueTest.class.getName());
+
+    private static SegmentQueueRepository queueRepository;
+    List<SessionMessageQueue<EnqueuedMessage>> queues = new ArrayList<>();
+
+    private int queueIndex = 0;
+    private static final String QUEUE_NAME = "test";
+
+    @TempDir
+    static Path tempQueueFolder;
+
+    @BeforeAll
+    public static void beforeAll() throws IOException, QueueException {
+        queueRepository = new SegmentQueueRepository(tempQueueFolder.toFile().getAbsolutePath());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        for (SessionMessageQueue<EnqueuedMessage> queue : queues) {
+            queue.closeAndPurge();
+        }
+        queues.clear();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        queueRepository.close();
+
+    }
+
+    private SessionMessageQueue<EnqueuedMessage> createQueue() {
+        SessionMessageQueue<EnqueuedMessage> queue = queueRepository.getOrCreateQueue(QUEUE_NAME + (queueIndex++));
+        queues.add(queue);
+        return queue;
+    }
+
+    private static void createAndAddToQueue(SessionMessageQueue<EnqueuedMessage> queue, String message) {
+        final SessionRegistry.PublishedMessage msg1 = createMessage(message);
+        msg1.retain();
+        queue.enqueue(msg1);
+        msg1.release();
+    }
+
+    private void createAndAddToQueues(String message) {
+        final SessionRegistry.PublishedMessage msg1 = createMessage(message);
+        for (SessionMessageQueue<EnqueuedMessage> queue : queues) {
+            msg1.retain();
+            queue.enqueue(msg1);
+        }
+        msg1.release();
+    }
+
+    private void assertAllEmpty(String message) {
+        for (SessionMessageQueue<EnqueuedMessage> queue : queues) {
+            assertTrue(queue.isEmpty(), message);
+        }
+    }
+
+    private void assertAllNonEmpty(String message) {
+        for (SessionMessageQueue<EnqueuedMessage> queue : queues) {
+            assertFalse(queue.isEmpty(), message);
+        }
+    }
+
+    private void dequeueFromAll(String expected) {
+        for (SessionMessageQueue<EnqueuedMessage> queue : queues) {
+            final SessionRegistry.PublishedMessage mesg = (SessionRegistry.PublishedMessage) queue.dequeue();
+            assertEquals(expected, mesg.getTopic().toString());
+        }
+    }
+
+    @Test
+    public void testAdd() {
+        LOGGER.info("testAdd");
+        SessionMessageQueue<EnqueuedMessage> queue = queueRepository.getOrCreateQueue("testAdd");
+        queues.add(queue);
+        assertTrue(queue.isEmpty(), "Queue must start empty.");
+        createAndAddToQueue(queue, "Hello");
+        assertFalse(queue.isEmpty(), "Queue must not be empty after adding.");
+        createAndAddToQueue(queue, "world");
+        assertFalse(queue.isEmpty(), "Queue must not be empty after adding.");
+
+        assertEquals("Hello", ((SessionRegistry.PublishedMessage) queue.dequeue()).getTopic().toString());
+        assertEquals("world", ((SessionRegistry.PublishedMessage) queue.dequeue()).getTopic().toString());
+        assertAllEmpty("After dequeueing all, queue must be empty");
+
+        createAndAddToQueue(queue, "Hello");
+        assertFalse(queue.isEmpty(), "Queue must not be empty after adding.");
+        assertEquals("Hello", ((SessionRegistry.PublishedMessage) queue.dequeue()).getTopic().toString());
+        assertAllEmpty("After dequeueing all, queue must be empty");
+    }
+
+    @Test
+    public void testAdd2() {
+        LOGGER.info("testAdd2");
+        testAddX(2);
+    }
+
+    @Test
+    public void testAdd10() {
+        LOGGER.info("testAdd10");
+        testAddX(10);
+    }
+
+    public void testAddX(int x) {
+        for (int i = 0; i < x; i++) {
+            createQueue();
+        }
+        assertAllEmpty("Queue must start empty.");
+
+        createAndAddToQueues("Hello");
+        assertAllNonEmpty("Queue must not be empty after adding.");
+
+        createAndAddToQueues("world");
+        assertAllNonEmpty("Queue must not be empty after adding.");
+
+        dequeueFromAll("Hello");
+        assertAllNonEmpty("After dequeueing one, queue must not be empty");
+
+        createAndAddToQueues("crazy");
+        assertAllNonEmpty("Queue must not be empty after adding.");
+
+        dequeueFromAll("world");
+        assertAllNonEmpty("Queue must not be empty after adding.");
+
+        dequeueFromAll("crazy");
+        assertAllEmpty("After dequeueing all, queue must be empty");
+    }
+
+    private static SessionRegistry.PublishedMessage createMessage(String name) {
+        final ByteBuf payload = Unpooled.wrappedBuffer(name.getBytes(StandardCharsets.UTF_8));
+        return new SessionRegistry.PublishedMessage(Topic.asTopic(name), MqttQoS.AT_LEAST_ONCE, payload, false);
+    }
+
+    @Test
+    public void testPerformance() {
+        LOGGER.info("testPerformance");
+        SessionMessageQueue<EnqueuedMessage> queue = queueRepository.getOrCreateQueue("testPerformance");
+        queues.add(queue);
+        final int numIterations = 1_000_000;
+        final int perIteration = 10;
+        int count = 0;
+        int j = 0;
+        final String message = "Queue should have contained " + perIteration + " items";
+        try {
+            for (int i = 0; i < numIterations; i++) {
+                for (j = 0; j < perIteration; j++) {
+                    createAndAddToQueue(queue, "Hello");
+                    count++;
+                }
+                j = 0;
+                while (!queue.isEmpty()) {
+                    assertEquals("Hello", ((SessionRegistry.PublishedMessage) queue.dequeue()).getTopic().toString());
+                    j++;
+                }
+                assertEquals(perIteration, j, message);
+            }
+        } catch (Exception ex) {
+            Assertions.fail("Failed on count " + count + ", j " + j, ex);
+        }
+        assertTrue(queue.isEmpty(), "should be empty");
+    }
+
+    @Test
+    public void testReloadFromPersistedState() {
+        LOGGER.info("testReloadFromPersistedState");
+        SessionMessageQueue<EnqueuedMessage> queue = queueRepository.getOrCreateQueue("testReloadFromPersistedState");
+        queues.add(queue);
+        createAndAddToQueue(queue, "Hello");
+        createAndAddToQueue(queue, "crazy");
+        createAndAddToQueue(queue, "world");
+        assertEquals("Hello", ((SessionRegistry.PublishedMessage) queue.dequeue()).getTopic().toString());
+
+        queue = queueRepository.getOrCreateQueue("testReloadFromPersistedState");
+
+        assertEquals("crazy", ((SessionRegistry.PublishedMessage) queue.dequeue()).getTopic().toString());
+        assertEquals("world", ((SessionRegistry.PublishedMessage) queue.dequeue()).getTopic().toString());
+        assertTrue(queue.isEmpty(), "should be empty");
+    }
+}


### PR DESCRIPTION
Other threads may be reading the same buffer, so we must ensure we have our own reading position and mark.

An alternative solution would be to have [PostOffice.publish2Subscribers()](https://github.com/moquette-io/moquette/blob/main/broker/src/main/java/io/moquette/broker/PostOffice.java#L467) somehow create a duplicate for each thread.