### PR TITLE
Implement and use a Session data storage

### DIFF
--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -167,6 +167,12 @@
             <version>${h2.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>RELEASE</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/broker/src/main/java/io/moquette/broker/ISessionsRepository.java
+++ b/broker/src/main/java/io/moquette/broker/ISessionsRepository.java
@@ -1,0 +1,77 @@
+package io.moquette.broker;
+
+import io.netty.handler.codec.mqtt.MqttVersion;
+
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Objects;
+
+/**
+ * Used to store data about persisted sessions like MQTT version, session's properties.
+ * */
+public interface ISessionsRepository {
+
+    // Data class
+    final class SessionData {
+        private final String clientId;
+        private final Instant created;
+        final MqttVersion version;
+        final long expiryInterval;
+
+        public SessionData(String clientId, Instant created, MqttVersion version, long expiryInterval) {
+            this.clientId = clientId;
+            this.created = created;
+            this.version = version;
+            this.expiryInterval = expiryInterval;
+        }
+
+        public String clientId() {
+            return clientId;
+        }
+
+        public MqttVersion protocolVersion() {
+            return version;
+        }
+
+        public Instant created() {
+            return created;
+        }
+
+        public long expiryInterval() {
+            return expiryInterval;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            SessionData that = (SessionData) o;
+            return clientId.equals(that.clientId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(clientId);
+        }
+
+        @Override
+        public String toString() {
+            return "SessionData{" +
+                "clientId='" + clientId + '\'' +
+                ", created=" + created +
+                ", version=" + version +
+                ", expiryInterval=" + expiryInterval +
+                '}';
+        }
+    }
+
+    /**
+     * @return the full list of persisted sessions data.
+     * */
+    Collection<SessionData> list();
+
+    /**
+     * Save data composing a session, es MQTT version, creation date and properties but not queues or subscriptions.
+     * */
+    void saveSession(SessionData session);
+}

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -28,7 +28,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -46,7 +49,9 @@ import java.util.concurrent.atomic.AtomicReference;
 class Session {
 
     private static final Logger LOG = LoggerFactory.getLogger(Session.class);
-    static final int INFINITE_EXPIRY = 0xFFFFFFFF;
+    // By specification session expiry value of 0xFFFFFFFF (UINT_MAX) (seconds) means
+    // session that doesn't expire, it's ~136 years, we can set a cap at 100 year
+    static final int INFINITE_EXPIRY = (int) Duration.of(100, ChronoUnit.YEARS).toMillis() / 1000;
 
     static class InFlightPacket implements Delayed {
 

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -46,6 +46,7 @@ import java.util.concurrent.atomic.AtomicReference;
 class Session {
 
     private static final Logger LOG = LoggerFactory.getLogger(Session.class);
+    static final int INFINITE_EXPIRY = 0xFFFFFFFF;
 
     static class InFlightPacket implements Delayed {
 
@@ -123,7 +124,7 @@ class Session {
         this.sessionQueue = sessionQueue;
         this.created = Instant.now();
         // in MQTT3 cleanSession = true means  expiryInterval=0 else infinite
-        expiryInterval = clean ? 0 : 0xFFFFFFFF;
+        expiryInterval = clean ? 0 : INFINITE_EXPIRY;
     }
 
     public boolean expireImmediately() {

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -22,16 +22,18 @@ import io.moquette.broker.SessionRegistry.PublishedMessage;
 import io.moquette.broker.subscriptions.Subscription;
 import io.moquette.broker.subscriptions.Topic;
 import io.netty.buffer.ByteBuf;
-import io.netty.handler.codec.mqtt.*;
+import io.netty.handler.codec.mqtt.MqttFixedHeader;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttMessageType;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttPublishVariableHeader;
+import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.util.ReferenceCountUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.time.Duration;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -101,7 +103,6 @@ class Session {
         }
     }
 
-    private final String clientId;
     private boolean clean;
     private Will will;
     private final SessionMessageQueue<SessionRegistry.EnqueuedMessage> sessionQueue;
@@ -112,28 +113,24 @@ class Session {
     private final DelayQueue<InFlightPacket> inflightTimeouts = new DelayQueue<>();
     private final Map<Integer, MqttPublishMessage> qos2Receiving = new HashMap<>();
     private final AtomicInteger inflightSlots = new AtomicInteger(INFLIGHT_WINDOW_SIZE); // this should be configurable
-    private final Instant created;
-    private final int expiryInterval;
+    private final ISessionsRepository.SessionData data;
 
-    Session(String clientId, boolean clean, Will will, SessionMessageQueue<SessionRegistry.EnqueuedMessage> sessionQueue) {
-        this(clientId, clean, sessionQueue);
+    Session(ISessionsRepository.SessionData data, boolean clean, Will will, SessionMessageQueue<SessionRegistry.EnqueuedMessage> sessionQueue) {
+        this(data, clean, sessionQueue);
         this.will = will;
     }
 
-    Session(String clientId, boolean clean, SessionMessageQueue<SessionRegistry.EnqueuedMessage> sessionQueue) {
+    Session(ISessionsRepository.SessionData data, boolean clean, SessionMessageQueue<SessionRegistry.EnqueuedMessage> sessionQueue) {
         if (sessionQueue == null) {
             throw new IllegalArgumentException("sessionQueue parameter can't be null");
         }
-        this.clientId = clientId;
+        this.data = data;
         this.clean = clean;
         this.sessionQueue = sessionQueue;
-        this.created = Instant.now();
-        // in MQTT3 cleanSession = true means  expiryInterval=0 else infinite
-        expiryInterval = clean ? 0 : INFINITE_EXPIRY;
     }
 
     public boolean expireImmediately() {
-        return expiryInterval == 0;
+        return data.expiryInterval() == 0;
     }
 
     void update(boolean clean, Will will) {
@@ -166,7 +163,7 @@ class Session {
     }
 
     public String getClientID() {
-        return clientId;
+        return data.clientId();
     }
 
     public List<Subscription> getSubscriptions() {
@@ -178,7 +175,7 @@ class Session {
     }
 
     public void removeSubscription(Topic topic) {
-        subscriptions.remove(new Subscription(clientId, topic, MqttQoS.EXACTLY_ONCE));
+        subscriptions.remove(new Subscription(data.clientId(), topic, MqttQoS.EXACTLY_ONCE));
     }
 
     public boolean hasWill() {
@@ -508,7 +505,7 @@ class Session {
     @Override
     public String toString() {
         return "Session{" +
-            "clientId='" + clientId + '\'' +
+            "clientId='" + data.clientId() + '\'' +
             ", clean=" + clean +
             ", status=" + status +
             ", inflightSlots=" + inflightSlots +

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -51,7 +51,7 @@ class Session {
     private static final Logger LOG = LoggerFactory.getLogger(Session.class);
     // By specification session expiry value of 0xFFFFFFFF (UINT_MAX) (seconds) means
     // session that doesn't expire, it's ~136 years, we can set a cap at 100 year
-    static final int INFINITE_EXPIRY = (int) Duration.of(100, ChronoUnit.YEARS).toMillis() / 1000;
+    static final int INFINITE_EXPIRY = (int) Duration.ofDays(80 * 365).toMillis() / 1000;
 
     static class InFlightPacket implements Delayed {
 

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -243,7 +243,7 @@ public class SessionRegistry {
         }
 
         newSession.markConnecting();
-        sessionsRepository.saveSession(new ISessionsRepository.SessionData(clientId, Instant.now(), MqttVersion.MQTT_3_1_1, INFINITE_EXPIRY));
+        sessionsRepository.saveSession(new ISessionsRepository.SessionData(clientId, MqttVersion.MQTT_3_1_1, INFINITE_EXPIRY));
         return newSession;
     }
 

--- a/broker/src/main/java/io/moquette/persistence/H2Builder.java
+++ b/broker/src/main/java/io/moquette/persistence/H2Builder.java
@@ -2,6 +2,7 @@ package io.moquette.persistence;
 
 import io.moquette.broker.IQueueRepository;
 import io.moquette.broker.IRetainedRepository;
+import io.moquette.broker.ISessionsRepository;
 import io.moquette.broker.ISubscriptionsRepository;
 import org.h2.mvstore.MVStore;
 import org.slf4j.Logger;
@@ -71,5 +72,9 @@ public class H2Builder {
 
     public IRetainedRepository retainedRepository() {
         return new H2RetainedRepository(mvStore);
+    }
+
+    public ISessionsRepository sessionsRepository() {
+        return new H2SessionsRepository(mvStore);
     }
 }

--- a/broker/src/main/java/io/moquette/persistence/H2SessionsRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/H2SessionsRepository.java
@@ -1,0 +1,80 @@
+package io.moquette.persistence;
+
+import io.moquette.broker.ISessionsRepository;
+import io.netty.handler.codec.mqtt.MqttVersion;
+import org.h2.mvstore.MVMap;
+import org.h2.mvstore.MVStore;
+import org.h2.mvstore.WriteBuffer;
+import org.h2.mvstore.type.BasicDataType;
+import org.h2.mvstore.type.StringDataType;
+
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.Collection;
+
+class H2SessionsRepository implements ISessionsRepository {
+
+    private final MVMap<String, SessionData> sessionMap;
+
+    public H2SessionsRepository(MVStore mvStore) {
+        final MVMap.Builder<String, ISessionsRepository.SessionData> sessionTypeBuilder =
+            new MVMap.Builder<String, ISessionsRepository.SessionData>()
+                .valueType(new SessionDataValueType());
+
+        this.sessionMap = mvStore.openMap("sessions_store", sessionTypeBuilder);
+    }
+
+    @Override
+    public Collection<SessionData> list() {
+        return sessionMap.values();
+    }
+
+    @Override
+    public void saveSession(SessionData session) {
+        sessionMap.put(session.clientId(), session);
+    }
+
+    /**
+     * Codec data type to load and store SessionData instances
+     */
+    private final class SessionDataValueType extends BasicDataType<SessionData> {
+
+        private final StringDataType stringDataType = new StringDataType();
+
+        @Override
+        public int getMemory(SessionData obj) {
+            return stringDataType.getMemory(obj.clientId()) + 8 + 1 + 8;
+        }
+
+        @Override
+        public void write(WriteBuffer buff, SessionData obj) {
+            stringDataType.write(buff, obj.clientId());
+            buff.putLong(obj.created().toEpochMilli());
+            buff.put(obj.protocolVersion().protocolLevel());
+            buff.putLong(obj.expiryInterval());
+        }
+
+        @Override
+        public SessionData read(ByteBuffer buff) {
+            final String clientId = stringDataType.read(buff);
+            final long created = buff.getLong();
+            final byte rawVersion = buff.get();
+            final MqttVersion version;
+            switch (rawVersion) {
+                case 3: version = MqttVersion.MQTT_3_1; break;
+                case 4: version = MqttVersion.MQTT_3_1_1; break;
+                case 5: version = MqttVersion.MQTT_5; break;
+                default:
+                    throw new IllegalArgumentException("Unrecognized MQTT version value " + rawVersion);
+            }
+            final long expiryInterval = buff.getLong();
+
+            return new SessionData(clientId, Instant.ofEpochMilli(created), version, expiryInterval);
+        }
+
+        @Override
+        public SessionData[] createStorage(int i) {
+            return new SessionData[i];
+        }
+    }
+}

--- a/broker/src/main/java/io/moquette/persistence/MemorySessionsRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/MemorySessionsRepository.java
@@ -1,0 +1,22 @@
+package io.moquette.persistence;
+
+import io.moquette.broker.ISessionsRepository;
+
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class MemorySessionsRepository implements ISessionsRepository {
+
+    private final ConcurrentMap<String, SessionData> sessions = new ConcurrentHashMap<>();
+
+    @Override
+    public Collection<SessionData> list() {
+        return sessions.values();
+    }
+
+    @Override
+    public void saveSession(SessionData session) {
+        sessions.put(session.clientId(), session);
+    }
+}

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
 
+import static io.moquette.broker.MQTTConnectionPublishTest.inMemorySessionsRepository;
 import static io.moquette.broker.NettyChannelAssertions.assertEqualsConnAck;
 import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.*;
 import static java.util.Collections.singleton;
@@ -70,7 +71,7 @@ public class MQTTConnectionConnectTest {
 
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
-        sessionRegistry = new SessionRegistry(subscriptions, queueRepository, permitAll);
+        sessionRegistry = new SessionRegistry(subscriptions, inMemorySessionsRepository(), queueRepository, permitAll);
         postOffice = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
                                     ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
 

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
 
-import static io.moquette.broker.MQTTConnectionPublishTest.inMemorySessionsRepository;
+import static io.moquette.broker.MQTTConnectionPublishTest.memorySessionsRepository;
 import static io.moquette.broker.NettyChannelAssertions.assertEqualsConnAck;
 import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.*;
 import static java.util.Collections.singleton;
@@ -71,7 +71,7 @@ public class MQTTConnectionConnectTest {
 
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
-        sessionRegistry = new SessionRegistry(subscriptions, inMemorySessionsRepository(), queueRepository, permitAll);
+        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll);
         postOffice = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
                                     ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
 

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
@@ -19,6 +19,7 @@ import io.moquette.broker.security.PermitAllAuthorizatorPolicy;
 import io.moquette.broker.subscriptions.CTrieSubscriptionDirectory;
 import io.moquette.broker.subscriptions.ISubscriptionsDirectory;
 import io.moquette.broker.security.IAuthenticator;
+import io.moquette.persistence.MemorySessionsRepository;
 import io.moquette.persistence.MemorySubscriptionsRepository;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -28,6 +29,7 @@ import io.netty.handler.codec.mqtt.MqttMessageBuilders;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.handler.codec.mqtt.MqttVersion;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -76,10 +78,15 @@ public class MQTTConnectionPublishTest {
 
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
-        sessionRegistry = new SessionRegistry(subscriptions, queueRepository, permitAll);
+        sessionRegistry = new SessionRegistry(subscriptions, inMemorySessionsRepository(), queueRepository, permitAll);
         final PostOffice postOffice = new PostOffice(subscriptions,
             new MemoryRetainedRepository(), sessionRegistry, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
         return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, postOffice);
+    }
+
+    @NotNull
+    static ISessionsRepository inMemorySessionsRepository() {
+        return new MemorySessionsRepository();
     }
 
     @Test

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
@@ -78,14 +78,14 @@ public class MQTTConnectionPublishTest {
 
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
-        sessionRegistry = new SessionRegistry(subscriptions, inMemorySessionsRepository(), queueRepository, permitAll);
+        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll);
         final PostOffice postOffice = new PostOffice(subscriptions,
             new MemoryRetainedRepository(), sessionRegistry, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
         return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, postOffice);
     }
 
     @NotNull
-    static ISessionsRepository inMemorySessionsRepository() {
+    static ISessionsRepository memorySessionsRepository() {
         return new MemorySessionsRepository();
     }
 

--- a/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import static io.moquette.broker.MQTTConnectionPublishTest.inMemorySessionsRepository;
 import static io.moquette.broker.PostOfficeUnsubscribeTest.CONFIG;
 import static io.netty.handler.codec.mqtt.MqttQoS.*;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -89,7 +90,7 @@ public class PostOfficeInternalPublishTest {
 
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
-        sessionRegistry = new SessionRegistry(subscriptions, queueRepository, permitAll);
+        sessionRegistry = new SessionRegistry(subscriptions, inMemorySessionsRepository(), queueRepository, permitAll);
         sut = new PostOffice(subscriptions, retainedRepository, sessionRegistry,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
     }

--- a/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
@@ -32,7 +32,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static io.moquette.broker.MQTTConnectionPublishTest.inMemorySessionsRepository;
+import static io.moquette.broker.MQTTConnectionPublishTest.memorySessionsRepository;
 import static io.moquette.broker.PostOfficeUnsubscribeTest.CONFIG;
 import static io.netty.handler.codec.mqtt.MqttQoS.*;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -90,7 +90,7 @@ public class PostOfficeInternalPublishTest {
 
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
-        sessionRegistry = new SessionRegistry(subscriptions, inMemorySessionsRepository(), queueRepository, permitAll);
+        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll);
         sut = new PostOffice(subscriptions, retainedRepository, sessionRegistry,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
     }

--- a/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static io.moquette.broker.MQTTConnectionPublishTest.inMemorySessionsRepository;
 import static io.moquette.broker.PostOfficeUnsubscribeTest.CONFIG;
 import static io.netty.handler.codec.mqtt.MqttQoS.AT_LEAST_ONCE;
 import static io.netty.handler.codec.mqtt.MqttQoS.AT_MOST_ONCE;
@@ -103,7 +104,7 @@ public class PostOfficePublishTest {
 
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
-        sessionRegistry = new SessionRegistry(subscriptions, queueRepository, permitAll);
+        sessionRegistry = new SessionRegistry(subscriptions, inMemorySessionsRepository(), queueRepository, permitAll);
         sut = new PostOffice(subscriptions, retainedRepository, sessionRegistry,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
     }

--- a/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
@@ -38,7 +38,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static io.moquette.broker.MQTTConnectionPublishTest.inMemorySessionsRepository;
+import static io.moquette.broker.MQTTConnectionPublishTest.memorySessionsRepository;
 import static io.moquette.broker.PostOfficeUnsubscribeTest.CONFIG;
 import static io.netty.handler.codec.mqtt.MqttQoS.AT_LEAST_ONCE;
 import static io.netty.handler.codec.mqtt.MqttQoS.AT_MOST_ONCE;
@@ -104,7 +104,7 @@ public class PostOfficePublishTest {
 
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
-        sessionRegistry = new SessionRegistry(subscriptions, inMemorySessionsRepository(), queueRepository, permitAll);
+        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll);
         sut = new PostOffice(subscriptions, retainedRepository, sessionRegistry,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
     }

--- a/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static io.moquette.broker.MQTTConnectionPublishTest.inMemorySessionsRepository;
 import static io.moquette.broker.PostOfficePublishTest.ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID;
 import static io.moquette.broker.PostOfficePublishTest.SUBSCRIBER_ID;
 import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_ACCEPTED;
@@ -95,7 +96,7 @@ public class PostOfficeSubscribeTest {
 
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
-        sessionRegistry = new SessionRegistry(subscriptions, queueRepository, permitAll);
+        sessionRegistry = new SessionRegistry(subscriptions, inMemorySessionsRepository(), queueRepository, permitAll);
         sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
     }

--- a/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
@@ -38,7 +38,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static io.moquette.broker.MQTTConnectionPublishTest.inMemorySessionsRepository;
+import static io.moquette.broker.MQTTConnectionPublishTest.memorySessionsRepository;
 import static io.moquette.broker.PostOfficePublishTest.ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID;
 import static io.moquette.broker.PostOfficePublishTest.SUBSCRIBER_ID;
 import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_ACCEPTED;
@@ -96,7 +96,7 @@ public class PostOfficeSubscribeTest {
 
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
-        sessionRegistry = new SessionRegistry(subscriptions, inMemorySessionsRepository(), queueRepository, permitAll);
+        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll);
         sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
     }

--- a/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
@@ -27,7 +27,6 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.mqtt.*;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -38,7 +37,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static io.moquette.broker.MQTTConnectionPublishTest.inMemorySessionsRepository;
+import static io.moquette.broker.MQTTConnectionPublishTest.memorySessionsRepository;
 import static io.moquette.broker.PostOfficePublishTest.PUBLISHER_ID;
 import static io.netty.handler.codec.mqtt.MqttQoS.*;
 import static java.util.Collections.*;
@@ -88,7 +87,7 @@ public class PostOfficeUnsubscribeTest {
 
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
-        sessionRegistry = new SessionRegistry(subscriptions, inMemorySessionsRepository(), queueRepository, permitAll);
+        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll);
         sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
     }

--- a/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static io.moquette.broker.MQTTConnectionPublishTest.inMemorySessionsRepository;
 import static io.moquette.broker.PostOfficePublishTest.PUBLISHER_ID;
 import static io.netty.handler.codec.mqtt.MqttQoS.*;
 import static java.util.Collections.*;
@@ -87,7 +88,7 @@ public class PostOfficeUnsubscribeTest {
 
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
-        sessionRegistry = new SessionRegistry(subscriptions, queueRepository, permitAll);
+        sessionRegistry = new SessionRegistry(subscriptions, inMemorySessionsRepository(), queueRepository, permitAll);
         sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
     }

--- a/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
@@ -40,7 +40,7 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutionException;
 
-import static io.moquette.broker.MQTTConnectionPublishTest.inMemorySessionsRepository;
+import static io.moquette.broker.MQTTConnectionPublishTest.memorySessionsRepository;
 import static io.moquette.broker.NettyChannelAssertions.assertEqualsConnAck;
 import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_ACCEPTED;
 import static java.util.Collections.singleton;
@@ -86,7 +86,7 @@ public class SessionRegistryTest {
 
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
-        sut = new SessionRegistry(subscriptions, inMemorySessionsRepository(), queueRepository, permitAll);
+        sut = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll);
         final PostOffice postOffice = new PostOffice(subscriptions,
             new MemoryRetainedRepository(), sut, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
         return new MQTTConnection(channel, config, mockAuthenticator, sut, postOffice);

--- a/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutionException;
 
+import static io.moquette.broker.MQTTConnectionPublishTest.inMemorySessionsRepository;
 import static io.moquette.broker.NettyChannelAssertions.assertEqualsConnAck;
 import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_ACCEPTED;
 import static java.util.Collections.singleton;
@@ -85,7 +86,7 @@ public class SessionRegistryTest {
 
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
-        sut = new SessionRegistry(subscriptions, queueRepository, permitAll);
+        sut = new SessionRegistry(subscriptions, inMemorySessionsRepository(), queueRepository, permitAll);
         final PostOffice postOffice = new PostOffice(subscriptions,
             new MemoryRetainedRepository(), sut, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
         return new MQTTConnection(channel, config, mockAuthenticator, sut, postOffice);

--- a/broker/src/test/java/io/moquette/broker/SessionTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionTest.java
@@ -6,6 +6,7 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttVersion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -13,7 +14,10 @@ import static io.moquette.BrokerConstants.FLIGHT_BEFORE_RESEND_MS;
 import io.moquette.broker.subscriptions.Subscription;
 import java.util.Arrays;
 import org.assertj.core.api.Assertions;
-import static org.junit.jupiter.api.Assertions.*;
+
+import static io.moquette.broker.Session.INFINITE_EXPIRY;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class SessionTest {
 
@@ -27,7 +31,8 @@ public class SessionTest {
     public void setUp() {
         testChannel = new EmbeddedChannel();
         queuedMessages = new InMemoryQueue();
-        client = new Session(CLIENT_ID, true, null, queuedMessages);
+        final ISessionsRepository.SessionData data = new ISessionsRepository.SessionData(CLIENT_ID, MqttVersion.MQTT_3_1_1, INFINITE_EXPIRY);
+        client = new Session(data, true, null, queuedMessages);
         createConnection(client);
     }
 


### PR DESCRIPTION
Introduce the concept of SessionsRepository to store session's data that are not subscriptions or queues; those are already persisted with their repository instances.
This is a step to move to MQTT5 which benefit also the MQTT3 implementation.

## What does it do?
- introduce `ISessionRepository` interface and its H2 implementation
- the session data are stored in a new data class named `SessionData`
- implements serializitaion/deserialization of `SessionData` for H2

## Task list
- [x] Use `SessionData` reference inside `Session` for the data part, to avoid moving data between object instances
