### PR TITLE
Fix/unsafe queues

### DIFF
--- a/broker/src/main/java/io/moquette/broker/unsafequeues/Queue.java
+++ b/broker/src/main/java/io/moquette/broker/unsafequeues/Queue.java
@@ -187,8 +187,8 @@ public class Queue {
             // header size + payload size + 1
             final int fullMessageSize = payloadLength + LENGTH_HEADER_SIZE;
             long remainingInSegment = tailSegment.bytesAfter(existingTail) + 1;
-            if (remainingInSegment >= fullMessageSize + 1) {
-                // currentSegments contains fully the payload
+            if (remainingInSegment > fullMessageSize) {
+                // tail segment fully contains the payload with space left over
                 currentTailPtr = existingTail.moveForward(fullMessageSize);
                 // read data from currentTail + 4 bytes(the length)
                 final VirtualPointer dataStart = existingTail.moveForward(LENGTH_HEADER_SIZE);

--- a/broker/src/main/java/io/moquette/broker/unsafequeues/Segment.java
+++ b/broker/src/main/java/io/moquette/broker/unsafequeues/Segment.java
@@ -44,17 +44,20 @@ final class Segment {
     }
 
     void write(SegmentPointer offset, ByteBuffer content) {
-        final ByteBuffer buffer = (ByteBuffer) mappedBuffer.position(offset.offset());
         checkContentStartWith(content);
-        buffer.put(content);
+        final int startPos = offset.offset();
+        final int endPos = startPos + content.remaining();
+        for (int i = startPos; i < endPos; i++) {
+            mappedBuffer.put(i, content.get());
+        }
     }
 
     // fill the segment with value bytes
     void fillWith(byte value) {
         LOG.debug("Wipe segment {}", this);
-        final ByteBuffer buffer = (ByteBuffer) mappedBuffer.position(this.begin.offset());
-        for (int i = 0; i < size(); i++) {
-            buffer.put(i, value);
+        final int target = begin.offset() + (int)size();
+        for (int i = begin.offset(); i < target; i++) {
+            mappedBuffer.put(i, value);
         }
     }
 
@@ -66,9 +69,11 @@ final class Segment {
     }
 
     void write(VirtualPointer offset, ByteBuffer content) {
-        final int pageOffset = rebasedOffset(offset);
-        final ByteBuffer buffer = (ByteBuffer) mappedBuffer.position(pageOffset);
-        buffer.put(content);
+        final int startPos = rebasedOffset(offset);
+        final int endPos = startPos + content.remaining();
+        for (int i = startPos; i < endPos; i++) {
+            mappedBuffer.put(i, content.get());
+        }
     }
 
     /**

--- a/broker/src/test/java/io/moquette/persistence/SegmentPersistentQueueTest.java
+++ b/broker/src/test/java/io/moquette/persistence/SegmentPersistentQueueTest.java
@@ -181,7 +181,7 @@ public class SegmentPersistentQueueTest {
             char z = 'Z';
             char curChar = a;
             StringBuilder bodyString = new StringBuilder();
-            for (int i = 0; i < 104 + 81; i++) {
+            for (int i = 0; i < bodySize; i++) {
                 bodyString.append(curChar);
                 if (curChar == z) {
                     curChar = a;


### PR DESCRIPTION
This fixes various bugs in the unsafeQueue implementation, originally from #716 :
- Head and Tail segments misbehaved when a read or write finished at exactly a Segment boundary
- Removed calls to Segment.mappedBuffer.position(), since this buffer is shared across all Segments in a Page
- Wiping of Segments overwrote the wrong parts of the page
- QueuePool was static, preventing multiple queue instances from being used at the same time

This PR bases on #724 and #728
This PR is followed by #723