### PR TITLE
Fix/segment persistent queues

### DIFF
--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -507,9 +507,10 @@ class PostOffice {
     }
 
     private void publishToSession(ByteBuf payload, Topic topic, Collection<Subscription> subscriptions, MqttQoS publishingQos) {
+        ByteBuf duplicate = payload.duplicate();
         for (Subscription sub : subscriptions) {
             MqttQoS qos = lowerQosToTheSubscriptionDesired(sub, publishingQos);
-            publishToSession(payload, topic, sub, qos);
+            publishToSession(duplicate, topic, sub, qos);
         }
     }
 

--- a/broker/src/main/java/io/moquette/persistence/SegmentPersistentQueue.java
+++ b/broker/src/main/java/io/moquette/persistence/SegmentPersistentQueue.java
@@ -49,9 +49,7 @@ public class SegmentPersistentQueue extends AbstractSessionMessageQueue<SessionR
         private void writePayload(ByteBuffer target, ByteBuf source) {
             final int payloadSize = source.readableBytes();
             byte[] rawBytes = new byte[payloadSize];
-            final int pinPoint = source.readerIndex();
-            source.readBytes(rawBytes).release();
-            source.readerIndex(pinPoint);
+            source.duplicate().readBytes(rawBytes).release();
             target.putInt(payloadSize);
             target.put(rawBytes);
         }

--- a/broker/src/main/java/io/moquette/persistence/SegmentPersistentQueue.java
+++ b/broker/src/main/java/io/moquette/persistence/SegmentPersistentQueue.java
@@ -49,7 +49,9 @@ public class SegmentPersistentQueue extends AbstractSessionMessageQueue<SessionR
         private void writePayload(ByteBuffer target, ByteBuf source) {
             final int payloadSize = source.readableBytes();
             byte[] rawBytes = new byte[payloadSize];
-            source.duplicate().readBytes(rawBytes).release();
+            final int pinPoint = source.readerIndex();
+            source.readBytes(rawBytes).release();
+            source.readerIndex(pinPoint);
             target.putInt(payloadSize);
             target.put(rawBytes);
         }


### PR DESCRIPTION
This PR builds on #724, #728 and #722 and contains further fixes from #716:

- Make a copy of the message buffer (one for each command thread) so access patterns don't interfere across threads