### PR TITLE
Fix/configurable queue sizes

### DIFF
--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -32,6 +32,10 @@ public final class BrokerConstants {
     public static final String DATA_PATH_PROPERTY_NAME = "data_path";
     public static final String PERSISTENT_QUEUE_TYPE_PROPERTY_NAME = "persistent_queue_type"; // h2 or segmented, default h2
     public static final String PERSISTENCE_ENABLED_PROPERTY_NAME = "persistence_enabled"; // true or false, default true
+    public static final String SEGMENTED_QUEUE_PAGE_SIZE = "queue_page_size";
+    public static final int DEFAULT_SEGMENTED_QUEUE_PAGE_SIZE = 64 * 1024 * 1024;
+    public static final String SEGMENTED_QUEUE_SEGMENT_SIZE = "queue_segment_size";
+    public static final int DEFAULT_SEGMENTED_QUEUE_SEGMENT_SIZE = 4 * 1024 * 1024;
     public static final String AUTOSAVE_INTERVAL_PROPERTY_NAME = "autosave_interval";
     public static final String PASSWORD_FILE_PROPERTY_NAME = "password_file";
     public static final String PORT_PROPERTY_NAME = "port";

--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -33,9 +33,10 @@ public final class BrokerConstants {
     public static final String PERSISTENT_QUEUE_TYPE_PROPERTY_NAME = "persistent_queue_type"; // h2 or segmented, default h2
     public static final String PERSISTENCE_ENABLED_PROPERTY_NAME = "persistence_enabled"; // true or false, default true
     public static final String SEGMENTED_QUEUE_PAGE_SIZE = "queue_page_size";
-    public static final int DEFAULT_SEGMENTED_QUEUE_PAGE_SIZE = 64 * 1024 * 1024;
+    public static final int MB = 1024 * 1024;
+    public static final int DEFAULT_SEGMENTED_QUEUE_PAGE_SIZE = 64 * MB;
     public static final String SEGMENTED_QUEUE_SEGMENT_SIZE = "queue_segment_size";
-    public static final int DEFAULT_SEGMENTED_QUEUE_SEGMENT_SIZE = 4 * 1024 * 1024;
+    public static final int DEFAULT_SEGMENTED_QUEUE_SEGMENT_SIZE = 4 * MB;
     public static final String AUTOSAVE_INTERVAL_PROPERTY_NAME = "autosave_interval";
     public static final String PASSWORD_FILE_PROPERTY_NAME = "password_file";
     public static final String PORT_PROPERTY_NAME = "port";

--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -265,8 +265,10 @@ public class Server {
             queueRepository = h2Builder.queueRepository();
         } else if ("segmented".equalsIgnoreCase(queueType)) {
             LOG.info("Configuring segmented queue store to {}", dataPath);
+            final int pageSize = config.intProp(BrokerConstants.SEGMENTED_QUEUE_PAGE_SIZE, BrokerConstants.DEFAULT_SEGMENTED_QUEUE_PAGE_SIZE);
+            final int segmentSize = config.intProp(BrokerConstants.SEGMENTED_QUEUE_SEGMENT_SIZE, BrokerConstants.DEFAULT_SEGMENTED_QUEUE_SEGMENT_SIZE);
             try {
-                queueRepository = new SegmentQueueRepository(dataPath);
+                queueRepository = new SegmentQueueRepository(dataPath, pageSize, segmentSize);
             } catch (QueueException e) {
                 throw new IOException("Problem in configuring persistent queue on path " + dataPath, e);
             }

--- a/broker/src/main/java/io/moquette/broker/unsafequeues/Queue.java
+++ b/broker/src/main/java/io/moquette/broker/unsafequeues/Queue.java
@@ -26,6 +26,7 @@ public class Queue {
     private Segment tailSegment;
 
     private final QueuePool queuePool;
+    private final SegmentAllocator allocator;
     private final PagedFilesAllocator.AllocationListener allocationListener;
 //    private final ReentrantLock lock = new ReentrantLock();
 
@@ -37,6 +38,7 @@ public class Queue {
         this.currentHeadPtr = currentHeadPtr;
         this.currentTailPtr = currentTailPtr;
         this.tailSegment = tailSegment;
+        this.allocator = allocator;
         this.allocationListener = allocationListener;
         this.queuePool = queuePool;
     }
@@ -91,7 +93,7 @@ public class Queue {
             //notify segment creation for queue in queue pool
             allocationListener.segmentedCreated(name, newSegment);
 
-            int copySize = (int) Math.min(rawData.remaining(), Segment.SIZE);
+            int copySize = (int) Math.min(rawData.remaining(), allocator.getSegmentSize());
             ByteBuffer slice = rawData.slice();
             slice.limit(copySize);
 
@@ -279,7 +281,7 @@ public class Queue {
     }
 
     private int segmentCountFromSize(int remaining) {
-        return (int) Math.ceil((double) remaining / Segment.SIZE);
+        return (int) Math.ceil((double) remaining / allocator.getSegmentSize());
     }
 
     private boolean isTailFirstUsage(VirtualPointer tail) {

--- a/broker/src/main/java/io/moquette/broker/unsafequeues/QueuePool.java
+++ b/broker/src/main/java/io/moquette/broker/unsafequeues/QueuePool.java
@@ -26,8 +26,6 @@ import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
-import static io.moquette.broker.unsafequeues.PagedFilesAllocator.PAGE_SIZE;
-
 public class QueuePool {
 
     private static final Logger LOG = LoggerFactory.getLogger(QueuePool.class);
@@ -129,10 +127,10 @@ public class QueuePool {
         // adds in head
         segmentRefs.add(0, new SegmentRef(segment));
 
-        LOG.debug("queueSegments for queue {} after insertion {}", queueName, queueSegments.get(queueName));
+        LOG.debug("queueSegments for queue {} after insertion {}", queueName, segmentRefs);
     }
 
-    public static QueuePool loadQueues(Path dataPath) throws QueueException {
+    public static QueuePool loadQueues(Path dataPath, int pageSize, int segmentSize) throws QueueException {
         // read in checkpoint.properties
         final Properties checkpointProps = createOrLoadCheckpointFile(dataPath);
 
@@ -140,9 +138,9 @@ public class QueuePool {
         final int lastPage = Integer.parseInt(checkpointProps.getProperty("segments.last_page", "0"));
         final int lastSegment = Integer.parseInt(checkpointProps.getProperty("segments.last_segment", "0"));
 
-        final PagedFilesAllocator allocator = new PagedFilesAllocator(dataPath, Segment.SIZE, lastPage, lastSegment);
+        final PagedFilesAllocator allocator = new PagedFilesAllocator(dataPath, pageSize, segmentSize, lastPage, lastSegment);
 
-        final QueuePool queuePool = new QueuePool(allocator, dataPath, Segment.SIZE);
+        final QueuePool queuePool = new QueuePool(allocator, dataPath, segmentSize);
         callback = new SegmentAllocationCallback(queuePool);
         queuePool.loadQueueDefinitions(checkpointProps);
         LOG.debug("Loaded queues definitions: {}", queuePool.queueSegments);
@@ -221,7 +219,7 @@ public class QueuePool {
             // Tail is an offset relative to start of the first segment in the list
             // Head is n-1 full segments plus the offset of the physical head
             final VirtualPointer logicalTail = new VirtualPointer(currentTail.offset());
-            final VirtualPointer logicalHead = new VirtualPointer((long)(numSegments - 1) * Segment.SIZE + currentHead.offset());
+            final VirtualPointer logicalHead = new VirtualPointer((long) (numSegments - 1) * segmentSize + currentHead.offset());
             final Queue queue = new Queue(queueName.name, headSegment, logicalHead, tailSegment, logicalTail,
                 allocator, callback, this);
             queues.put(queueName, queue);
@@ -310,7 +308,7 @@ public class QueuePool {
             }
         } else if (prev.pageId + 1 == segment.pageId) {
             // adjacent pages, last segment in one and first in the other
-            if (prev.offset == PagedFilesAllocator.PAGE_SIZE - Segment.SIZE && segment.offset == 0) {
+            if (prev.offset == allocator.getPageSize() - segmentSize && segment.offset == 0) {
                 return true;
             }
         }
@@ -327,13 +325,13 @@ public class QueuePool {
         if (fromSegment != null) {
             prevPageId = fromSegment.pageId;
             // holes after previous segment, to complete the page
-            recreatedSegments.addAll(recreateRecycledSegments(fromSegment.offset + segmentSize, PAGE_SIZE, fromSegment.pageId));
+            recreatedSegments.addAll(recreateRecycledSegments(fromSegment.offset + segmentSize, allocator.getPageSize(), fromSegment.pageId));
             prevPageId++;
         }
 
         // all the intermediate pages
         for (; prevPageId < toSegment.pageId; prevPageId++) {
-            recreatedSegments.addAll(recreateRecycledSegments(0, PAGE_SIZE, prevPageId));
+            recreatedSegments.addAll(recreateRecycledSegments(0, allocator.getPageSize(), prevPageId));
         }
 
         // holes before the current segment
@@ -410,8 +408,8 @@ public class QueuePool {
 
             // queues.0.head_offset = bytes offset from the start of the page where last data was written
             final Queue queue = queues.get(queueName);
-            checkpoint.setProperty("queues." + queueCounter + ".head_offset", String.valueOf(queue.currentHead().segmentOffset()));
-            checkpoint.setProperty("queues." + queueCounter + ".tail_offset", String.valueOf(queue.currentTail().segmentOffset()));
+            checkpoint.setProperty("queues." + queueCounter + ".head_offset", String.valueOf(queue.currentHead().segmentOffset(segmentSize)));
+            checkpoint.setProperty("queues." + queueCounter + ".tail_offset", String.valueOf(queue.currentTail().segmentOffset(segmentSize)));
         }
 
         final File propertiesFile = dataPath.resolve("checkpoint.properties").toFile();
@@ -446,7 +444,7 @@ public class QueuePool {
 
         final MappedByteBuffer tailPage;
         try (FileChannel fileChannel = FileChannel.open(pageFile, StandardOpenOption.READ, StandardOpenOption.WRITE)) {
-            tailPage = fileChannel.map(FileChannel.MapMode.READ_WRITE/*READ_ONLY*/, 0, PAGE_SIZE);
+            tailPage = fileChannel.map(FileChannel.MapMode.READ_WRITE/*READ_ONLY*/, 0, allocator.getPageSize());
         } catch (IOException ex) {
             throw new QueueException("Can't open page file " + pageFile, ex);
         }

--- a/broker/src/main/java/io/moquette/broker/unsafequeues/SegmentAllocator.java
+++ b/broker/src/main/java/io/moquette/broker/unsafequeues/SegmentAllocator.java
@@ -18,4 +18,18 @@ interface SegmentAllocator {
     void close() throws QueueException;
 
     void dumpState(Properties checkpoint);
+
+    /**
+     * Get the size of a page that this allocator uses.
+     *
+     * @return the size of a page that this allocator uses.
+     */
+    int getPageSize();
+
+    /**
+     * Get the size of a segment that this allocator uses.
+     *
+     * @return the size of a segment that this allocator uses.
+     */
+    int getSegmentSize();
 }

--- a/broker/src/main/java/io/moquette/broker/unsafequeues/VirtualPointer.java
+++ b/broker/src/main/java/io/moquette/broker/unsafequeues/VirtualPointer.java
@@ -16,8 +16,8 @@ public class VirtualPointer implements Comparable<VirtualPointer> {
         return Long.compare(logicalOffset, other.logicalOffset);
     }
 
-    public long segmentOffset() {
-        return logicalOffset % Segment.SIZE;
+    public long segmentOffset(int segmentSize) {
+        return logicalOffset % segmentSize;
     }
 
     public long logicalOffset() {

--- a/broker/src/main/java/io/moquette/persistence/SegmentQueueRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/SegmentQueueRepository.java
@@ -19,12 +19,12 @@ public class SegmentQueueRepository implements IQueueRepository {
 
     private final QueuePool queuePool;
 
-    public SegmentQueueRepository(String path) throws QueueException {
-        queuePool = QueuePool.loadQueues(Paths.get(path));
+    public SegmentQueueRepository(String path, int pageSize, int segmentSize) throws QueueException {
+        queuePool = QueuePool.loadQueues(Paths.get(path), pageSize, segmentSize);
     }
 
-    public SegmentQueueRepository(Path path) throws QueueException {
-        queuePool = QueuePool.loadQueues(path);
+    public SegmentQueueRepository(Path path, int pageSize, int segmentSize) throws QueueException {
+        queuePool = QueuePool.loadQueues(path, pageSize, segmentSize);
     }
 
     @Override

--- a/broker/src/test/java/io/moquette/broker/unsafequeues/DummySegmentAllocator.java
+++ b/broker/src/test/java/io/moquette/broker/unsafequeues/DummySegmentAllocator.java
@@ -1,5 +1,6 @@
 package io.moquette.broker.unsafequeues;
 
+import io.moquette.BrokerConstants;
 import java.io.IOException;
 import java.nio.MappedByteBuffer;
 import java.util.Properties;
@@ -10,7 +11,7 @@ public class DummySegmentAllocator implements SegmentAllocator {
     public Segment nextFreeSegment() {
         final MappedByteBuffer pageBuffer = createFreshPageTmpTile();
         final SegmentPointer begin = new SegmentPointer(0, 0);
-        final SegmentPointer end = new SegmentPointer(0, Segment.SIZE);
+        final SegmentPointer end = new SegmentPointer(0, BrokerConstants.DEFAULT_SEGMENTED_QUEUE_SEGMENT_SIZE);
         return new Segment(pageBuffer, begin, end);
     }
 
@@ -18,7 +19,7 @@ public class DummySegmentAllocator implements SegmentAllocator {
     public Segment reopenSegment(int pageId, int beginOffset) throws QueueException {
         final MappedByteBuffer pageBuffer = createFreshPageTmpTile();
         final SegmentPointer begin = new SegmentPointer(pageId, beginOffset);
-        final SegmentPointer end = new SegmentPointer(pageId, beginOffset + Segment.SIZE);
+        final SegmentPointer end = new SegmentPointer(pageId, beginOffset + BrokerConstants.DEFAULT_SEGMENTED_QUEUE_SEGMENT_SIZE);
         return new Segment(pageBuffer, begin, end);
     }
 
@@ -40,5 +41,15 @@ public class DummySegmentAllocator implements SegmentAllocator {
 
     @Override
     public void dumpState(Properties checkpoint) {
+    }
+
+    @Override
+    public int getPageSize() {
+        return BrokerConstants.DEFAULT_SEGMENTED_QUEUE_PAGE_SIZE;
+    }
+
+    @Override
+    public int getSegmentSize() {
+        return BrokerConstants.DEFAULT_SEGMENTED_QUEUE_SEGMENT_SIZE;
     }
 }

--- a/broker/src/test/java/io/moquette/broker/unsafequeues/Utils.java
+++ b/broker/src/test/java/io/moquette/broker/unsafequeues/Utils.java
@@ -22,10 +22,10 @@ class Utils {
         return fileChannel.map(FileChannel.MapMode.READ_WRITE, 0, size);
     }
 
-    static MappedByteBuffer openPageFile(Path pageFile) throws IOException {
+    static MappedByteBuffer openPageFile(Path pageFile, int pageSize) throws IOException {
         final OpenOption[] openOptions = {StandardOpenOption.READ, StandardOpenOption.TRUNCATE_EXISTING};
         FileChannel fileChannel = FileChannel.open(pageFile, openOptions);
-        return fileChannel.map(FileChannel.MapMode.READ_ONLY, 0, PagedFilesAllocator.PAGE_SIZE);
+        return fileChannel.map(FileChannel.MapMode.READ_ONLY, 0, pageSize);
     }
 
     static String bufferToString(ByteBuffer buffer) {


### PR DESCRIPTION
This PR makes the PageSize and SegmentSize configurable.

This makes testing easier, since certain bugs appear faster on smaller queues. Also, for low-volume high-user-count servers, smaller segments are more efficient, since at least one Segment is used for each user.

This is the first UnsafeQueue related PR from #716.
PRs #728, #722 and #723 will build on this one
