### PR TITLE
Avoid attempt at purge of already purged session

### DIFF
--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -187,6 +187,10 @@ class Session {
         return status.compareAndSet(expected, newState);
     }
 
+    boolean hasState(SessionStatus expectedStatus) {
+        return status.get() == expectedStatus;
+    }
+
     public void closeImmediately() {
         mqttConnection.dropConnection();
         mqttConnection = null;

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -264,7 +264,7 @@ public class SessionRegistry {
 
     void connectionClosed(Session session) {
         session.disconnect();
-        if (session.expireImmediately()) {
+        if (session.expireImmediately()&& !session.hasState(SessionStatus.DESTROYED)) {
             purgeSessionState(session);
             return;
         } else {


### PR DESCRIPTION
The purge method can be called from both the disconnect message handler and from the connectionLost handler. If the disconnect happened normally then the connectionLost handler doesn't need to purge any more. Thus there is no need to throw an Exception.