### PR TITLE
Avoid to use deprecated PERSISTENT_STORE_PROPERTY_NAME property

### DIFF
--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -300,7 +300,7 @@ public class Server {
     }
 
     private String checkOrCreateUUID(IConfig config) {
-        final String storagePath = config.getProperty(BrokerConstants.PERSISTENT_STORE_PROPERTY_NAME, "");
+        final String storagePath = config.getProperty(BrokerConstants.DATA_PATH_PROPERTY_NAME, "");
         final Path uuidFilePath = Paths.get(storagePath, ".moquette_uuid");
         if (Files.exists(uuidFilePath)) {
             try {


### PR DESCRIPTION
Use the new DATA_PATH_PROPERTY_NAME, which is eventually valued from PERSISTENT_STORE_PROPERTY_NAME if present.

Fixes #730 