### PR TITLE
Avoid to drain on an already closed/destroyed session

### DIFF
--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -338,8 +338,11 @@ final class MQTTConnection {
         if (bindedSession.hasWill()) {
             postOffice.fireWill(bindedSession.getWill());
         }
-        sessionRegistry.connectionClosed(bindedSession);
-        connected = false;
+        if (bindedSession.connected()) {
+            LOG.debug("Closing session on connectionLost {}", clientID);
+            sessionRegistry.connectionClosed(bindedSession);
+            connected = false;
+        }
         //dispatch connection lost to intercept.
         String userName = NettyUtils.userName(channel);
         postOffice.dispatchConnectionLost(clientID,userName);
@@ -368,6 +371,7 @@ final class MQTTConnection {
                 LOG.debug("NOT processing disconnect {}, not bound.", clientID);
                 return null;
             }
+            LOG.debug("Closing session on disconnect {}", clientID);
             sessionRegistry.connectionClosed(bindedSession);
             connected = false;
             channel.close().addListener(FIRE_EXCEPTION_ON_FAILURE);

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -427,7 +427,7 @@ class Session {
 
     private void drainQueueToConnection() {
         // consume the queue
-        while (!sessionQueue.isEmpty() && inflighHasSlotsAndConnectionIsUp()) {
+        while (connected() && !sessionQueue.isEmpty() && inflighHasSlotsAndConnectionIsUp()) {
             final SessionRegistry.EnqueuedMessage msg = sessionQueue.dequeue();
             if (msg == null) {
                 // Our message was already fetched by another Thread.

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -277,7 +277,7 @@ public class SessionRegistry {
         LOG.debug("Remove session state for client {}", session.getClientID());
         boolean result = session.assignState(SessionStatus.DISCONNECTED, SessionStatus.DESTROYED);
         if (!result) {
-            throw new SessionCorruptedException("Session has already changed state");
+            throw new SessionCorruptedException("Session has already changed state: " + session);
         }
 
         unsubscribe(session);


### PR DESCRIPTION
On a DISCONNECT message Netty is notified of the MQTT disconnect message, which destroy the session and then when the TCP connection terminates it receives channelReadComplete (on connection lost notification). In this case draining the session queue (which is already closed) on a closed session generates an error.

This commit avoid to drain on already closed sessions.