### PR TITLE
Bubble up session loop's exceptions

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.17-SNAPSHOT:
+   [feature] added new callback method in interceptor to notify exceptions that happens on SessionEventLoop (#736).
    [feature] introduce new `buffer_flush_millis` deprecating the old `immediate_buffer_flush` and switch default behavior to flush on every write (#738).
    [refactory] purge of session state also on disconnect and reused logic (#715).
    [feature] add `moquette.session_loop.debug` property to enable session loop checking assignments (#714).

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -19,6 +19,7 @@ import io.moquette.interception.BrokerInterceptor;
 import io.moquette.broker.subscriptions.ISubscriptionsDirectory;
 import io.moquette.broker.subscriptions.Subscription;
 import io.moquette.broker.subscriptions.Topic;
+import io.moquette.interception.messages.InterceptExceptionMessage;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.mqtt.*;
@@ -198,6 +199,9 @@ class PostOffice {
                 // executed in session loop thread
                 // collect the exception thrown to later re-throw
                 loopThrownExceptions.put(loopThread.getName(), ex);
+
+                // This is done in asynch from another thread in BrokerInterceptor
+                interceptor.notifyLoopException(new InterceptExceptionMessage(ex));
             });
             newLoop.start();
             this.sessionExecutors[i] = newLoop;

--- a/broker/src/main/java/io/moquette/broker/SessionEventLoop.java
+++ b/broker/src/main/java/io/moquette/broker/SessionEventLoop.java
@@ -13,8 +13,6 @@ final class SessionEventLoop extends Thread {
     private final BlockingQueue<FutureTask<String>> sessionQueue;
     private final boolean flushOnExit;
 
-    private RuntimeException interruptingError = null;
-
     public SessionEventLoop(BlockingQueue<FutureTask<String>> sessionQueue) {
         this(sessionQueue, true);
     }
@@ -37,9 +35,6 @@ final class SessionEventLoop extends Thread {
             } catch (InterruptedException e) {
                 LOG.info("SessionEventLoop {} interrupted", Thread.currentThread().getName());
                 Thread.currentThread().interrupt();
-            } catch (RuntimeException th) {
-                interruptingError = th;
-                Thread.currentThread().interrupt();
             }
         }
         LOG.info("SessionEventLoop {} exit", Thread.currentThread().getName());
@@ -56,12 +51,6 @@ final class SessionEventLoop extends Thread {
                 LOG.warn("SessionEventLoop {} reached exception in processing command", Thread.currentThread().getName(), th);
                 throw new RuntimeException(th);
             }
-        }
-    }
-
-    public void failIfError() {
-        if (interruptingError != null) {
-            throw interruptingError;
         }
     }
 }

--- a/broker/src/main/java/io/moquette/interception/AbstractInterceptHandler.java
+++ b/broker/src/main/java/io/moquette/interception/AbstractInterceptHandler.java
@@ -25,7 +25,7 @@ import io.moquette.interception.messages.InterceptSubscribeMessage;
 import io.moquette.interception.messages.InterceptUnsubscribeMessage;
 
 /**
- * Basic abstract class usefull to avoid empty methods creation in subclasses.
+ * Basic abstract class useful to avoid empty methods creation in subclasses.
  */
 public abstract class AbstractInterceptHandler implements InterceptHandler {
 

--- a/broker/src/main/java/io/moquette/interception/BrokerInterceptor.java
+++ b/broker/src/main/java/io/moquette/interception/BrokerInterceptor.java
@@ -167,6 +167,13 @@ public final class BrokerInterceptor implements Interceptor {
     }
 
     @Override
+    public void notifyLoopException(InterceptExceptionMessage msg) {
+        for (final InterceptHandler handler : this.handlers.get(InterceptExceptionMessage.class)) {
+            handler.onSessionLoopError(msg.getError());
+        }
+    }
+
+    @Override
     public void addInterceptHandler(InterceptHandler interceptHandler) {
         Class<?>[] interceptedMessageTypes = getInterceptedMessageTypes(interceptHandler);
         LOG.info("Adding MQTT message interceptor. InterceptorId={}, handledMessageTypes={}",

--- a/broker/src/main/java/io/moquette/interception/InterceptHandler.java
+++ b/broker/src/main/java/io/moquette/interception/InterceptHandler.java
@@ -22,6 +22,7 @@ import io.netty.handler.codec.mqtt.MqttMessage;
 
 /**
  * This interface is used to inject code for intercepting broker events.
+ * This is part of the API that integrator of Moquette has to implement.
  * <p>
  * The events can act only as observers.
  * <p>
@@ -33,7 +34,7 @@ public interface InterceptHandler {
 
     Class<?>[] ALL_MESSAGE_TYPES = {InterceptConnectMessage.class, InterceptDisconnectMessage.class,
             InterceptConnectionLostMessage.class, InterceptPublishMessage.class, InterceptSubscribeMessage.class,
-            InterceptUnsubscribeMessage.class, InterceptAcknowledgedMessage.class};
+            InterceptUnsubscribeMessage.class, InterceptAcknowledgedMessage.class, InterceptExceptionMessage.class};
 
     /**
      * @return the identifier of this intercept handler.
@@ -65,4 +66,6 @@ public interface InterceptHandler {
     void onUnsubscribe(InterceptUnsubscribeMessage msg);
 
     void onMessageAcknowledged(InterceptAcknowledgedMessage msg);
+
+    void onSessionLoopError(Throwable error);
 }

--- a/broker/src/main/java/io/moquette/interception/Interceptor.java
+++ b/broker/src/main/java/io/moquette/interception/Interceptor.java
@@ -18,6 +18,7 @@ package io.moquette.interception;
 
 import io.moquette.interception.messages.InterceptAcknowledgedMessage;
 import io.moquette.broker.subscriptions.Subscription;
+import io.moquette.interception.messages.InterceptExceptionMessage;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 
@@ -46,6 +47,8 @@ public interface Interceptor {
     void notifyTopicUnsubscribed(String topic, String clientID, String username);
 
     void notifyMessageAcknowledged(InterceptAcknowledgedMessage msg);
+
+    void notifyLoopException(InterceptExceptionMessage th);
 
     void addInterceptHandler(InterceptHandler interceptHandler);
 

--- a/broker/src/main/java/io/moquette/interception/messages/InterceptExceptionMessage.java
+++ b/broker/src/main/java/io/moquette/interception/messages/InterceptExceptionMessage.java
@@ -1,0 +1,13 @@
+package io.moquette.interception.messages;
+
+public class InterceptExceptionMessage implements InterceptMessage {
+    private Throwable error;
+
+    public InterceptExceptionMessage(Throwable error) {
+        this.error = error;
+    }
+
+    public Throwable getError() {
+        return error;
+    }
+}

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
@@ -29,7 +29,7 @@ import io.netty.handler.codec.mqtt.MqttMessageBuilders;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.handler.codec.mqtt.MqttVersion;
-import org.jetbrains.annotations.NotNull;
+//import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -85,7 +85,7 @@ public class MQTTConnectionPublishTest {
         return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, postOffice);
     }
 
-    @NotNull
+//    @NotNull
     static ISessionsRepository memorySessionsRepository() {
         return new MemorySessionsRepository();
     }

--- a/broker/src/test/java/io/moquette/interception/BrokerInterceptorTest.java
+++ b/broker/src/test/java/io/moquette/interception/BrokerInterceptorTest.java
@@ -89,6 +89,11 @@ public class BrokerInterceptorTest {
         public void onMessageAcknowledged(InterceptAcknowledgedMessage msg) {
             n.set(90);
         }
+
+        @Override
+        public void onSessionLoopError(Throwable error) {
+            throw new RuntimeException(error);
+        }
     }
 
     private static final BrokerInterceptor interceptor = new BrokerInterceptor(


### PR DESCRIPTION
When a session loop the exception is simply logged and lost, so the error status is not reported to the broker.
This PR interrupt the session loop on an exception, saving the error in a local variable.
    
When the `PostOffice` terminates it re-throw the exception that was reached during session loop
execution, while in the meantime it notifies the user implemented API `InterceptHandler.onSessionLoopError`.
The firing of the newly added event type `InterceptExceptionMessage` containing the error stacktrace, is done asychronously from the launching thread (the session loop thread that terminating because of the error).

## What it does?#
- create a new interception hook in the Moquette interception framework.
- modify the `SessionEventLoop` to be itself a thread (and not a `Runnable` task)
- set an `uncatchedExceptionHandler` in the  newly ``SessionEventLoop` thread to scatter the notification.
- collect the error, if any, for each SessionEventLoop and log on termination of PostOffice.
