### PR TITLE
Implement session expiry cleanup for persisted sessions

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.17-SNAPSHOT:
+   [feature] add saved session expiry configurable through the `persistent_client_expiration` setting (#739).
    [feature] implemented methods to forcibly disconnects a clients from a Server instance (#744).
    [refactory] moved code to handle session event loops from PostOffice into separate SessionEventLoopGroup (#742).
    [feature] added new callback method in interceptor to notify exceptions that happens on SessionEventLoop (#736).

--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -112,6 +112,8 @@ public final class BrokerConstants {
 
     public static final String STORAGE_CLASS_NAME = "storage_class";
 
+    public static final String PERSISTENT_CLEAN_EXPIRATION_PROPERTY_NAME = "persistent_client_expiration";
+
     public static final int FLIGHT_BEFORE_RESEND_MS = 5_000;
     public static final int INFLIGHT_WINDOW_SIZE = 10;
 

--- a/broker/src/main/java/io/moquette/broker/ISessionsRepository.java
+++ b/broker/src/main/java/io/moquette/broker/ISessionsRepository.java
@@ -21,14 +21,14 @@ public interface ISessionsRepository {
         private Instant expireAt = null;
         final MqttVersion version;
         private final int expiryInterval;
-        private final Clock clock;
+        private transient final Clock clock;
 
         /**
          * Create a new SessionData setting the expiration instant computed by
          * the actual instant and the expiry interval defined for the session.
          * */
         static SessionData calculateExpiration(SessionData session) {
-            final Instant expireAt = Instant.now().plusSeconds(session.expiryInterval);
+            final Instant expireAt = session.clock.instant().plusSeconds(session.expiryInterval);
             return new SessionData(session.clientId, expireAt, session.version, session.expiryInterval, session.clock);
         }
 

--- a/broker/src/main/java/io/moquette/broker/ISessionsRepository.java
+++ b/broker/src/main/java/io/moquette/broker/ISessionsRepository.java
@@ -24,15 +24,6 @@ public interface ISessionsRepository {
         private transient final Clock clock;
 
         /**
-         * Create a new SessionData setting the expiration instant computed by
-         * the actual instant and the expiry interval defined for the session.
-         * */
-        static SessionData calculateExpiration(SessionData session) {
-            final Instant expireAt = session.clock.instant().plusSeconds(session.expiryInterval);
-            return new SessionData(session.clientId, expireAt, session.version, session.expiryInterval, session.clock);
-        }
-
-        /**
          * Construct a new SessionData without expiration set yet.
          *
          * @expiryInterval seconds after which the persistent session could be dropped.
@@ -77,6 +68,11 @@ public interface ISessionsRepository {
 
         public int expiryInterval() {
             return expiryInterval;
+        }
+
+        public SessionData withExpirationComputed() {
+            final Instant expiresAt = clock.instant().plusSeconds(expiryInterval);
+            return new SessionData(clientId, expiresAt, version, expiryInterval, clock);
         }
 
         @Override

--- a/broker/src/main/java/io/moquette/broker/ISessionsRepository.java
+++ b/broker/src/main/java/io/moquette/broker/ISessionsRepository.java
@@ -34,6 +34,8 @@ public interface ISessionsRepository {
 
         /**
          * Construct a new SessionData without expiration set yet.
+         *
+         * @expiryInterval seconds after which the persistent session could be dropped.
          * */
         public SessionData(String clientId, MqttVersion version, int expiryInterval, Clock clock) {
             this.clientId = clientId;
@@ -44,6 +46,8 @@ public interface ISessionsRepository {
 
         /**
          * Construct SessionData with an expiration instant, created by loading from the storage.
+         *
+         * @expiryInterval seconds after which the persistent session could be dropped.
          * */
         public SessionData(String clientId, Instant expireAt, MqttVersion version, int expiryInterval, Clock clock) {
             Objects.requireNonNull(expireAt, "An expiration time is requested");

--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -251,9 +251,10 @@ public class Server {
             globalSessionExpiry = INFINITE_EXPIRY;
         }
 
-        sessions = new SessionRegistry(subscriptions, sessionsRepository, queueRepository, authorizator, scheduler, clock, globalSessionExpiry);
         final int sessionQueueSize = config.intProp(BrokerConstants.SESSION_QUEUE_SIZE, 1024);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(interceptor, sessionQueueSize);
+        sessions = new SessionRegistry(subscriptions, sessionsRepository, queueRepository, authorizator, scheduler,
+            clock, globalSessionExpiry, loopsGroup);
         dispatcher = new PostOffice(subscriptions, retainedRepository, sessions, interceptor, authorizator,
             loopsGroup);
         final BrokerConfiguration brokerConfig = new BrokerConfiguration(config);

--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -55,6 +55,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.ParseException;
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -210,6 +211,8 @@ public class Server {
             config.setProperty(BrokerConstants.DATA_PATH_PROPERTY_NAME, dataPath);
         }
 
+        final Clock clock = Clock.systemDefaultZone();
+
         if (Boolean.parseBoolean(config.getProperty(BrokerConstants.PERSISTENCE_ENABLED_PROPERTY_NAME))) {
             final Path dataPath = Paths.get(config.getProperty(BrokerConstants.DATA_PATH_PROPERTY_NAME));
             if (!dataPath.toFile().exists()) {
@@ -222,7 +225,7 @@ public class Server {
 
             LOG.debug("Configuring persistent subscriptions store and queues, path: {}", dataPath);
             final int autosaveInterval = Integer.parseInt(config.getProperty(BrokerConstants.AUTOSAVE_INTERVAL_PROPERTY_NAME, "30"));
-            h2Builder = new H2Builder(scheduler, dataPath, autosaveInterval).initStore();
+            h2Builder = new H2Builder(scheduler, dataPath, autosaveInterval, clock).initStore();
             queueRepository = initQueuesRepository(config, dataPath, h2Builder);
             LOG.trace("Configuring H2 subscriptions repository");
             subscriptionsRepository = h2Builder.subscriptionsRepository();
@@ -239,7 +242,7 @@ public class Server {
         ISubscriptionsDirectory subscriptions = new CTrieSubscriptionDirectory();
         subscriptions.init(subscriptionsRepository);
         final Authorizator authorizator = new Authorizator(authorizatorPolicy);
-        sessions = new SessionRegistry(subscriptions, sessionsRepository, queueRepository, authorizator, scheduler);
+        sessions = new SessionRegistry(subscriptions, sessionsRepository, queueRepository, authorizator, scheduler, clock);
         final int sessionQueueSize = config.intProp(BrokerConstants.SESSION_QUEUE_SIZE, 1024);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(interceptor, sessionQueueSize);
         dispatcher = new PostOffice(subscriptions, retainedRepository, sessions, interceptor, authorizator,

--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -239,7 +239,7 @@ public class Server {
         ISubscriptionsDirectory subscriptions = new CTrieSubscriptionDirectory();
         subscriptions.init(subscriptionsRepository);
         final Authorizator authorizator = new Authorizator(authorizatorPolicy);
-        sessions = new SessionRegistry(subscriptions, sessionsRepository, queueRepository, authorizator);
+        sessions = new SessionRegistry(subscriptions, sessionsRepository, queueRepository, authorizator, scheduler);
         final int sessionQueueSize = config.intProp(BrokerConstants.SESSION_QUEUE_SIZE, 1024);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(interceptor, sessionQueueSize);
         dispatcher = new PostOffice(subscriptions, retainedRepository, sessions, interceptor, authorizator,

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -502,6 +502,10 @@ class Session {
         }
     }
 
+    ISessionsRepository.SessionData getSessionData() {
+        return this.data;
+    }
+
     @Override
     public String toString() {
         return "Session{" +

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -33,7 +33,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -51,9 +50,9 @@ import java.util.concurrent.atomic.AtomicReference;
 class Session {
 
     private static final Logger LOG = LoggerFactory.getLogger(Session.class);
-    // By specification session expiry value of 0xFFFFFFFF (UINT_MAX) (seconds) means
-    // session that doesn't expire, it's ~136 years, we can set a cap at 100 year
-    static final int INFINITE_EXPIRY = (int) Duration.ofDays(80 * 365).toMillis() / 1000;
+    // By specification session expiry value of 0xEFFFFFFF (UINT_MAX) (seconds) means
+    // session that doesn't expire, it's ~68 years.
+    static final int INFINITE_EXPIRY = Integer.MAX_VALUE;
 
     static class InFlightPacket implements Delayed {
 

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 import static io.moquette.broker.Session.INFINITE_EXPIRY;
@@ -122,15 +123,18 @@ public class SessionRegistry {
     private final ISessionsRepository sessionsRepository;
     private final IQueueRepository queueRepository;
     private final Authorizator authorizator;
+    private final ScheduledExecutorService scheduler;
 
     SessionRegistry(ISubscriptionsDirectory subscriptionsDirectory,
                     ISessionsRepository sessionsRepository,
                     IQueueRepository queueRepository,
-                    Authorizator authorizator) {
+                    Authorizator authorizator,
+                    ScheduledExecutorService scheduler) {
         this.subscriptionsDirectory = subscriptionsDirectory;
         this.sessionsRepository = sessionsRepository;
         this.queueRepository = queueRepository;
         this.authorizator = authorizator;
+        this.scheduler = scheduler;
         recreateSessionPool();
     }
 

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -198,7 +198,7 @@ public class SessionRegistry {
             }
         }
         if (!queues.isEmpty()) {
-            LOG.error("Recreating sessions left {} unused queues. This is probably bug. Session IDs: {}", queues.size(), Arrays.toString(queues.toArray()));
+            LOG.error("Recreating sessions left {} unused queues. This is probably a bug. Session IDs: {}", queues.size(), Arrays.toString(queues.toArray()));
         }
     }
 
@@ -334,7 +334,7 @@ public class SessionRegistry {
             purgeSessionState(session);
         } else {
             //bound session has expiry, disconnect it and add to the queue for removal
-            trackForRemovalOnExpiration(ISessionsRepository.SessionData.calculateExpiration(session.getSessionData()));
+            trackForRemovalOnExpiration(session.getSessionData().withExpirationComputed());
         }
     }
 
@@ -424,7 +424,7 @@ public class SessionRegistry {
             .filter(s -> !s.isClean()) // not clean session
             .map(Session::getSessionData)
             .filter(s -> !s.expireAt().isPresent()) // without expire set
-            .map(ISessionsRepository.SessionData::calculateExpiration) // new SessionData with expireAt valued
+            .map(ISessionsRepository.SessionData::withExpirationComputed) // new SessionData with expireAt valued
             .forEach(sessionsRepository::saveSession); // update the storage
     }
 }

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -168,7 +168,7 @@ public class SessionRegistry {
     private void checkExpiredSessions() {
         List<ISessionsRepository.SessionData> expiredSessions = new ArrayList<>();
         int drainedSessions = removableSessions.drainTo(expiredSessions);
-        LOG.debug("Retrieved {} expired sessions", drainedSessions);
+        LOG.debug("Retrieved {} expired sessions or {}", drainedSessions, removableSessions.size());
         for (ISessionsRepository.SessionData expiredSession : expiredSessions) {
             final String expiredAt = expiredSession.expireAt().map(Instant::toString).orElse("UNDEFINED");
             LOG.debug("Removing session {}, expired on {}", expiredSession.clientId(), expiredAt);
@@ -181,6 +181,7 @@ public class SessionRegistry {
         if (!session.expireAt().isPresent()) {
             throw new RuntimeException("Can't track for expiration a session without expiry instant, client_id: " + session.clientId());
         }
+        LOG.debug("start tracking the session {} for removal", session.clientId());
         removableSessions.add(session);
     }
 

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -185,6 +185,10 @@ public class SessionRegistry {
         removableSessions.add(session);
     }
 
+    private void untrackFromRemovalOnExpiration(ISessionsRepository.SessionData session) {
+
+    }
+
     private void recreateSessionPool() {
         final Set<String> queues = queueRepository.listQueueNames();
         for (ISessionsRepository.SessionData session : sessionsRepository.list()) {
@@ -255,6 +259,8 @@ public class SessionRegistry {
             LOG.trace("case 3, oldSession with same CId {} disconnected", clientId);
             creationResult = new SessionCreationResult(oldSession, CreationModeEnum.REOPEN_EXISTING, true);
         }
+
+        untrackFromRemovalOnExpiration(creationResult.session.getSessionData());
 
         // case not covered new session is clean true/false and old session not in CONNECTED/DISCONNECTED
         return creationResult;

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import java.net.InetSocketAddress;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,6 +52,7 @@ public class SessionRegistry {
     private final ScheduledFuture<?> scheduledExpiredSessions;
     private int globalExpirySeconds;
     private final SessionEventLoopGroup loopsGroup;
+    static final Duration EXPIRED_SESSION_CLEANER_TASK_INTERVAL = Duration.ofSeconds(1);
 
     public abstract static class EnqueuedMessage {
 
@@ -158,7 +160,9 @@ public class SessionRegistry {
         this.sessionsRepository = sessionsRepository;
         this.queueRepository = queueRepository;
         this.authorizator = authorizator;
-        this.scheduledExpiredSessions = scheduler.scheduleWithFixedDelay(this::checkExpiredSessions, 1, 1, TimeUnit.SECONDS);
+        this.scheduledExpiredSessions = scheduler.scheduleWithFixedDelay(this::checkExpiredSessions,
+            EXPIRED_SESSION_CLEANER_TASK_INTERVAL.getSeconds(), EXPIRED_SESSION_CLEANER_TASK_INTERVAL.getSeconds(),
+            TimeUnit.SECONDS);
         this.clock = clock;
         this.globalExpirySeconds = globalExpirySeconds;
         this.loopsGroup = loopsGroup;
@@ -186,7 +190,6 @@ public class SessionRegistry {
     }
 
     private void untrackFromRemovalOnExpiration(ISessionsRepository.SessionData session) {
-
     }
 
     private void recreateSessionPool() {

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -190,6 +190,7 @@ public class SessionRegistry {
     }
 
     private void untrackFromRemovalOnExpiration(ISessionsRepository.SessionData session) {
+        removableSessions.remove(session);
     }
 
     private void recreateSessionPool() {

--- a/broker/src/main/java/io/moquette/broker/config/IConfig.java
+++ b/broker/src/main/java/io/moquette/broker/config/IConfig.java
@@ -18,6 +18,10 @@ package io.moquette.broker.config;
 
 import io.moquette.BrokerConstants;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+
 /**
  * Base interface for all configuration implementations (filesystem, memory or classpath)
  */
@@ -78,5 +82,32 @@ public abstract class IConfig {
             return defaultValue;
         }
         return Boolean.parseBoolean(propertyValue);
+    }
+
+    public Duration durationProp(String propertyName) {
+        String propertyValue = getProperty(propertyName);
+        final char timeSpecifier = propertyValue.charAt(propertyValue.length() - 1);
+        final TemporalUnit periodType;
+        switch (timeSpecifier) {
+            case 'h':
+                periodType = ChronoUnit.HOURS;
+                break;
+            case 'd':
+                periodType = ChronoUnit.DAYS;
+                break;
+            case 'w':
+                periodType = ChronoUnit.WEEKS;
+                break;
+            case 'm':
+                periodType = ChronoUnit.MONTHS;
+                break;
+            case 'y':
+                periodType = ChronoUnit.YEARS;
+                break;
+            default:
+                throw new IllegalStateException("Can' parse duration property " + propertyName + " with value: " + propertyValue + ", admitted only h, d, w, m, y");
+
+        }
+        return Duration.of(Integer.parseInt(propertyValue.substring(0, propertyValue.length() - 1)), periodType);
     }
 }

--- a/broker/src/main/java/io/moquette/broker/config/IConfig.java
+++ b/broker/src/main/java/io/moquette/broker/config/IConfig.java
@@ -89,6 +89,12 @@ public abstract class IConfig {
         final char timeSpecifier = propertyValue.charAt(propertyValue.length() - 1);
         final TemporalUnit periodType;
         switch (timeSpecifier) {
+            case 's':
+                periodType = ChronoUnit.SECONDS;
+                break;
+            case 'm':
+                periodType = ChronoUnit.MINUTES;
+                break;
             case 'h':
                 periodType = ChronoUnit.HOURS;
                 break;
@@ -98,7 +104,7 @@ public abstract class IConfig {
             case 'w':
                 periodType = ChronoUnit.WEEKS;
                 break;
-            case 'm':
+            case 'M':
                 periodType = ChronoUnit.MONTHS;
                 break;
             case 'y':

--- a/broker/src/main/java/io/moquette/persistence/H2Builder.java
+++ b/broker/src/main/java/io/moquette/persistence/H2Builder.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Clock;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -22,12 +23,14 @@ public class H2Builder {
     private final String storePath;
     private final int autosaveInterval; // in seconds
     private final ScheduledExecutorService scheduler;
+    private final Clock clock;
     private MVStore mvStore;
 
-    public H2Builder(ScheduledExecutorService scheduler, Path storePath, int autosaveInterval) {
+    public H2Builder(ScheduledExecutorService scheduler, Path storePath, int autosaveInterval, Clock clock) {
         this.storePath = storePath.resolve("moquette_store.h2").toAbsolutePath().toString();
         this.autosaveInterval = autosaveInterval;
         this.scheduler = scheduler;
+        this.clock = clock;
     }
 
     @SuppressWarnings("FutureReturnValueIgnored")
@@ -75,6 +78,6 @@ public class H2Builder {
     }
 
     public ISessionsRepository sessionsRepository() {
-        return new H2SessionsRepository(mvStore);
+        return new H2SessionsRepository(mvStore, clock);
     }
 }

--- a/broker/src/main/java/io/moquette/persistence/MemorySessionsRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/MemorySessionsRepository.java
@@ -19,4 +19,9 @@ public class MemorySessionsRepository implements ISessionsRepository {
     public void saveSession(SessionData session) {
         sessions.put(session.clientId(), session);
     }
+
+    @Override
+    public void delete(SessionData session) {
+        sessions.remove(session.clientId());
+    }
 }

--- a/broker/src/test/java/io/moquette/broker/ForwardableClock.java
+++ b/broker/src/test/java/io/moquette/broker/ForwardableClock.java
@@ -1,0 +1,38 @@
+package io.moquette.broker;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+
+/**
+ * Utility class to represent a clock that can be moved in time.
+ * This is used for tests that needs to verify conditions after a certain amount of time.
+ * */
+class ForwardableClock extends Clock {
+
+    private Clock currentClock;
+
+    ForwardableClock(Clock clock) {
+        this.currentClock = clock;
+    }
+
+    void forward(Duration period) {
+        currentClock = Clock.offset(currentClock, period);
+    }
+
+    @Override
+    public ZoneId getZone() {
+        return currentClock.getZone();
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+        return currentClock.withZone(zone);
+    }
+
+    @Override
+    public Instant instant() {
+        return currentClock.instant();
+    }
+}

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
@@ -25,11 +25,14 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttMessageBuilders;
 import io.netty.handler.codec.mqtt.MqttVersion;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static io.moquette.broker.MQTTConnectionPublishTest.memorySessionsRepository;
 import static io.moquette.BrokerConstants.NO_BUFFER_FLUSH;
@@ -58,9 +61,11 @@ public class MQTTConnectionConnectTest {
     private IAuthenticator mockAuthenticator;
     private PostOffice postOffice;
     private MemoryQueueRepository queueRepository;
+    private ScheduledExecutorService scheduler;
 
     @BeforeEach
     public void setUp() {
+        scheduler = Executors.newScheduledThreadPool(1);
         connMsg = MqttMessageBuilders.connect().protocolVersion(MqttVersion.MQTT_3_1).cleanSession(true);
 
         mockAuthenticator = new MockAuthenticator(singleton(FAKE_CLIENT_ID), singletonMap(TEST_USER, TEST_PWD));
@@ -72,13 +77,18 @@ public class MQTTConnectionConnectTest {
 
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
-        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
+        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler);
         postOffice = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
                                     ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
 
         sut = createMQTTConnection(CONFIG);
         channel = (EmbeddedChannel) sut.channel;
+    }
+
+    @AfterEach
+    public void tearDown() {
+        scheduler.shutdown();
     }
 
     private MQTTConnection createMQTTConnection(BrokerConfiguration config) {

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
@@ -78,7 +78,7 @@ public class MQTTConnectionConnectTest {
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
-        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler);
+        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler, loopsGroup);
         postOffice = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
                                     ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
 

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
@@ -91,7 +91,7 @@ public class MQTTConnectionPublishTest {
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
-        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler);
+        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler, loopsGroup);
         final PostOffice postOffice = new PostOffice(subscriptions,
             new MemoryRetainedRepository(), sessionRegistry, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
         return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, postOffice);

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
@@ -30,10 +30,13 @@ import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.handler.codec.mqtt.MqttVersion;
 //import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static io.moquette.BrokerConstants.NO_BUFFER_FLUSH;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -52,6 +55,7 @@ public class MQTTConnectionPublishTest {
     private SessionRegistry sessionRegistry;
     private MqttMessageBuilders.ConnectBuilder connMsg;
     private MemoryQueueRepository queueRepository;
+    private ScheduledExecutorService scheduler;
 
     @BeforeEach
     public void setUp() {
@@ -59,7 +63,14 @@ public class MQTTConnectionPublishTest {
 
         BrokerConfiguration config = new BrokerConfiguration(true, true, false, NO_BUFFER_FLUSH);
 
+        scheduler = Executors.newScheduledThreadPool(1);
+
         createMQTTConnection(config);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        scheduler.shutdown();
     }
 
     private void createMQTTConnection(BrokerConfiguration config) {
@@ -79,8 +90,8 @@ public class MQTTConnectionPublishTest {
 
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
-        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
+        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler);
         final PostOffice postOffice = new PostOffice(subscriptions,
             new MemoryRetainedRepository(), sessionRegistry, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
         return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, postOffice);

--- a/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
@@ -102,7 +102,7 @@ public class PostOfficeInternalPublishTest {
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
-        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler);
+        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler, loopsGroup);
         sut = new PostOffice(subscriptions, retainedRepository, sessionRegistry,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
     }

--- a/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
@@ -25,11 +25,14 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.mqtt.*;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static io.moquette.broker.MQTTConnectionPublishTest.memorySessionsRepository;
@@ -59,6 +62,7 @@ public class PostOfficeInternalPublishTest {
         new BrokerConfiguration(true, true, false, NO_BUFFER_FLUSH);
     private MemoryRetainedRepository retainedRepository;
     private MemoryQueueRepository queueRepository;
+    private ScheduledExecutorService scheduler;
 
     @BeforeEach
     public void setUp() throws ExecutionException, InterruptedException {
@@ -73,6 +77,11 @@ public class PostOfficeInternalPublishTest {
         ConnectionTestUtils.assertConnectAccepted(channel);
     }
 
+    @AfterEach
+    public void tearDown() {
+        scheduler.shutdown();
+    }
+
     private MQTTConnection createMQTTConnection(BrokerConfiguration config) {
         channel = new EmbeddedChannel();
         return createMQTTConnection(config, channel);
@@ -83,6 +92,7 @@ public class PostOfficeInternalPublishTest {
     }
 
     private void initPostOfficeAndSubsystems() {
+        scheduler = Executors.newScheduledThreadPool(1);
         subscriptions = new CTrieSubscriptionDirectory();
         ISubscriptionsRepository subscriptionsRepository = new MemorySubscriptionsRepository();
         subscriptions.init(subscriptionsRepository);
@@ -91,8 +101,8 @@ public class PostOfficeInternalPublishTest {
 
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
-        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
+        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler);
         sut = new PostOffice(subscriptions, retainedRepository, sessionRegistry,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
     }

--- a/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
@@ -34,9 +34,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
 import java.util.*;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 
 import static io.moquette.broker.MQTTConnectionPublishTest.memorySessionsRepository;
 import static io.moquette.BrokerConstants.NO_BUFFER_FLUSH;
@@ -71,6 +69,7 @@ public class PostOfficePublishTest {
         new BrokerConfiguration(true, true, false, NO_BUFFER_FLUSH);
     private MemoryRetainedRepository retainedRepository;
     private MemoryQueueRepository queueRepository;
+    private ScheduledExecutorService scheduler;
 
     @BeforeEach
     public void setUp() {
@@ -85,6 +84,7 @@ public class PostOfficePublishTest {
 
     @AfterEach
     public void tearDown() {
+        scheduler.shutdown();
         sut.terminate();
     }
 
@@ -97,6 +97,7 @@ public class PostOfficePublishTest {
     }
 
     private void initPostOfficeAndSubsystems() {
+        scheduler = Executors.newScheduledThreadPool(1);
         subscriptions = new CTrieSubscriptionDirectory();
         ISubscriptionsRepository subscriptionsRepository = new MemorySubscriptionsRepository();
         subscriptions.init(subscriptionsRepository);
@@ -105,8 +106,8 @@ public class PostOfficePublishTest {
 
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
-        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
+        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler);
         sut = new PostOffice(subscriptions, retainedRepository, sessionRegistry,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
     }

--- a/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
@@ -107,7 +107,7 @@ public class PostOfficePublishTest {
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
-        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler);
+        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler, loopsGroup);
         sut = new PostOffice(subscriptions, retainedRepository, sessionRegistry,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
     }

--- a/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
@@ -28,15 +28,14 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.mqtt.*;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 
 import static io.moquette.broker.MQTTConnectionPublishTest.memorySessionsRepository;
 import static io.moquette.BrokerConstants.NO_BUFFER_FLUSH;
@@ -71,6 +70,7 @@ public class PostOfficeSubscribeTest {
     private SessionRegistry sessionRegistry;
     public static final BrokerConfiguration CONFIG = new BrokerConfiguration(true, true, false, NO_BUFFER_FLUSH);
     private MemoryQueueRepository queueRepository;
+    private ScheduledExecutorService scheduler;
 
     @BeforeEach
     public void setUp() {
@@ -82,12 +82,18 @@ public class PostOfficeSubscribeTest {
         createMQTTConnection(CONFIG);
     }
 
+    @AfterEach
+    public void tearDown() {
+        scheduler.shutdown();
+    }
+
     private void createMQTTConnection(BrokerConfiguration config) {
         channel = new EmbeddedChannel();
         connection = createMQTTConnection(config, channel);
     }
 
     private void prepareSUT() {
+        scheduler = Executors.newScheduledThreadPool(1);
         mockAuthenticator = new MockAuthenticator(singleton(FAKE_CLIENT_ID), singletonMap(TEST_USER, TEST_PWD));
 
         subscriptions = new CTrieSubscriptionDirectory();
@@ -97,8 +103,8 @@ public class PostOfficeSubscribeTest {
 
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
-        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
+        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler);
         sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
     }

--- a/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
@@ -104,7 +104,7 @@ public class PostOfficeSubscribeTest {
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
-        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler);
+        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler, loopsGroup);
         sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
     }

--- a/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
@@ -27,15 +27,14 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.mqtt.*;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 
 import static io.moquette.broker.MQTTConnectionPublishTest.memorySessionsRepository;
 import static io.moquette.BrokerConstants.NO_BUFFER_FLUSH;
@@ -62,6 +61,7 @@ public class PostOfficeUnsubscribeTest {
     private SessionRegistry sessionRegistry;
     public static final BrokerConfiguration CONFIG = new BrokerConfiguration(true, true, false, NO_BUFFER_FLUSH);
     private MemoryQueueRepository queueRepository;
+    private ScheduledExecutorService scheduler;
 
     @BeforeEach
     public void setUp() {
@@ -73,12 +73,18 @@ public class PostOfficeUnsubscribeTest {
         createMQTTConnection(CONFIG);
     }
 
+    @AfterEach
+    public void tearDown() {
+        scheduler.shutdown();
+    }
+
     private void createMQTTConnection(BrokerConfiguration config) {
         channel = new EmbeddedChannel();
         connection = createMQTTConnection(config, channel);
     }
 
     private void prepareSUT() {
+        scheduler = Executors.newScheduledThreadPool(1);
         mockAuthenticator = new MockAuthenticator(singleton(FAKE_CLIENT_ID), singletonMap(TEST_USER, TEST_PWD));
 
         subscriptions = new CTrieSubscriptionDirectory();
@@ -88,8 +94,8 @@ public class PostOfficeUnsubscribeTest {
 
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
-        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
+        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler);
         sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
     }

--- a/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
@@ -95,7 +95,7 @@ public class PostOfficeUnsubscribeTest {
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
-        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler);
+        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler, loopsGroup);
         sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
     }

--- a/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
@@ -57,6 +57,7 @@ import java.util.concurrent.TimeUnit;
 import static io.moquette.broker.MQTTConnectionPublishTest.memorySessionsRepository;
 import static io.moquette.BrokerConstants.NO_BUFFER_FLUSH;
 import static io.moquette.broker.NettyChannelAssertions.assertEqualsConnAck;
+import static io.moquette.broker.Session.INFINITE_EXPIRY;
 import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_ACCEPTED;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
@@ -117,7 +118,7 @@ public class SessionRegistryTest {
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
         sessionRepository = memorySessionsRepository();
-        sut = new SessionRegistry(subscriptions, sessionRepository, queueRepository, permitAll, scheduler, slidingClock);
+        sut = new SessionRegistry(subscriptions, sessionRepository, queueRepository, permitAll, scheduler, slidingClock, INFINITE_EXPIRY);
         final PostOffice postOffice = new PostOffice(subscriptions,
             new MemoryRetainedRepository(), sut, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
         return new MQTTConnection(channel, config, mockAuthenticator, sut, postOffice);

--- a/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
@@ -118,7 +118,7 @@ public class SessionRegistryTest {
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
         sessionRepository = memorySessionsRepository();
-        sut = new SessionRegistry(subscriptions, sessionRepository, queueRepository, permitAll, scheduler, slidingClock, INFINITE_EXPIRY);
+        sut = new SessionRegistry(subscriptions, sessionRepository, queueRepository, permitAll, scheduler, slidingClock, INFINITE_EXPIRY, loopsGroup);
         final PostOffice postOffice = new PostOffice(subscriptions,
             new MemoryRetainedRepository(), sut, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
         return new MQTTConnection(channel, config, mockAuthenticator, sut, postOffice);

--- a/broker/src/test/java/io/moquette/broker/SessionTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 
 import static io.moquette.BrokerConstants.FLIGHT_BEFORE_RESEND_MS;
 import io.moquette.broker.subscriptions.Subscription;
+
+import java.time.Clock;
 import java.util.Arrays;
 import org.assertj.core.api.Assertions;
 
@@ -33,7 +35,8 @@ public class SessionTest {
     public void setUp() {
         testChannel = new EmbeddedChannel();
         queuedMessages = new InMemoryQueue();
-        final ISessionsRepository.SessionData data = new ISessionsRepository.SessionData(CLIENT_ID, MqttVersion.MQTT_3_1_1, INFINITE_EXPIRY);
+        final Clock clock = Clock.systemDefaultZone();
+        final ISessionsRepository.SessionData data = new ISessionsRepository.SessionData(CLIENT_ID, MqttVersion.MQTT_3_1_1, INFINITE_EXPIRY, clock);
         client = new Session(data, true, null, queuedMessages);
         createConnection(client);
     }

--- a/distribution/src/main/resources/moquette.conf
+++ b/distribution/src/main/resources/moquette.conf
@@ -205,8 +205,8 @@ password_file config/password_file.conf
 #       This option allows the session of persistent clients (those with clean session set to false) that are not
 #       currently connected to be removed if they do not reconnect within a certain time frame.
 #       This is a non-standard option in MQTT v3.1. MQTT v3.1.1 and v5.0 allow brokers to remove client sessions.
-#       The expiration period should be an integer followed by one of h d w m y for hour, day, week,
-#       month and year respectively. For example: 2m or  14d or 1y
+#       The expiration period should be an integer followed by one of s m h d w M y for seconds, minutes, hours, days, weeks,
+#       months and years respectively. For example: 2m or  14d or 1y
 # default: infinite expiry
 #*********************************************************************
 # persistent_client_expiration 3d

--- a/distribution/src/main/resources/moquette.conf
+++ b/distribution/src/main/resources/moquette.conf
@@ -197,3 +197,17 @@ password_file config/password_file.conf
 # default: immediate
 #*********************************************************************
 # buffer_flush_millis immediate
+
+#*********************************************************************
+# Duration after which expire persisted sessions.
+#
+# persistent_client_expiration:
+#       This option allows the session of persistent clients (those with clean session set to false) that are not
+#       currently connected to be removed if they do not reconnect within a certain time frame.
+#       This is a non-standard option in MQTT v3.1. MQTT v3.1.1 and v5.0 allow brokers to remove client sessions.
+#       The expiration period should be an integer followed by one of h d w m y for hour, day, week,
+#       month and year respectively. For example: 2m or  14d or 1y
+# default: infinite expiry
+#*********************************************************************
+# persistent_client_expiration 3d
+


### PR DESCRIPTION
## Release notes
Implement the logic to expire the not clean sessions.

## What does it do?
Track all expiration time after a session is closed or disconnects. Uses a delay queue to track the not clean session that expires and using a scheduled task, every second, check for the expired sessions and removes from the both SessionRegistry and also from the persistent store (SessionRepositoy).

## Why it's important for the user?
This feature let the user to auto-purge the state of  the not clean session after a certain amount of time configured at broker level in `moquette.conf` file through the `persistent_client_expiration` property which could have the format:
 `<number><unit>` such as 1d for 1 day. Admitted values to unit are `s` `m` `h` `d` `w` `M` `y` which respectively means seconds, minutes, hours, days, weeks, months and years. If not specified this global expiry defaults to INFINITE_EXPIRY which is ~80 years.

- close #662 