### PR TITLE
Extract session event loops from post office

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.17-SNAPSHOT:
+   [refactory] moved code to handle session event loops from PostOffice into separate SessionEventLoopGroup (#742).
    [feature] added new callback method in interceptor to notify exceptions that happens on SessionEventLoop (#736).
    [feature] introduce new `buffer_flush_millis` deprecating the old `immediate_buffer_flush` and switch default behavior to flush on every write (#738).
    [refactory] purge of session state also on disconnect and reused logic (#715).

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -172,12 +172,7 @@ class PostOffice {
     private final IRetainedRepository retainedRepository;
     private SessionRegistry sessionRegistry;
     private BrokerInterceptor interceptor;
-
-//    private final SessionEventLoop[] sessionExecutors;
-//    private final BlockingQueue<FutureTask<String>>[] sessionQueues;
-//    private final int eventLoops = Runtime.getRuntime().availableProcessors();
     private final FailedPublishCollection failedPublishes = new FailedPublishCollection();
-//    private final ConcurrentMap<String, Throwable> loopThrownExceptions = new ConcurrentHashMap<>();
     private final SessionEventLoopGroup sessionLoops;
 
     PostOffice(ISubscriptionsDirectory subscriptions, IRetainedRepository retainedRepository,
@@ -187,33 +182,8 @@ class PostOffice {
         this.retainedRepository = retainedRepository;
         this.sessionRegistry = sessionRegistry;
         this.interceptor = interceptor;
-
-//        this.sessionQueues = new BlockingQueue[eventLoops];
-//        for (int i = 0; i < eventLoops; i++) {
-//            this.sessionQueues[i] = new ArrayBlockingQueue<>(sessionQueueSize);
-//        }
-//        this.sessionExecutors = new SessionEventLoop[eventLoops];
-//        for (int i = 0; i < eventLoops; i++) {
-//            SessionEventLoop newLoop = new SessionEventLoop(this.sessionQueues[i]);
-//            newLoop.setName(sessionLoopName(i));
-//            newLoop.setUncaughtExceptionHandler((loopThread, ex) -> {
-//                // executed in session loop thread
-//                // collect the exception thrown to later re-throw
-//                loopThrownExceptions.put(loopThread.getName(), ex);
-//
-//                // This is done in asynch from another thread in BrokerInterceptor
-//                interceptor.notifyLoopException(new InterceptExceptionMessage(ex));
-//            });
-//            newLoop.start();
-//            this.sessionExecutors[i] = newLoop;
-//        }
-
         this.sessionLoops = new SessionEventLoopGroup(interceptor, sessionQueueSize);
     }
-
-//    private String sessionLoopName(int i) {
-//        return "Session Executor " + i;
-//    }
 
     public void init(SessionRegistry sessionRegistry) {
         this.sessionRegistry = sessionRegistry;
@@ -642,10 +612,6 @@ class PostOffice {
     String sessionLoopThreadName(String clientId) {
         return sessionLoops.sessionLoopThreadName(clientId);
     }
-
-//    private int targetQueueOrdinal(String clientId) {
-//        return Math.abs(clientId.hashCode()) % this.eventLoops;
-//    }
 
     static class SessionEventLoopGroup {
         private static final Logger LOG = LoggerFactory.getLogger(SessionEventLoopGroup.class);

--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -241,8 +241,9 @@ public class Server {
         final Authorizator authorizator = new Authorizator(authorizatorPolicy);
         sessions = new SessionRegistry(subscriptions, sessionsRepository, queueRepository, authorizator);
         final int sessionQueueSize = config.intProp(BrokerConstants.SESSION_QUEUE_SIZE, 1024);
+        final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(interceptor, sessionQueueSize);
         dispatcher = new PostOffice(subscriptions, retainedRepository, sessions, interceptor, authorizator,
-                                    sessionQueueSize);
+            loopsGroup);
         final BrokerConfiguration brokerConfig = new BrokerConfiguration(config);
         MQTTConnectionFactory connectionFactory = new MQTTConnectionFactory(brokerConfig, authenticator, sessions,
                                                                             dispatcher);

--- a/broker/src/main/java/io/moquette/broker/SessionEventLoopGroup.java
+++ b/broker/src/main/java/io/moquette/broker/SessionEventLoopGroup.java
@@ -1,0 +1,105 @@
+package io.moquette.broker;
+
+import io.moquette.interception.BrokerInterceptor;
+import io.moquette.interception.messages.InterceptExceptionMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.FutureTask;
+
+class SessionEventLoopGroup {
+    private static final Logger LOG = LoggerFactory.getLogger(SessionEventLoopGroup.class);
+
+    private final SessionEventLoop[] sessionExecutors;
+    private final BlockingQueue<FutureTask<String>>[] sessionQueues;
+    private final int eventLoops = Runtime.getRuntime().availableProcessors();
+    private final ConcurrentMap<String, Throwable> loopThrownExceptions = new ConcurrentHashMap<>();
+
+    SessionEventLoopGroup(BrokerInterceptor interceptor, int sessionQueueSize) {
+        this.sessionQueues = new BlockingQueue[eventLoops];
+        for (int i = 0; i < eventLoops; i++) {
+            this.sessionQueues[i] = new ArrayBlockingQueue<>(sessionQueueSize);
+        }
+        this.sessionExecutors = new SessionEventLoop[eventLoops];
+        for (int i = 0; i < eventLoops; i++) {
+            SessionEventLoop newLoop = new SessionEventLoop(this.sessionQueues[i]);
+            newLoop.setName(sessionLoopName(i));
+            newLoop.setUncaughtExceptionHandler((loopThread, ex) -> {
+                // executed in session loop thread
+                // collect the exception thrown to later re-throw
+                loopThrownExceptions.put(loopThread.getName(), ex);
+
+                // This is done in asynch from another thread in BrokerInterceptor
+                interceptor.notifyLoopException(new InterceptExceptionMessage(ex));
+            });
+            newLoop.start();
+            this.sessionExecutors[i] = newLoop;
+        }
+    }
+
+    int targetQueueOrdinal(String clientId) {
+        return Math.abs(clientId.hashCode()) % this.eventLoops;
+    }
+
+    private String sessionLoopName(int i) {
+        return "Session Executor " + i;
+    }
+
+    String sessionLoopThreadName(String clientId) {
+        final int targetQueueId = targetQueueOrdinal(clientId);
+        return sessionLoopName(targetQueueId);
+    }
+
+    /**
+     * Route the command to the owning SessionEventLoop
+     */
+    public PostOffice.RouteResult routeCommand(String clientId, String actionDescription, Callable<String> action) {
+        SessionCommand cmd = new SessionCommand(clientId, action);
+        final int targetQueueId = targetQueueOrdinal(cmd.getSessionId());
+        LOG.debug("Routing cmd [{}] for session [{}] to event processor {}", actionDescription, cmd.getSessionId(), targetQueueId);
+        final FutureTask<String> task = new FutureTask<>(() -> {
+            cmd.execute();
+            cmd.complete();
+            return cmd.getSessionId();
+        });
+        if (Thread.currentThread() == sessionExecutors[targetQueueId]) {
+            SessionEventLoop.executeTask(task);
+            return PostOffice.RouteResult.success(clientId, cmd.completableFuture());
+        }
+        if (this.sessionQueues[targetQueueId].offer(task)) {
+            return PostOffice.RouteResult.success(clientId, cmd.completableFuture());
+        } else {
+            LOG.warn("Session command queue {} is full executing action {}", targetQueueId, actionDescription);
+            return PostOffice.RouteResult.failed(clientId);
+        }
+    }
+
+    public void terminate() {
+        for (SessionEventLoop processor : sessionExecutors) {
+            processor.interrupt();
+        }
+        for (SessionEventLoop processor : sessionExecutors) {
+            try {
+                processor.join(5_000);
+            } catch (InterruptedException ex) {
+                LOG.info("Interrupted while joining session event loop {}", processor.getName(), ex);
+            }
+        }
+
+        for (Map.Entry<String, Throwable> loopThrownExceptionEntry : loopThrownExceptions.entrySet()) {
+            String threadName = loopThrownExceptionEntry.getKey();
+            Throwable threadError = loopThrownExceptionEntry.getValue();
+            LOG.error("Session event loop {} terminated with error", threadName, threadError);
+        }
+    }
+
+    public int getEventLoopCount() {
+        return eventLoops;
+    }
+}

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
@@ -73,8 +73,9 @@ public class MQTTConnectionConnectTest {
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll);
+        final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
         postOffice = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
-                                    ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
+                                    ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
 
         sut = createMQTTConnection(CONFIG);
         channel = (EmbeddedChannel) sut.channel;

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
@@ -80,8 +80,9 @@ public class MQTTConnectionPublishTest {
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll);
+        final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
         final PostOffice postOffice = new PostOffice(subscriptions,
-            new MemoryRetainedRepository(), sessionRegistry, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
+            new MemoryRetainedRepository(), sessionRegistry, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
         return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, postOffice);
     }
 

--- a/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
@@ -92,8 +92,9 @@ public class PostOfficeInternalPublishTest {
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll);
+        final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
         sut = new PostOffice(subscriptions, retainedRepository, sessionRegistry,
-                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
+                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
     }
 
     private void internalPublishNotRetainedTo(String topic) {

--- a/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
@@ -106,8 +106,9 @@ public class PostOfficePublishTest {
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll);
+        final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
         sut = new PostOffice(subscriptions, retainedRepository, sessionRegistry,
-                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
+                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
     }
 
     @Test

--- a/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
@@ -98,8 +98,9 @@ public class PostOfficeSubscribeTest {
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll);
+        final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
         sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
-                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
+                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
     }
 
     private MQTTConnection createMQTTConnection(BrokerConfiguration config, Channel channel) {
@@ -171,8 +172,9 @@ public class PostOfficeSubscribeTest {
         when(prohibitReadOnNewsTopic.canRead(eq(new Topic(NEWS_TOPIC)), eq(FAKE_USER_NAME), eq(FAKE_CLIENT_ID)))
             .thenReturn(false);
 
+        final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
         sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
-                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, new Authorizator(prohibitReadOnNewsTopic), 1024);
+                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, new Authorizator(prohibitReadOnNewsTopic), loopsGroup);
 
         connection.processConnect(connectMessage).completableFuture().get();
         ConnectionTestUtils.assertConnectAccepted(channel);

--- a/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
@@ -89,8 +89,9 @@ public class PostOfficeUnsubscribeTest {
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll);
+        final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
         sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
-                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
+                             ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
     }
 
     private MQTTConnection createMQTTConnection(BrokerConfiguration config, Channel channel) {

--- a/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
@@ -88,8 +88,9 @@ public class SessionRegistryTest {
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         sut = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll);
+        final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
         final PostOffice postOffice = new PostOffice(subscriptions,
-            new MemoryRetainedRepository(), sut, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, 1024);
+            new MemoryRetainedRepository(), sut, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
         return new MQTTConnection(channel, config, mockAuthenticator, sut, postOffice);
     }
 


### PR DESCRIPTION
The session event loops is create and manged internally by `PostOffice`, to use the session loops to manipulate the session state in isolation from other part (like for example `SessionRegistry`) the `PostOffice` should be shared, which from a design perspective is not correct. The `PostOffice` should be only responsible to route incoming publish messages down to the subscribers.

This PR extracts all the logic related to session loops in a new separate class `SessionEventLoopGroup`.