### PR TITLE
Avoid NPE if broker yet not started

### DIFF
--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -637,8 +637,9 @@ public class Server {
      * Returns null if the broker is not started.
      * */
     public Collection<ClientDescriptor> listConnectedClients() {
-        if (sessions == null) {
-            return null;
+        if (!initialized) {
+            LOG.error("Moquette is not started, MQTT clients listing unavailable");
+            throw new IllegalStateException("Can't get clients list from a integration that is not yet started");
         }
         return sessions.listConnectedClients();
     }

--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -639,7 +639,7 @@ public class Server {
     public Collection<ClientDescriptor> listConnectedClients() {
         if (!initialized) {
             LOG.error("Moquette is not started, MQTT clients listing unavailable");
-            throw new IllegalStateException("Can't get clients list from a integration that is not yet started");
+            throw new IllegalStateException("Can't get clients list from a Server that is not yet started");
         }
         return sessions.listConnectedClients();
     }

--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -634,8 +634,12 @@ public class Server {
 
     /**
      * Return a list of descriptors of connected clients.
+     * Returns null if the broker is not started.
      * */
     public Collection<ClientDescriptor> listConnectedClients() {
+        if (sessions == null) {
+            return null;
+        }
         return sessions.listConnectedClients();
     }
 }


### PR DESCRIPTION
make listConnectedClients method safe for all broker states

Formaly, there is nothing to restrict one to call clients listing (`server.listConnectedClients()`) immediatelly after constructing instance using `new Server();`. In this case caller will get NulPointerException which may ruin the runtime.
This PR fixes that.