### PR TITLE
Fix embedded test artifact to be built as a project

### DIFF
--- a/embedding_moquette/pom.xml
+++ b/embedding_moquette/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>embedded_test</artifactId>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
     <name>Moquette - Embedded test</name>
 
     <dependencies>


### PR DESCRIPTION
Fix embedded test artifact to be built as a project. With pom type, resources are not processed.