### PR TITLE
Connection filter interface for IP Bans

### DIFF
--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -66,6 +66,8 @@ public final class BrokerConstants {
     public static final String REAUTHORIZE_SUBSCRIPTIONS_ON_CONNECT = "reauthorize_subscriptions_on_connect";
     public static final String ALLOW_ZERO_BYTE_CLIENT_ID_PROPERTY_NAME = "allow_zero_byte_client_id";
     public static final String ACL_FILE_PROPERTY_NAME = "acl_file";
+
+    public static final String CONNECTION_FILTER_CLASS_NAME = "connection_filter_class";
     public static final String AUTHORIZATOR_CLASS_NAME = "authorizator_class";
     public static final String AUTHENTICATOR_CLASS_NAME = "authenticator_class";
     public static final String DB_AUTHENTICATOR_DRIVER = "authenticator.db.driver";

--- a/broker/src/main/java/io/moquette/broker/MQTTConnectionFactory.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnectionFactory.java
@@ -16,24 +16,27 @@
 package io.moquette.broker;
 
 import io.moquette.broker.security.IAuthenticator;
+import io.moquette.broker.security.IConnectionFilter;
 import io.netty.channel.Channel;
 
 class MQTTConnectionFactory {
 
     private final BrokerConfiguration brokerConfig;
     private final IAuthenticator authenticator;
+    private final IConnectionFilter connectionFilter;
     private final SessionRegistry sessionRegistry;
     private final PostOffice postOffice;
 
     MQTTConnectionFactory(BrokerConfiguration brokerConfig, IAuthenticator authenticator,
-                          SessionRegistry sessionRegistry, PostOffice postOffice) {
+                          IConnectionFilter connectionFilter, SessionRegistry sessionRegistry, PostOffice postOffice) {
         this.brokerConfig = brokerConfig;
         this.authenticator = authenticator;
+        this.connectionFilter = connectionFilter;
         this.sessionRegistry = sessionRegistry;
         this.postOffice = postOffice;
     }
 
     MQTTConnection create(Channel channel) {
-        return new MQTTConnection(channel, brokerConfig, authenticator, sessionRegistry, postOffice);
+        return new MQTTConnection(channel, brokerConfig, authenticator, connectionFilter, sessionRegistry, postOffice);
     }
 }

--- a/broker/src/main/java/io/moquette/broker/security/IConnectionFilter.java
+++ b/broker/src/main/java/io/moquette/broker/security/IConnectionFilter.java
@@ -1,0 +1,7 @@
+package io.moquette.broker.security;
+
+import io.moquette.broker.ClientDescriptor;
+
+public interface IConnectionFilter {
+    boolean allowConnection(ClientDescriptor clientDescriptor);
+}

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
@@ -55,6 +55,7 @@ public class MQTTConnectionConnectTest {
     private SessionRegistry sessionRegistry;
     private MqttMessageBuilders.ConnectBuilder connMsg;
     private static final BrokerConfiguration CONFIG = new BrokerConfiguration(true, true, false, NO_BUFFER_FLUSH);
+    private MockConnectionFilter connectionFilter = new MockConnectionFilter();
     private IAuthenticator mockAuthenticator;
     private PostOffice postOffice;
     private MemoryQueueRepository queueRepository;
@@ -92,7 +93,7 @@ public class MQTTConnectionConnectTest {
     }
 
     private MQTTConnection createMQTTConnection(BrokerConfiguration config, Channel channel, PostOffice postOffice) {
-        return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, postOffice);
+        return new MQTTConnection(channel, config, mockAuthenticator, connectionFilter, sessionRegistry, postOffice);
     }
 
     @Test
@@ -192,6 +193,23 @@ public class MQTTConnectionConnectTest {
         // Verify
         assertEqualsConnAck(CONNECTION_ACCEPTED, channel.readOutbound());
         assertTrue(channel.isOpen(), "Connection is accepted and therefore must remain open");
+    }
+
+
+    @Test
+    public void validAuthenticationBannedClient() throws ExecutionException, InterruptedException {
+        MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID)
+            .username(TEST_USER).password(TEST_PWD).build();
+
+        connectionFilter.banClientId(FAKE_CLIENT_ID);
+
+        // Exercise
+        PostOffice.RouteResult result = sut.processConnect(msg);
+        assertFalse(result.isSuccess());
+
+        // Verify
+        assertEqualsConnAck(CONNECTION_REFUSED_BANNED, channel.readOutbound());
+        assertFalse(channel.isOpen(), "Connection is refused/baned and therefore must not remain open");
     }
 
     @Test

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
@@ -15,6 +15,7 @@
  */
 package io.moquette.broker;
 
+import io.moquette.broker.security.IConnectionFilter;
 import io.moquette.broker.security.PermitAllAuthorizatorPolicy;
 import io.moquette.broker.subscriptions.CTrieSubscriptionDirectory;
 import io.moquette.broker.subscriptions.ISubscriptionsDirectory;
@@ -71,6 +72,7 @@ public class MQTTConnectionPublishTest {
     private MQTTConnection createMQTTConnection(BrokerConfiguration config, Channel channel) {
         IAuthenticator mockAuthenticator = new MockAuthenticator(singleton(FAKE_CLIENT_ID),
                                                                  singletonMap(TEST_USER, TEST_PWD));
+        IConnectionFilter connectionFilter = new MockConnectionFilter();
 
         ISubscriptionsDirectory subscriptions = new CTrieSubscriptionDirectory();
         ISubscriptionsRepository subscriptionsRepository = new MemorySubscriptionsRepository();
@@ -83,7 +85,7 @@ public class MQTTConnectionPublishTest {
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
         final PostOffice postOffice = new PostOffice(subscriptions,
             new MemoryRetainedRepository(), sessionRegistry, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
-        return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, postOffice);
+        return new MQTTConnection(channel, config, mockAuthenticator, connectionFilter, sessionRegistry, postOffice);
     }
 
 //    @NotNull

--- a/broker/src/test/java/io/moquette/broker/MockConnectionFilter.java
+++ b/broker/src/test/java/io/moquette/broker/MockConnectionFilter.java
@@ -1,0 +1,33 @@
+package io.moquette.broker;
+
+import io.moquette.broker.security.IConnectionFilter;
+
+import java.util.Set;
+import java.util.HashSet;
+import java.util.stream.Stream;
+
+public class MockConnectionFilter implements IConnectionFilter {
+    private Set<String> bannedClientIds = new HashSet<>();
+    private Set<String> bannedAddresses = new HashSet<>();
+    @Override
+    public boolean allowConnection(ClientDescriptor clientDescriptor) {
+        return !bannedClientIds.contains(clientDescriptor.getClientID())
+            && !bannedAddresses.contains(clientDescriptor.getAddress());
+    }
+
+    public MockConnectionFilter banClientId(String clientId) {
+        bannedClientIds.add(clientId);
+        return this;
+    }
+
+    public MockConnectionFilter banAddress(String address) {
+        bannedAddresses.add(address);
+        return this;
+    }
+
+    public MockConnectionFilter reset() {
+        bannedClientIds = new HashSet<>();
+        bannedAddresses = new HashSet<>();
+        return this;
+    }
+}

--- a/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
@@ -54,6 +54,7 @@ public class PostOfficeInternalPublishTest {
     private ISubscriptionsDirectory subscriptions;
     private MqttConnectMessage connectMessage;
     private SessionRegistry sessionRegistry;
+    private MockConnectionFilter connectionFilter = new MockConnectionFilter();
     private MockAuthenticator mockAuthenticator;
     private static final BrokerConfiguration ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID =
         new BrokerConfiguration(true, true, false, NO_BUFFER_FLUSH);
@@ -79,7 +80,7 @@ public class PostOfficeInternalPublishTest {
     }
 
     private MQTTConnection createMQTTConnection(BrokerConfiguration config, Channel channel) {
-        return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, sut);
+        return new MQTTConnection(channel, config, mockAuthenticator, connectionFilter, sessionRegistry, sut);
     }
 
     private void initPostOfficeAndSubsystems() {

--- a/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
@@ -66,6 +66,7 @@ public class PostOfficePublishTest {
     public static final String FAKE_USER_NAME = "UnAuthUser";
     private MqttConnectMessage connectMessage;
     private SessionRegistry sessionRegistry;
+    private MockConnectionFilter connectionFilter = new MockConnectionFilter();
     private MockAuthenticator mockAuthenticator;
     static final BrokerConfiguration ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID =
         new BrokerConfiguration(true, true, false, NO_BUFFER_FLUSH);
@@ -93,7 +94,7 @@ public class PostOfficePublishTest {
     }
 
     private MQTTConnection createMQTTConnection(BrokerConfiguration config, Channel channel) {
-        return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, sut);
+        return new MQTTConnection(channel, config, mockAuthenticator, connectionFilter, sessionRegistry, sut);
     }
 
     private void initPostOfficeAndSubsystems() {

--- a/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
@@ -67,6 +67,7 @@ public class PostOfficeSubscribeTest {
     private ISubscriptionsDirectory subscriptions;
     public static final String FAKE_USER_NAME = "UnAuthUser";
     private MqttConnectMessage connectMessage;
+    private MockConnectionFilter connectionFilter = new MockConnectionFilter();
     private IAuthenticator mockAuthenticator;
     private SessionRegistry sessionRegistry;
     public static final BrokerConfiguration CONFIG = new BrokerConfiguration(true, true, false, NO_BUFFER_FLUSH);
@@ -104,7 +105,7 @@ public class PostOfficeSubscribeTest {
     }
 
     private MQTTConnection createMQTTConnection(BrokerConfiguration config, Channel channel) {
-        return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, sut);
+        return new MQTTConnection(channel, config, mockAuthenticator, connectionFilter, sessionRegistry, sut);
     }
 
     protected void connect() {

--- a/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
@@ -58,6 +58,7 @@ public class PostOfficeUnsubscribeTest {
     private PostOffice sut;
     private ISubscriptionsDirectory subscriptions;
     private MqttConnectMessage connectMessage;
+    private MockConnectionFilter connectionFilter = new MockConnectionFilter();
     private IAuthenticator mockAuthenticator;
     private SessionRegistry sessionRegistry;
     public static final BrokerConfiguration CONFIG = new BrokerConfiguration(true, true, false, NO_BUFFER_FLUSH);
@@ -95,7 +96,7 @@ public class PostOfficeUnsubscribeTest {
     }
 
     private MQTTConnection createMQTTConnection(BrokerConfiguration config, Channel channel) {
-        return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, sut);
+        return new MQTTConnection(channel, config, mockAuthenticator, connectionFilter, sessionRegistry, sut);
     }
 
     protected static void connect(MQTTConnection connection, String clientId) {

--- a/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
@@ -79,6 +79,7 @@ public class SessionRegistryTest {
     private MQTTConnection createMQTTConnection(BrokerConfiguration config, Channel channel) {
         IAuthenticator mockAuthenticator = new MockAuthenticator(singleton(FAKE_CLIENT_ID),
                                                                  singletonMap(TEST_USER, TEST_PWD));
+        MockConnectionFilter connectionFilter = new MockConnectionFilter();
 
         ISubscriptionsDirectory subscriptions = new CTrieSubscriptionDirectory();
         ISubscriptionsRepository subscriptionsRepository = new MemorySubscriptionsRepository();
@@ -91,7 +92,7 @@ public class SessionRegistryTest {
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
         final PostOffice postOffice = new PostOffice(subscriptions,
             new MemoryRetainedRepository(), sut, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
-        return new MQTTConnection(channel, config, mockAuthenticator, sut, postOffice);
+        return new MQTTConnection(channel, config, mockAuthenticator, connectionFilter, sut, postOffice);
     }
 
     @Test

--- a/broker/src/test/java/io/moquette/broker/SessionTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionTest.java
@@ -19,7 +19,6 @@ import static io.moquette.broker.Session.INFINITE_EXPIRY;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static io.moquette.BrokerConstants.NO_BUFFER_FLUSH;
-import static org.junit.jupiter.api.Assertions.*;
 
 public class SessionTest {
 
@@ -122,7 +121,7 @@ public class SessionTest {
 
     private void createConnection(Session client) {
         BrokerConfiguration brokerConfiguration = new BrokerConfiguration(true, false, false, NO_BUFFER_FLUSH);
-        MQTTConnection mqttConnection = new MQTTConnection(testChannel, brokerConfiguration, null, null, null);
+        MQTTConnection mqttConnection = new MQTTConnection(testChannel, brokerConfiguration, null, null, null, null);
         client.markConnecting();
         client.bind(mqttConnection);
         client.completeConnection();

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationPahoCanPublishOnReadBlockedTopicTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationPahoCanPublishOnReadBlockedTopicTest.java
@@ -96,7 +96,7 @@ public class ServerIntegrationPahoCanPublishOnReadBlockedTopicTest {
             }
         };
 
-        m_server.startServer(m_config, EMPTY_OBSERVERS, null, new AcceptAllAuthenticator(), switchingAuthorizator);
+        m_server.startServer(m_config, EMPTY_OBSERVERS, null, null, new AcceptAllAuthenticator(), switchingAuthorizator);
     }
 
     @BeforeEach


### PR DESCRIPTION
I'm doing an integration with an application server (Quarkus). Due to some legacy support requirements, we do need to leave some endpoints rather open to abuse, so we are monitoring client connections, message counts and payloads to watch for DoS attempts.

If their message count for a given topic far exceeds a normal threshold, or their payloads balloon in size, or they start sending us garbage, I'd like to ban the clients by IP. This is a shot at making an interface similar to the `IAuthenticator` interface for vetoing client connections.

Suggestions welcome. It is currently possible for me to work around the need for this using dependency injection, but that creates a circular dependency between the broker (`Server::listConnectedClients`) and the `IAuthenticator`.