### PR TITLE
[infra] Moved GH Actions CI build from Ubuntu 18.04  to 20.04

### DIFF
--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:
-                os: [ubuntu-18.04, ubuntu-latest]
+                os: [ubuntu-20.04, ubuntu-latest]
                 java: [11, 17]
                 arch: [x64] # when ARM will be present add aarch64
             fail-fast: false


### PR DESCRIPTION
Moved GH Actions CI build from Ubuntu 18.04 (unsupported by 2022/12/01) to Ubuntu 20.04