### PR TITLE
Fixed #633 adding subscriptions

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.17-SNAPSHOT:
+   [fix] resolved issue #633 of bad perfomance when adding many subscriptions to few topics, resolved in #758.
    [fix] resolved issue #629 that originated from subscription trees wide and flat, resolved in #630
    [dependency] updated Netty to 4.1.93 and tcnative to 2.0.61 (#755)
    [feature] add saved session expiry configurable through the `persistent_client_expiration` setting (#739).

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -455,7 +455,7 @@ class PostOffice {
 
     private RoutingResults publish2Subscribers(ByteBuf payload, Topic topic, MqttQoS publishingQos,
                                                Set<String> filterTargetClients) {
-        Set<Subscription> topicMatchingSubscriptions = subscriptions.matchQosSharpening(topic);
+        List<Subscription> topicMatchingSubscriptions = subscriptions.matchQosSharpening(topic);
         if (topicMatchingSubscriptions.isEmpty()) {
             // no matching subscriptions, clean exit
             LOG.trace("No matching subscriptions for topic: {}", topic);

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
@@ -1,7 +1,9 @@
 package io.moquette.broker.subscriptions;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -64,24 +66,24 @@ public class CTrie {
         return NavigationAction.GODEEP;
     }
 
-    public Set<Subscription> recursiveMatch(Topic topic) {
+    public List<Subscription> recursiveMatch(Topic topic) {
         return recursiveMatch(topic, this.root);
     }
 
-    private Set<Subscription> recursiveMatch(Topic topic, INode inode) {
+    private List<Subscription> recursiveMatch(Topic topic, INode inode) {
         CNode cnode = inode.mainNode();
         if (cnode instanceof TNode) {
-            return Collections.emptySet();
+            return Collections.emptyList();
         }
         NavigationAction action = evaluate(topic, cnode);
         if (action == NavigationAction.MATCH) {
             return cnode.subscriptions;
         }
         if (action == NavigationAction.STOP) {
-            return Collections.emptySet();
+            return Collections.emptyList();
         }
         Topic remainingTopic = (ROOT.equals(cnode.getToken())) ? topic : topic.exceptHeadToken();
-        Set<Subscription> subscriptions = new HashSet<>();
+        List<Subscription> subscriptions = new ArrayList<>();
 
         // We should only consider the maximum three children children of
         // type #, + or exact match

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
@@ -76,13 +76,13 @@ public class CTrieSubscriptionDirectory implements ISubscriptionsDirectory {
      * @return the list of matching subscriptions, or empty if not matching.
      */
     @Override
-    public Set<Subscription> matchWithoutQosSharpening(Topic topic) {
+    public List<Subscription> matchWithoutQosSharpening(Topic topic) {
         return ctrie.recursiveMatch(topic);
     }
 
     @Override
-    public Set<Subscription> matchQosSharpening(Topic topic) {
-        final Set<Subscription> subscriptions = matchWithoutQosSharpening(topic);
+    public List<Subscription> matchQosSharpening(Topic topic) {
+        final List<Subscription> subscriptions = matchWithoutQosSharpening(topic);
 
         Map<String, Subscription> subsGroupedByClient = new HashMap<>();
         for (Subscription sub : subscriptions) {
@@ -92,7 +92,7 @@ public class CTrieSubscriptionDirectory implements ISubscriptionsDirectory {
                 subsGroupedByClient.put(sub.clientId, sub);
             }
         }
-        return new HashSet<>(subsGroupedByClient.values());
+        return new ArrayList<>(subsGroupedByClient.values());
     }
 
     @Override

--- a/broker/src/main/java/io/moquette/broker/subscriptions/ISubscriptionsDirectory.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/ISubscriptionsDirectory.java
@@ -26,9 +26,9 @@ public interface ISubscriptionsDirectory {
 
     Set<String> listAllSessionIds();
 
-    Set<Subscription> matchWithoutQosSharpening(Topic topic);
+    List<Subscription> matchWithoutQosSharpening(Topic topic);
 
-    Set<Subscription> matchQosSharpening(Topic topic);
+    List<Subscription> matchQosSharpening(Topic topic);
 
     void add(Subscription newSubscription);
 

--- a/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
@@ -42,6 +42,7 @@ import static io.netty.handler.codec.mqtt.MqttQoS.*;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
+import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class PostOfficeInternalPublishTest {
@@ -337,7 +338,7 @@ public class PostOfficeInternalPublishTest {
         final String clientId = connection.getClientId();
         Subscription expectedSubscription = new Subscription(clientId, new Topic(topic), desiredQos);
 
-        final Set<Subscription> matchedSubscriptions = subscriptions.matchWithoutQosSharpening(new Topic(topic));
+        final List<Subscription> matchedSubscriptions = subscriptions.matchWithoutQosSharpening(new Topic(topic));
         assertEquals(1, matchedSubscriptions.size());
         final Subscription onlyMatchedSubscription = matchedSubscriptions.iterator().next();
         assertEquals(expectedSubscription, onlyMatchedSubscription);

--- a/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
@@ -196,7 +196,7 @@ public class PostOfficePublishTest {
         final String clientId = connection.getClientId();
         Subscription expectedSubscription = new Subscription(clientId, new Topic(topic), desiredQos);
 
-        final Set<Subscription> matchedSubscriptions = subscriptions.matchWithoutQosSharpening(new Topic(topic));
+        final List<Subscription> matchedSubscriptions = subscriptions.matchWithoutQosSharpening(new Topic(topic));
         assertEquals(1, matchedSubscriptions.size());
         final Subscription onlyMatchedSubscription = matchedSubscriptions.iterator().next();
         assertEquals(expectedSubscription, onlyMatchedSubscription);

--- a/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
@@ -144,7 +144,7 @@ public class PostOfficeSubscribeTest {
         final String clientId = NettyUtils.clientID(channel);
         Subscription expectedSubscription = new Subscription(clientId, new Topic(topic), desiredQos);
 
-        final Set<Subscription> matchedSubscriptions = subscriptions.matchWithoutQosSharpening(new Topic(topic));
+        final List<Subscription> matchedSubscriptions = subscriptions.matchWithoutQosSharpening(new Topic(topic));
         assertEquals(1, matchedSubscriptions.size());
         final Subscription onlyMatchedSubscription = matchedSubscriptions.iterator().next();
         assertEquals(expectedSubscription, onlyMatchedSubscription);
@@ -164,7 +164,7 @@ public class PostOfficeSubscribeTest {
         final String clientId = connection.getClientId();
         Subscription expectedSubscription = new Subscription(clientId, new Topic(topic), desiredQos);
 
-        final Set<Subscription> matchedSubscriptions = subscriptions.matchWithoutQosSharpening(new Topic(topic));
+        final List<Subscription> matchedSubscriptions = subscriptions.matchWithoutQosSharpening(new Topic(topic));
         assertEquals(1, matchedSubscriptions.size());
         final Subscription onlyMatchedSubscription = matchedSubscriptions.iterator().next();
         assertEquals(expectedSubscription, onlyMatchedSubscription);

--- a/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
@@ -41,6 +41,7 @@ import static io.moquette.BrokerConstants.NO_BUFFER_FLUSH;
 import static io.moquette.broker.PostOfficePublishTest.PUBLISHER_ID;
 import static io.netty.handler.codec.mqtt.MqttQoS.*;
 import static java.util.Collections.*;
+import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -123,7 +124,7 @@ public class PostOfficeUnsubscribeTest {
         final String clientId = connection.getClientId();
         Subscription expectedSubscription = new Subscription(clientId, new Topic(topic), desiredQos);
 
-        final Set<Subscription> matchedSubscriptions = subscriptions.matchQosSharpening(new Topic(topic));
+        final List<Subscription> matchedSubscriptions = subscriptions.matchQosSharpening(new Topic(topic));
         assertEquals(1, matchedSubscriptions.size());
         //assertTrue(matchedSubscriptions.size() >=1);
         final Subscription onlyMatchedSubscription = matchedSubscriptions.iterator().next();

--- a/broker/src/test/java/io/moquette/broker/subscriptions/CTrieSpeedTest.java
+++ b/broker/src/test/java/io/moquette/broker/subscriptions/CTrieSpeedTest.java
@@ -16,8 +16,10 @@
 package io.moquette.broker.subscriptions;
 
 import static io.moquette.broker.subscriptions.Topic.asTopic;
+import io.netty.handler.codec.mqtt.MqttQoS;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -33,6 +35,13 @@ public class CTrieSpeedTest {
 
     static Subscription clientSubOnTopic(String clientID, String topicName) {
         return new Subscription(clientID, asTopic(topicName), null);
+    }
+
+    @Test
+    @Timeout(value = MAX_DURATION_S)
+    public void testManyClientsFewTopics() {
+        List<Subscription> subscriptionList = prepareSubscriptionsManyClientsFewTopic();
+        createSubscriptions(subscriptionList);
     }
 
     @Test
@@ -71,6 +80,15 @@ public class CTrieSpeedTest {
         long end = System.currentTimeMillis();
         long duration = end - start;
         LOGGER.info("Added " + count + " subscriptions in " + duration + " ms (" + Math.round(1000.0 * count / duration) + "/s)");
+    }
+
+    public List<Subscription> prepareSubscriptionsManyClientsFewTopic() {
+        List<Subscription> subscriptionList = new ArrayList<>(TOTAL_SUBSCRIPTIONS);
+        for (int i = 0; i < TOTAL_SUBSCRIPTIONS; i++) {
+            Topic topic = asTopic("topic/test/" + new Random().nextInt(1 + i % 10) + "/test");
+            subscriptionList.add(new Subscription("TestClient-" + i, topic, MqttQoS.AT_LEAST_ONCE));
+        }
+        return subscriptionList;
     }
 
     public List<Subscription> prepareSubscriptionsFlat() {

--- a/broker/src/test/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectoryMatchingTest.java
+++ b/broker/src/test/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectoryMatchingTest.java
@@ -27,6 +27,7 @@ import java.util.Set;
 
 import static io.moquette.broker.subscriptions.CTrieTest.clientSubOnTopic;
 import static io.moquette.broker.subscriptions.Topic.asTopic;
+import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -203,7 +204,7 @@ public class CTrieSubscriptionDirectoryMatchingTest {
         sut.add(specificSub);
 
         //Exercise
-        final Set<Subscription> matchingForSpecific = sut.matchQosSharpening(asTopic("a/b"));
+        final List<Subscription> matchingForSpecific = sut.matchQosSharpening(asTopic("a/b"));
 
         // Verify
         assertThat(matchingForSpecific.size()).isEqualTo(1);
@@ -234,7 +235,7 @@ public class CTrieSubscriptionDirectoryMatchingTest {
         sut.removeSubscription(asTopic("/topic"), slashSub.clientId);
 
         // Verify
-        final Set<Subscription> matchingSubscriptions = sut.matchWithoutQosSharpening(asTopic("/topic"));
+        final List<Subscription> matchingSubscriptions = sut.matchWithoutQosSharpening(asTopic("/topic"));
         assertThat(matchingSubscriptions).isEmpty();
     }
 
@@ -252,7 +253,7 @@ public class CTrieSubscriptionDirectoryMatchingTest {
         this.sut.add(client1SubQoS2);
 
         // Verify
-        Set<Subscription> subscriptions = this.sut.matchQosSharpening(asTopic("client/test/b"));
+        List<Subscription> subscriptions = this.sut.matchQosSharpening(asTopic("client/test/b"));
         assertThat(subscriptions).contains(client1SubQoS2);
         assertThat(subscriptions).contains(client2Sub);
 

--- a/broker/src/test/java/io/moquette/broker/subscriptions/CTrieTest.java
+++ b/broker/src/test/java/io/moquette/broker/subscriptions/CTrieTest.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static io.moquette.broker.subscriptions.Topic.asTopic;
+import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -94,7 +95,7 @@ public class CTrieTest {
         //Verify
         final Optional<CNode> matchedNode = sut.lookup(asTopic("/temp"));
         assertTrue(matchedNode.isPresent(), "Node on path /temp must be present");
-        final Set<Subscription> subscriptions = matchedNode.get().subscriptions;
+        final List<Subscription> subscriptions = matchedNode.get().subscriptions;
         assertTrue(subscriptions.contains(newSubscription));
     }
 
@@ -109,7 +110,7 @@ public class CTrieTest {
         //Verify
         final Optional<CNode> matchedNode = sut.lookup(asTopic("/italy/happiness"));
         assertTrue(matchedNode.isPresent(), "Node on path /italy/happiness must be present");
-        final Set<Subscription> subscriptions = matchedNode.get().subscriptions;
+        final List<Subscription> subscriptions = matchedNode.get().subscriptions;
         assertTrue(subscriptions.contains(happinessSensor));
     }
 
@@ -176,7 +177,7 @@ public class CTrieTest {
         sut.removeFromTree(asTopic("/temp/1"), "TempSensor1");
 
         sut.removeFromTree(asTopic("/temp/1"), "TempSensor1");
-        final Set<Subscription> matchingSubs = sut.recursiveMatch(asTopic("/temp/2"));
+        final List<Subscription> matchingSubs = sut.recursiveMatch(asTopic("/temp/2"));
 
         //Verify
         final Subscription expectedMatchingsub = new Subscription("TempSensor1", asTopic("/temp/2"), MqttQoS.AT_MOST_ONCE);
@@ -191,8 +192,8 @@ public class CTrieTest {
         //Exercise
         sut.removeFromTree(asTopic("/temp"), "TempSensor1");
 
-        final Set<Subscription> matchingSubs1 = sut.recursiveMatch(asTopic("/temp/1"));
-        final Set<Subscription> matchingSubs2 = sut.recursiveMatch(asTopic("/temp/2"));
+        final List<Subscription> matchingSubs1 = sut.recursiveMatch(asTopic("/temp/1"));
+        final List<Subscription> matchingSubs2 = sut.recursiveMatch(asTopic("/temp/2"));
 
         //Verify
         // not clear to me, but I believe /temp unsubscribe should not unsub you from downstream /temp/1 or /temp/2
@@ -218,7 +219,7 @@ public class CTrieTest {
         sut.addToTree(clientSubOnTopic("TempSensor1", "/temp"));
 
         //Exercise
-        final Set<Subscription> matchingSubs = sut.recursiveMatch(asTopic("/temp"));
+        final List<Subscription> matchingSubs = sut.recursiveMatch(asTopic("/temp"));
 
         //Verify
         final Subscription expectedMatchingsub = new Subscription("TempSensor1", asTopic("/temp"), MqttQoS.AT_MOST_ONCE);
@@ -231,8 +232,8 @@ public class CTrieTest {
         sut.addToTree(clientSubOnTopic("TempSensor1", "temp/1"));
 
         //Exercise
-        final Set<Subscription> matchingSubs1 = sut.recursiveMatch(asTopic("temp"));
-        final Set<Subscription> matchingSubs2 = sut.recursiveMatch(asTopic("temp/1"));
+        final List<Subscription> matchingSubs1 = sut.recursiveMatch(asTopic("temp"));
+        final List<Subscription> matchingSubs2 = sut.recursiveMatch(asTopic("temp/1"));
 
         //Verify
         final Subscription expectedMatchingsub1 = new Subscription("TempSensor1", asTopic("temp"), MqttQoS.AT_MOST_ONCE);
@@ -244,8 +245,8 @@ public class CTrieTest {
         sut.removeFromTree(asTopic("temp"), "TempSensor1");
 
         //Exercise
-        final Set<Subscription> matchingSubs3 = sut.recursiveMatch(asTopic("temp"));
-        final Set<Subscription> matchingSubs4 = sut.recursiveMatch(asTopic("temp/1"));
+        final List<Subscription> matchingSubs3 = sut.recursiveMatch(asTopic("temp"));
+        final List<Subscription> matchingSubs4 = sut.recursiveMatch(asTopic("temp/1"));
 
         assertThat(matchingSubs3).doesNotContain(expectedMatchingsub1);
         assertThat(matchingSubs4).contains(expectedMatchingsub2);
@@ -257,8 +258,8 @@ public class CTrieTest {
         sut.addToTree(clientSubOnTopic("TempSensor2", "temp/1"));
 
         //Exercise
-        final Set<Subscription> matchingSubs1 = sut.recursiveMatch(asTopic("temp"));
-        final Set<Subscription> matchingSubs2 = sut.recursiveMatch(asTopic("temp/1"));
+        final List<Subscription> matchingSubs1 = sut.recursiveMatch(asTopic("temp"));
+        final List<Subscription> matchingSubs2 = sut.recursiveMatch(asTopic("temp/1"));
 
         //Verify
         final Subscription expectedMatchingsub1 = new Subscription("TempSensor1", asTopic("temp"), MqttQoS.AT_MOST_ONCE);
@@ -270,8 +271,8 @@ public class CTrieTest {
         sut.removeFromTree(asTopic("temp"), "TempSensor1");
 
         //Exercise
-        final Set<Subscription> matchingSubs3 = sut.recursiveMatch(asTopic("temp"));
-        final Set<Subscription> matchingSubs4 = sut.recursiveMatch(asTopic("temp/1"));
+        final List<Subscription> matchingSubs3 = sut.recursiveMatch(asTopic("temp"));
+        final List<Subscription> matchingSubs4 = sut.recursiveMatch(asTopic("temp/1"));
 
         assertThat(matchingSubs3).doesNotContain(expectedMatchingsub1);
         assertThat(matchingSubs4).contains(expectedMatchingsub2);
@@ -283,8 +284,8 @@ public class CTrieTest {
         sut.addToTree(clientSubOnTopic("TempSensor2", "temp/1"));
 
         //Exercise
-        final Set<Subscription> matchingSubs1 = sut.recursiveMatch(asTopic("temp"));
-        final Set<Subscription> matchingSubs2 = sut.recursiveMatch(asTopic("temp/1"));
+        final List<Subscription> matchingSubs1 = sut.recursiveMatch(asTopic("temp"));
+        final List<Subscription> matchingSubs2 = sut.recursiveMatch(asTopic("temp/1"));
 
         //Verify
         final Subscription expectedMatchingsub1 = new Subscription("TempSensor1", asTopic("temp"), MqttQoS.AT_MOST_ONCE);
@@ -296,8 +297,8 @@ public class CTrieTest {
         sut.removeFromTree(asTopic("temp/1"), "TempSensor2");
 
         //Exercise
-        final Set<Subscription> matchingSubs3 = sut.recursiveMatch(asTopic("temp"));
-        final Set<Subscription> matchingSubs4 = sut.recursiveMatch(asTopic("temp/1"));
+        final List<Subscription> matchingSubs3 = sut.recursiveMatch(asTopic("temp"));
+        final List<Subscription> matchingSubs4 = sut.recursiveMatch(asTopic("temp/1"));
 
         assertThat(matchingSubs3).contains(expectedMatchingsub1);
         assertThat(matchingSubs4).doesNotContain(expectedMatchingsub2);


### PR DESCRIPTION
Converted subscription from HashSet to ArrayList
   
Copying a Set is much slower than copying an ArrayList. Since the slow part in the code is the copy step, using an ArrayList is much faster overall. Since the code using the subscriptions only iterates over them, the change from Set to List makes no real difference.

Fixes #633 