### PR TITLE
Handle will delay interval and MQTT5's Will optional properties

### DIFF
--- a/.github/workflows/maven_central_release_version.yml
+++ b/.github/workflows/maven_central_release_version.yml
@@ -16,7 +16,7 @@ jobs:
         steps:
             - uses: actions/checkout@v2
             - name: Set up Maven Central Repository
-              uses: actions/setup-java@v3
+              uses: actions/setup-java@v1
               with:
                   java-version: 11
                   server-id: ossrh

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.18-SNAPSHOT:
+   [feature] Handle will delay interval and MQTT5's Will optional properties (#770)
    [fix] Handle empty collector batches in PostOffice (#777)
    [feature] Introduce a new option "PEER_CERTIFICATE_AS_USERNAME". When enabled, the client certificate is provided as the username to the authenticator.
 

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -14,9 +14,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <netty.version>4.1.93.Final</netty.version>
+        <netty.version>4.1.100.Final</netty.version>
         <!-- Check Netty pom.xm to know the right version of tcnative, for example
-             https://github.com/netty/netty/blob/netty-4.1.93.Final/pom.xml#L625 -->
+             https://github.com/netty/netty/blob/netty-4.1.100.Final/pom.xml#L650 -->
         <netty.tcnative.version>2.0.61.Final</netty.tcnative.version>
         <paho.version>1.2.5</paho.version>
         <hivemqclient.version>1.3.0</hivemqclient.version>

--- a/broker/src/main/java/io/moquette/broker/ISessionsRepository.java
+++ b/broker/src/main/java/io/moquette/broker/ISessionsRepository.java
@@ -4,8 +4,10 @@ import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.handler.codec.mqtt.MqttVersion;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Delayed;
@@ -176,6 +178,79 @@ public interface ISessionsRepository {
         }
     }
 
+    final class WillOptions {
+
+        private final Duration messageExpiry;
+        private final String contentType;
+        private final String responseTopic;
+        private final byte[] correlationData;
+        private final Map<String, String> userProperties;
+        private final boolean empty;
+
+        private WillOptions(Duration messageExpiry, String contentType, String responseTopic, byte[] correlationData,
+                            Map<String, String> userProperties, boolean empty) {
+            this.messageExpiry = messageExpiry;
+            this.contentType = contentType;
+            this.responseTopic = responseTopic;
+            this.correlationData = correlationData;
+            this.userProperties = userProperties;
+            this.empty = empty;
+        }
+
+        public static WillOptions empty() {
+            return new WillOptions(null, null, null, null, null, true);
+        }
+
+        public WillOptions withMessageExpiry(Duration interval) {
+            Objects.requireNonNull(interval, "A valid interval duration must be provided");
+            return new WillOptions(interval, this.contentType, this.responseTopic, this.correlationData, this.userProperties, true);
+        }
+
+        public WillOptions withContentType(String contentType) {
+            Objects.requireNonNull(contentType, "A valid contentType string must be provided");
+            return new WillOptions(this.messageExpiry, contentType, this.responseTopic, this.correlationData, this.userProperties, true);
+        }
+
+        public WillOptions withResponseTopic(String responseTopic) {
+            Objects.requireNonNull(responseTopic, "A valid responseTopic string must be provided");
+            return new WillOptions(this.messageExpiry, this.contentType, responseTopic, this.correlationData, this.userProperties, true);
+        }
+
+        public WillOptions withCorrelationData(byte[] correlationData) {
+            Objects.requireNonNull(correlationData, "A valid correlationData string must be provided");
+            return new WillOptions(this.messageExpiry, this.contentType, this.responseTopic, correlationData, this.userProperties, true);
+        }
+
+        public WillOptions withUserProperties(Map<String, String> properties) {
+            Objects.requireNonNull(properties, "A valid properties Map must be provided");
+            return new WillOptions(this.messageExpiry, this.contentType, this.responseTopic, this.correlationData, properties, true);
+        }
+
+        public Optional<Duration> messageExpiry() {
+            return Optional.ofNullable(this.messageExpiry);
+        }
+
+        public Optional<String> contentType() {
+            return Optional.ofNullable(this.contentType);
+        }
+
+        public Optional<String> responseTopic() {
+            return Optional.ofNullable(this.responseTopic);
+        }
+
+        public Optional<byte[]> correlationData() {
+            return Optional.ofNullable(this.correlationData);
+        }
+
+        public Optional<Map<String, String>> userProperties() {
+            return Optional.ofNullable(this.userProperties);
+        }
+
+        public boolean notEmpty() {
+            return empty;
+        }
+    }
+
      final class Will implements Expirable {
 
          public final String topic;
@@ -183,6 +258,7 @@ public interface ISessionsRepository {
          public final MqttQoS qos;
          public final boolean retained;
          public final int delayInterval;
+         public final WillOptions properties;
          private Instant expireAt = null;
 
          public Will(String topic, byte[] payload, MqttQoS qos, boolean retained, int delayInterval) {
@@ -191,11 +267,28 @@ public interface ISessionsRepository {
              this.qos = qos;
              this.retained = retained;
              this.delayInterval = delayInterval;
+             this.properties = ISessionsRepository.WillOptions.empty();
          }
 
+         /**
+          * Used only when update with an expire instant.
+          * */
          public Will(Will orig, Instant expireAt) {
             this(orig.topic, orig.payload, orig.qos, orig.retained, orig.delayInterval);
             this.expireAt = expireAt;
+         }
+
+         /**
+          * Used only when update with optional properties are provided.
+          * */
+         public Will(Will orig, WillOptions properties) {
+             this.topic = orig.topic;
+             this.payload = orig.payload;
+             this.qos = orig.qos;
+             this.retained = orig.retained;
+             this.delayInterval = orig.delayInterval;
+             this.expireAt = orig.expireAt;
+             this.properties = properties;
          }
 
          @Override

--- a/broker/src/main/java/io/moquette/broker/ISessionsRepository.java
+++ b/broker/src/main/java/io/moquette/broker/ISessionsRepository.java
@@ -177,12 +177,14 @@ public interface ISessionsRepository {
          public final byte[] payload;
          public final MqttQoS qos;
          public final boolean retained;
+         public final int delayInterval;
 
-         public Will(String topic, byte[] payload, MqttQoS qos, boolean retained) {
+         public Will(String topic, byte[] payload, MqttQoS qos, boolean retained, int delayInterval) {
              this.topic = topic;
              this.payload = payload;
              this.qos = qos;
              this.retained = retained;
+             this.delayInterval = delayInterval;
          }
      }
 

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -456,7 +456,9 @@ final class MQTTConnection {
     // Invoked when a TCP connection drops and not when a client send DISCONNECT and close.
     private void processConnectionLost(String clientID) {
         if (bindedSession.hasWill()) {
-            postOffice.fireWill(bindedSession.getWill(), clientID);
+//            bindedSession.getWill().delayInterval
+//            bindedSession.getSessionData().expireAt()
+            postOffice.fireWill(bindedSession);
         }
         if (bindedSession.connected()) {
             LOG.debug("Closing session on connectionLost {}", clientID);
@@ -496,7 +498,7 @@ final class MQTTConnection {
                 if (disconnectHeader.reasonCode() != MqttReasonCodes.Disconnect.NORMAL_DISCONNECT.byteValue()) {
                     // handle the will
                     if (bindedSession.hasWill()) {
-                        postOffice.fireWill(bindedSession.getWill(), clientID);
+                        postOffice.fireWill(bindedSession);
                     }
                 }
             }

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -456,8 +456,6 @@ final class MQTTConnection {
     // Invoked when a TCP connection drops and not when a client send DISCONNECT and close.
     private void processConnectionLost(String clientID) {
         if (bindedSession.hasWill()) {
-//            bindedSession.getWill().delayInterval
-//            bindedSession.getSessionData().expireAt()
             postOffice.fireWill(bindedSession);
         }
         if (bindedSession.connected()) {

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -25,27 +25,8 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelPipeline;
-import io.netty.handler.codec.mqtt.MqttConnAckMessage;
-import io.netty.handler.codec.mqtt.MqttConnectMessage;
-import io.netty.handler.codec.mqtt.MqttConnectPayload;
-import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
-import io.netty.handler.codec.mqtt.MqttFixedHeader;
-import io.netty.handler.codec.mqtt.MqttMessage;
-import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.netty.handler.codec.mqtt.*;
 import io.netty.handler.codec.mqtt.MqttMessageBuilders.ConnAckPropertiesBuilder;
-import io.netty.handler.codec.mqtt.MqttMessageIdVariableHeader;
-import io.netty.handler.codec.mqtt.MqttMessageType;
-import io.netty.handler.codec.mqtt.MqttProperties;
-import io.netty.handler.codec.mqtt.MqttPubAckMessage;
-import io.netty.handler.codec.mqtt.MqttPublishMessage;
-import io.netty.handler.codec.mqtt.MqttPublishVariableHeader;
-import io.netty.handler.codec.mqtt.MqttQoS;
-import io.netty.handler.codec.mqtt.MqttReasonCodeAndPropertiesVariableHeader;
-import io.netty.handler.codec.mqtt.MqttSubAckMessage;
-import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
-import io.netty.handler.codec.mqtt.MqttUnsubAckMessage;
-import io.netty.handler.codec.mqtt.MqttUnsubscribeMessage;
-import io.netty.handler.codec.mqtt.MqttVersion;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import org.slf4j.Logger;
@@ -510,7 +491,7 @@ final class MQTTConnection {
             }
             if (protocolVersion == MqttVersion.MQTT_5.protocolLevel()) {
                 MqttReasonCodeAndPropertiesVariableHeader disconnectHeader = (MqttReasonCodeAndPropertiesVariableHeader) msg.variableHeader();
-                if (disconnectHeader.reasonCode() != 0x00) {
+                if (disconnectHeader.reasonCode() != MqttReasonCodes.Disconnect.NORMAL_DISCONNECT.byteValue()) {
                     // handle the will
                     if (bindedSession.hasWill()) {
                         postOffice.fireWill(bindedSession.getWill());

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -34,6 +34,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.util.List;
@@ -46,13 +50,7 @@ import javax.net.ssl.SSLPeerUnverifiedException;
 import static io.moquette.BrokerConstants.INFLIGHT_WINDOW_SIZE;
 import static io.netty.channel.ChannelFutureListener.CLOSE_ON_FAILURE;
 import static io.netty.channel.ChannelFutureListener.FIRE_EXCEPTION_ON_FAILURE;
-import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_ACCEPTED;
-import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_REFUSED_BAD_USERNAME_OR_PASSWORD;
-import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD;
-import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_REFUSED_CLIENT_IDENTIFIER_NOT_VALID;
-import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_REFUSED_IDENTIFIER_REJECTED;
-import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_REFUSED_SERVER_UNAVAILABLE;
-import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_REFUSED_UNACCEPTABLE_PROTOCOL_VERSION;
+import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.*;
 import static io.netty.handler.codec.mqtt.MqttMessageIdVariableHeader.from;
 import static io.netty.handler.codec.mqtt.MqttQoS.AT_LEAST_ONCE;
 import static io.netty.handler.codec.mqtt.MqttQoS.AT_MOST_ONCE;
@@ -239,6 +237,21 @@ final class MQTTConnection {
      * Invoked by the Session's event loop.
      * */
     private void executeConnect(MqttConnectMessage msg, String clientId, boolean serverGeneratedClientId) {
+        if (isProtocolVersion(msg, MqttVersion.MQTT_5)) {
+            // if MQTT5 validate the payload of the will
+            boolean hasPayloadFormatIndicator = extractWillPayloadFormatIndicator(msg.payload().willProperties());
+            if (hasPayloadFormatIndicator) {
+                byte[] willPayload = msg.payload().willMessageInBytes();
+                boolean validWillPayload = checkUTF8Validity(willPayload);
+                if (!validWillPayload) {
+                    final ConnAckPropertiesBuilder builder = prepareConnAckPropertiesBuilder(false, clientId);
+                    builder.reasonString("Not UTF8 payload in Will");
+                    abortConnectionV5(CONNECTION_REFUSED_PAYLOAD_FORMAT_INVALID, builder);
+                    return;
+                }
+            }
+        }
+
         final SessionRegistry.SessionCreationResult result;
         try {
             LOG.trace("Binding MQTTConnection to session");
@@ -312,6 +325,30 @@ final class MQTTConnection {
 
             }
         });
+    }
+
+    /**
+     * @return the value of the Payload Format Indicator property from Will specification.
+     * */
+    private static boolean extractWillPayloadFormatIndicator(MqttProperties mqttProperties) {
+        final MqttProperties.MqttProperty<Integer> payloadFormatIndicatorProperty =
+            mqttProperties.getProperty(MqttProperties.MqttPropertyType.PAYLOAD_FORMAT_INDICATOR.value());
+        boolean hasPayloadFormatIndicator = false;
+        if (payloadFormatIndicatorProperty != null) {
+            int payloadFormatIndicator = payloadFormatIndicatorProperty.value();
+            hasPayloadFormatIndicator = payloadFormatIndicator == 1;
+        }
+        return hasPayloadFormatIndicator;
+    }
+
+    private static boolean checkUTF8Validity(byte[] rawBytes) {
+        CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
+        try {
+            decoder.decode(ByteBuffer.wrap(rawBytes));
+        } catch (CharacterCodingException ex) {
+            return false;
+        }
+        return true;
     }
 
     private MqttProperties prepareConnAckProperties(boolean serverGeneratedClientId, String clientId) {

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -202,8 +202,8 @@ class PostOffice {
         this.sessionRegistry = sessionRegistry;
     }
 
-    public void fireWill(final Session.Will will) {
-        if (will.willDelayInterval == 0) {
+    public void fireWill(final ISessionsRepository.Will will) {
+        if (will.delayInterval == 0) {
             // if interval is 0 fire immediately
             // MQTT3  3.1.2.8-17
             publish2Subscribers(Unpooled.copiedBuffer(will.payload), new Topic(will.topic), will.qos);
@@ -211,7 +211,7 @@ class PostOffice {
             // MQTT5 MQTT-3.1.3-9
             delayedWillPublications.schedule(() -> {
                 publish2Subscribers(Unpooled.copiedBuffer(will.payload), new Topic(will.topic), will.qos);
-            }, will.willDelayInterval, TimeUnit.SECONDS);
+            }, will.delayInterval, TimeUnit.SECONDS);
         }
     }
 

--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -256,8 +256,8 @@ public class Server {
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(interceptor, sessionQueueSize);
         sessions = new SessionRegistry(subscriptions, sessionsRepository, queueRepository, authorizator, scheduler,
             clock, globalSessionExpiry, loopsGroup);
-        dispatcher = new PostOffice(subscriptions, retainedRepository, sessions, interceptor, authorizator,
-            loopsGroup);
+        dispatcher = new PostOffice(subscriptions, retainedRepository, sessions, sessionsRepository, interceptor,
+            authorizator, loopsGroup, clock);
         final BrokerConfiguration brokerConfig = new BrokerConfiguration(config);
         MQTTConnectionFactory connectionFactory = new MQTTConnectionFactory(brokerConfig, authenticator, sessions,
                                                                             dispatcher);

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -349,8 +349,7 @@ public class SessionRegistry {
         // retrieve Will Delay if present and if the connection is MQTT5
         if (Utils.versionFromConnect(msg) == MqttVersion.MQTT_5) {
             final MqttProperties.MqttProperty<Integer> willDelayIntervalProperty =
-                (MqttProperties.MqttProperty<Integer>) msg.variableHeader().properties()
-                    .getProperty(MqttProperties.MqttPropertyType.WILL_DELAY_INTERVAL.value());
+                msg.payload().willProperties().getProperty(MqttProperties.MqttPropertyType.WILL_DELAY_INTERVAL.value());
             if (willDelayIntervalProperty != null) {
                 willDelayIntervalSeconds = willDelayIntervalProperty.value();
             } else {

--- a/broker/src/main/java/io/moquette/persistence/H2SessionsRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/H2SessionsRepository.java
@@ -158,6 +158,7 @@ class H2SessionsRepository implements ISessionsRepository {
             byte retained = will.retained ? (byte) 0x10 : 0x00;
             byte qos = (byte) (will.qos.value() & 0x0F);
             buff.put((byte) (retained & qos));
+            buff.putInt(will.delayInterval);
         }
 
         @Override
@@ -170,8 +171,9 @@ class H2SessionsRepository implements ISessionsRepository {
             // MSB retained, LSB QoS
             final byte qos = (byte) (rawFlags & 0x0F);
             final boolean retained = ((rawFlags >> 4) & 0x0F) > 0;
+            final int willDelayInterval = buff.getInt();
 
-            return new Will(topic, payload, MqttQoS.valueOf(qos), retained);
+            return new Will(topic, payload, MqttQoS.valueOf(qos), retained, willDelayInterval);
         }
 
         @Override

--- a/broker/src/main/java/io/moquette/persistence/H2SessionsRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/H2SessionsRepository.java
@@ -7,12 +7,18 @@ import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
 import org.h2.mvstore.WriteBuffer;
 import org.h2.mvstore.type.BasicDataType;
+import org.h2.mvstore.type.ByteArrayDataType;
 import org.h2.mvstore.type.StringDataType;
 
 import java.nio.ByteBuffer;
 import java.time.Clock;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.BiConsumer;
 
 class H2SessionsRepository implements ISessionsRepository {
@@ -161,6 +167,7 @@ class H2SessionsRepository implements ISessionsRepository {
     private final class WillDataValueType extends BasicDataType<Will> {
 
         private final StringDataType stringDataType = new StringDataType();
+        private final WillOptionsDataValueType willOptionsDataType = new WillOptionsDataValueType();
 
         @Override
         public int getMemory(Will will) {
@@ -186,6 +193,9 @@ class H2SessionsRepository implements ISessionsRepository {
             } else {
                 buff.putLong(will.expireAt().toEpochMilli());
             }
+            if (will.properties.notEmpty()) {
+                willOptionsDataType.write(buff, will.properties);
+            }
         }
 
         @Override
@@ -206,12 +216,179 @@ class H2SessionsRepository implements ISessionsRepository {
                 will = new Will(will, Instant.ofEpochMilli(expiresAt));
             }
 
+            final WillOptions options = willOptionsDataType.read(buff);
+            if (options != null && options.notEmpty()) {
+                will = new Will(will, options);
+            }
+
             return will;
         }
 
         @Override
         public Will[] createStorage(int i) {
             return new Will[i];
+        }
+    }
+
+    private static final class WillOptionsDataValueType extends BasicDataType<WillOptions> {
+
+        private static final byte EMPTY_OPTIONS = -1;
+        private static final byte MESSAGE_EXPIRY_FLAG = 0x01;
+        private static final byte CONTENT_TYPE_FLAG = MESSAGE_EXPIRY_FLAG << 1;
+        private static final byte RESPONSE_TOPIC_FLAG = CONTENT_TYPE_FLAG << 1;
+        private static final byte CORRELATION_DATA_FLAG = RESPONSE_TOPIC_FLAG << 1;
+        private static final byte USER_PROPERTIES_FLAG = CORRELATION_DATA_FLAG << 1;
+        private final DurationDataValueType durationDataValueType = new DurationDataValueType();
+        private final StringDataType stringDataType = StringDataType.INSTANCE;
+        private final ByteArrayDataType byteArrayDataType = ByteArrayDataType.INSTANCE;
+        private final UserPropertiesDataValueType userPropertiesDataValueType = new UserPropertiesDataValueType();
+
+        @Override
+        public int getMemory(WillOptions willOptions) {
+            int size = 1; //the header with option bitmask
+
+            if (willOptions.messageExpiry().isPresent()) {
+                size += durationDataValueType.getMemory(willOptions.messageExpiry().get());
+            }
+            if (willOptions.contentType().isPresent()) {
+                size += stringDataType.getMemory(willOptions.contentType().get());
+            }
+            if (willOptions.responseTopic().isPresent()) {
+                size += stringDataType.getMemory(willOptions.responseTopic().get());
+            }
+            if (willOptions.correlationData().isPresent()) {
+                size += byteArrayDataType.getMemory(willOptions.correlationData().get());
+            }
+            if (willOptions.userProperties().isPresent()) {
+                size += userPropertiesDataValueType.getMemory(willOptions.userProperties().get());
+            }
+            return size;
+        }
+
+        @Override
+        public void write(WriteBuffer writeBuffer, WillOptions willOptions) {
+            if (willOptions == null || !willOptions.notEmpty()) {
+                writeBuffer.put(EMPTY_OPTIONS);
+                return;
+            }
+
+            // determine which options are present and compute the bitmask
+            byte optionBitmask = 0x00;
+            if (willOptions.messageExpiry().isPresent()) {
+                optionBitmask = (byte) (optionBitmask | MESSAGE_EXPIRY_FLAG);
+            }
+            if (willOptions.contentType().isPresent()) {
+                optionBitmask = (byte) (optionBitmask | CONTENT_TYPE_FLAG);
+            }
+            if (willOptions.responseTopic().isPresent()) {
+                optionBitmask = (byte) (optionBitmask | RESPONSE_TOPIC_FLAG);
+            }
+            if (willOptions.correlationData().isPresent()) {
+                optionBitmask = (byte) (optionBitmask | CORRELATION_DATA_FLAG);
+            }
+            if (willOptions.userProperties().isPresent()) {
+                optionBitmask = (byte) (optionBitmask | USER_PROPERTIES_FLAG);
+            }
+            writeBuffer.put(optionBitmask);
+
+            willOptions.messageExpiry().ifPresent(expiry -> durationDataValueType.write(writeBuffer, expiry));
+            willOptions.contentType().ifPresent(contentType -> stringDataType.write(writeBuffer, contentType));
+            willOptions.responseTopic().ifPresent(responseTopic -> stringDataType.write(writeBuffer, responseTopic));
+            willOptions.correlationData().ifPresent(correlationData -> byteArrayDataType.write(writeBuffer, correlationData));
+            willOptions.userProperties().ifPresent(userProps -> userPropertiesDataValueType.write(writeBuffer, userProps));
+        }
+
+        @Override
+        public WillOptions read(ByteBuffer byteBuffer) {
+            byte header = byteBuffer.get();
+            WillOptions options = WillOptions.empty();
+            if (header == EMPTY_OPTIONS) {
+                return options;
+            }
+            if ((header & MESSAGE_EXPIRY_FLAG) > 0) {
+                options = options.withMessageExpiry(durationDataValueType.read(byteBuffer));
+            }
+            if ((header & CONTENT_TYPE_FLAG) > 0) {
+                options = options.withContentType(stringDataType.read(byteBuffer));
+            }
+            if ((header & RESPONSE_TOPIC_FLAG) > 0) {
+                options = options.withResponseTopic(stringDataType.read(byteBuffer));
+            }
+            if ((header & CORRELATION_DATA_FLAG) > 0) {
+                options = options.withCorrelationData(byteArrayDataType.read(byteBuffer));
+            }
+            if ((header & USER_PROPERTIES_FLAG) > 0) {
+                options = options.withUserProperties(userPropertiesDataValueType.read(byteBuffer));
+            }
+            return options;
+        }
+
+        @Override
+        public WillOptions[] createStorage(int i) {
+            return new WillOptions[i];
+        }
+    }
+
+    private static final class DurationDataValueType extends BasicDataType<Duration> {
+
+        @Override
+        public int getMemory(Duration duration) {
+            return 4;
+        }
+
+        @Override
+        public void write(WriteBuffer writeBuffer, Duration duration) {
+            int seconds = (int) duration.get(ChronoUnit.SECONDS);
+            writeBuffer.putInt(seconds);
+        }
+
+        @Override
+        public Duration read(ByteBuffer byteBuffer) {
+            return Duration.ofSeconds(byteBuffer.getInt());
+        }
+
+        @Override
+        public Duration[] createStorage(int i) {
+            return new Duration[i];
+        }
+    }
+
+    private static final class UserPropertiesDataValueType extends BasicDataType<Map<String, String>> {
+
+        @Override
+        public int getMemory(Map<String, String> userProps) {
+            int kvSize = userProps.entrySet().stream()
+                .map(kv -> StringDataType.INSTANCE.getMemory(kv.getKey()) + StringDataType.INSTANCE.getMemory(kv.getValue()))
+                .mapToInt(Integer::intValue)
+                .sum();
+            return 4 + // length of the key, value couples list
+                   kvSize;
+        }
+
+        @Override
+        public void write(WriteBuffer writeBuffer, Map<String, String> userProps) {
+            writeBuffer.putInt(userProps.size());
+            for (Map.Entry<String, String> kv : userProps.entrySet()) {
+                StringDataType.INSTANCE.write(writeBuffer, kv.getKey());
+                StringDataType.INSTANCE.write(writeBuffer, kv.getValue());
+            }
+        }
+
+        @Override
+        public Map<String, String> read(ByteBuffer byteBuffer) {
+            int length = byteBuffer.getInt();
+            final Map<String, String> result = new HashMap(length);
+            for (int i = 0; i < length; i++) {
+                String key = StringDataType.INSTANCE.read(byteBuffer);
+                String value = StringDataType.INSTANCE.read(byteBuffer);
+                result.put(key, value);
+            }
+            return result;
+        }
+
+        @Override
+        public Map<String, String>[] createStorage(int i) {
+            return new Map[i];
         }
     }
 }

--- a/broker/src/main/java/io/moquette/persistence/MemorySessionsRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/MemorySessionsRepository.java
@@ -5,10 +5,12 @@ import io.moquette.broker.ISessionsRepository;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiConsumer;
 
 public class MemorySessionsRepository implements ISessionsRepository {
 
     private final ConcurrentMap<String, SessionData> sessions = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, Will> wills = new ConcurrentHashMap<>();
 
     @Override
     public Collection<SessionData> list() {
@@ -23,5 +25,21 @@ public class MemorySessionsRepository implements ISessionsRepository {
     @Override
     public void delete(SessionData session) {
         sessions.remove(session.clientId());
+    }
+
+    @Override
+    public void listSessionsWill(BiConsumer<String, Will> visitor) {
+        wills.entrySet().stream()
+            .forEach(e -> visitor.accept(e.getKey(), e.getValue()));
+    }
+
+    @Override
+    public void saveWill(String clientId, Will will) {
+        wills.put(clientId, will);
+    }
+
+    @Override
+    public void deleteWill(String clientId) {
+        wills.remove(clientId);
     }
 }

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
@@ -60,6 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -194,7 +195,7 @@ public class MQTTConnectionConnectTest {
         sut.handleConnectionLost();
 
         // Verify
-        verify(postOfficeMock).fireWill(any(ISessionsRepository.Will.class));
+        verify(postOfficeMock).fireWill(any(ISessionsRepository.Will.class), eq(FAKE_CLIENT_ID));
         assertFalse(sut.isConnected(), "Connection MUST be disconnected");
     }
 

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
@@ -98,8 +98,9 @@ public class MQTTConnectionConnectTest {
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
-        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler, loopsGroup);
-        postOffice = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
+        ISessionsRepository fakeSessionRepo = memorySessionsRepository();
+        sessionRegistry = new SessionRegistry(subscriptions, fakeSessionRepo, queueRepository, permitAll, scheduler, loopsGroup);
+        postOffice = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry, fakeSessionRepo,
                                     ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
 
         sut = createMQTTConnection(CONFIG);

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
@@ -195,7 +195,7 @@ public class MQTTConnectionConnectTest {
         sut.handleConnectionLost();
 
         // Verify
-        verify(postOfficeMock).fireWill(any(ISessionsRepository.Will.class), eq(FAKE_CLIENT_ID));
+        verify(postOfficeMock).fireWill(any(Session.class));
         assertFalse(sut.isConnected(), "Connection MUST be disconnected");
     }
 

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java
@@ -28,6 +28,7 @@ import io.netty.channel.ChannelPromise;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.netty.handler.codec.mqtt.MqttProperties;
 import io.netty.handler.codec.mqtt.MqttVersion;
 import io.netty.handler.ssl.SslHandler;
 import org.junit.jupiter.api.AfterEach;
@@ -51,9 +52,7 @@ import javax.net.ssl.SSLSession;
 import static io.moquette.BrokerConstants.NO_BUFFER_FLUSH;
 import static io.moquette.broker.MQTTConnectionPublishTest.memorySessionsRepository;
 import static io.moquette.broker.NettyChannelAssertions.assertEqualsConnAck;
-import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_ACCEPTED;
-import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_REFUSED_BAD_USER_NAME_OR_PASSWORD;
-import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.CONNECTION_REFUSED_IDENTIFIER_REJECTED;
+import static io.netty.handler.codec.mqtt.MqttConnectReturnCode.*;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -181,24 +180,48 @@ public class MQTTConnectionConnectTest {
         assertTrue(channel.isOpen(), "Connection is accepted and therefore should remain open");
     }
 
-    @Disabled("already covered by testWillMessageIsFiredOnClientKeepAliveExpiry and testWillMessageIsPublishedOnClientBadDisconnection")
     @Test
-    public void testWillIsFired() throws ExecutionException, InterruptedException {
-        final PostOffice postOfficeMock = mock(PostOffice.class);
-        sut = createMQTTConnectionWithPostOffice(CONFIG, postOfficeMock);
-        channel = (EmbeddedChannel) sut.channel;
+    public void whenConnectWithWillAndPayloadFormatIndicator_withInvalidWillPayload_thenReturnANegativeConnAck() throws ExecutionException, InterruptedException {
+        MqttProperties.MqttProperty<Integer> payloadFormatInvalid = new MqttProperties.IntegerProperty(MqttProperties.MqttPropertyType.PAYLOAD_FORMAT_INDICATOR.value(), 1);
 
-        MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID).willFlag(true)
-            .willTopic("topic").willMessage("Topic message").build();
-        sut.processConnect(msg).completableFuture().get();
+        MqttProperties willProperties = new MqttProperties();
+        willProperties.add(payloadFormatInvalid);
+
+        byte[] invalidUtf8Payload = new byte[]{(byte) 0xC0, (byte) 0xC1, (byte) 0xF5, (byte) 0xFF};
+
+        MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID)
+            .protocolVersion(MqttVersion.MQTT_5)
+            .willFlag(true)
+            .willTopic("topic")
+            .willMessage(invalidUtf8Payload)
+            .willProperties(willProperties)
+            .build();
 
         // Exercise
-        sut.handleConnectionLost();
+        sut.processConnect(msg).completableFuture().get();
 
         // Verify
-        verify(postOfficeMock).fireWill(any(Session.class));
-        assertFalse(sut.isConnected(), "Connection MUST be disconnected");
+        assertEqualsConnAck(CONNECTION_REFUSED_PAYLOAD_FORMAT_INVALID, channel.readOutbound());
     }
+
+//    @Disabled("already covered by testWillMessageIsFiredOnClientKeepAliveExpiry and testWillMessageIsPublishedOnClientBadDisconnection")
+//    @Test
+//    public void testWillIsFired() throws ExecutionException, InterruptedException {
+//        final PostOffice postOfficeMock = mock(PostOffice.class);
+//        sut = createMQTTConnectionWithPostOffice(CONFIG, postOfficeMock);
+//        channel = (EmbeddedChannel) sut.channel;
+//
+//        MqttConnectMessage msg = connMsg.clientId(FAKE_CLIENT_ID).willFlag(true)
+//            .willTopic("topic").willMessage("Topic message").build();
+//        sut.processConnect(msg).completableFuture().get();
+//
+//        // Exercise
+//        sut.handleConnectionLost();
+//
+//        // Verify
+//        verify(postOfficeMock).fireWill(any(Session.class));
+//        assertFalse(sut.isConnected(), "Connection MUST be disconnected");
+//    }
 
     @Test
     public void acceptAnonymousClient() throws ExecutionException, InterruptedException {

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
@@ -91,9 +91,10 @@ public class MQTTConnectionPublishTest {
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
-        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler, loopsGroup);
+        ISessionsRepository fakeSessionRepo = memorySessionsRepository();
+        sessionRegistry = new SessionRegistry(subscriptions, fakeSessionRepo, queueRepository, permitAll, scheduler, loopsGroup);
         final PostOffice postOffice = new PostOffice(subscriptions,
-            new MemoryRetainedRepository(), sessionRegistry, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
+            new MemoryRetainedRepository(), sessionRegistry, fakeSessionRepo, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
         return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, postOffice);
     }
 

--- a/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
@@ -103,8 +103,9 @@ public class PostOfficeInternalPublishTest {
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
-        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler, loopsGroup);
-        sut = new PostOffice(subscriptions, retainedRepository, sessionRegistry,
+        ISessionsRepository fakeSessionRepo = memorySessionsRepository();
+        sessionRegistry = new SessionRegistry(subscriptions, fakeSessionRepo, queueRepository, permitAll, scheduler, loopsGroup);
+        sut = new PostOffice(subscriptions, retainedRepository, sessionRegistry, fakeSessionRepo,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
     }
 

--- a/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
@@ -107,8 +107,9 @@ public class PostOfficePublishTest {
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
-        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler, loopsGroup);
-        sut = new PostOffice(subscriptions, retainedRepository, sessionRegistry,
+        ISessionsRepository fakeSessionRepo = memorySessionsRepository();
+        sessionRegistry = new SessionRegistry(subscriptions, fakeSessionRepo, queueRepository, permitAll, scheduler, loopsGroup);
+        sut = new PostOffice(subscriptions, retainedRepository, sessionRegistry, fakeSessionRepo,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
     }
 

--- a/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
@@ -71,6 +71,7 @@ public class PostOfficeSubscribeTest {
     public static final BrokerConfiguration CONFIG = new BrokerConfiguration(true, true, false, NO_BUFFER_FLUSH);
     private MemoryQueueRepository queueRepository;
     private ScheduledExecutorService scheduler;
+    private ISessionsRepository fakeSessionRepo;
 
     @BeforeEach
     public void setUp() {
@@ -104,8 +105,9 @@ public class PostOfficeSubscribeTest {
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
-        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler, loopsGroup);
-        sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
+        fakeSessionRepo = memorySessionsRepository();
+        sessionRegistry = new SessionRegistry(subscriptions, fakeSessionRepo, queueRepository, permitAll, scheduler, loopsGroup);
+        sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry, fakeSessionRepo,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
     }
 
@@ -179,7 +181,7 @@ public class PostOfficeSubscribeTest {
             .thenReturn(false);
 
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
-        sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
+        sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry, fakeSessionRepo,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, new Authorizator(prohibitReadOnNewsTopic), loopsGroup);
 
         connection.processConnect(connectMessage).completableFuture().get();

--- a/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
@@ -96,8 +96,9 @@ public class PostOfficeUnsubscribeTest {
         final PermitAllAuthorizatorPolicy authorizatorPolicy = new PermitAllAuthorizatorPolicy();
         final Authorizator permitAll = new Authorizator(authorizatorPolicy);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, 1024);
-        sessionRegistry = new SessionRegistry(subscriptions, memorySessionsRepository(), queueRepository, permitAll, scheduler, loopsGroup);
-        sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry,
+        ISessionsRepository fakeSessionRepo = memorySessionsRepository();
+        sessionRegistry = new SessionRegistry(subscriptions, fakeSessionRepo, queueRepository, permitAll, scheduler, loopsGroup);
+        sut = new PostOffice(subscriptions, new MemoryRetainedRepository(), sessionRegistry, fakeSessionRepo,
                              ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
     }
 

--- a/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
@@ -120,7 +120,7 @@ public class SessionRegistryTest {
         sessionRepository = memorySessionsRepository();
         sut = new SessionRegistry(subscriptions, sessionRepository, queueRepository, permitAll, scheduler, slidingClock, GLOBAL_SESSION_EXPIRY_SECONDS, loopsGroup);
         final PostOffice postOffice = new PostOffice(subscriptions,
-            new MemoryRetainedRepository(), sut, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
+            new MemoryRetainedRepository(), sut, sessionRepository, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
         return new MQTTConnection(channel, config, mockAuthenticator, sut, postOffice);
     }
 

--- a/broker/src/test/java/io/moquette/integration/mqtt5/AbstractServerIntegrationTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/AbstractServerIntegrationTest.java
@@ -22,7 +22,7 @@ abstract class AbstractServerIntegrationTest {
 
     @TempDir
     Path tempFolder;
-    private String dbPath;
+    protected String dbPath;
 
     Client lowLevelClient;
 
@@ -53,7 +53,7 @@ abstract class AbstractServerIntegrationTest {
         stopServer();
     }
 
-    private void stopServer() {
+    protected void stopServer() {
         broker.stopServer();
     }
 }

--- a/broker/src/test/java/io/moquette/integration/mqtt5/ConnectTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/ConnectTest.java
@@ -209,6 +209,21 @@ class ConnectTest extends AbstractServerIntegrationTest {
         }
     }
 
+    @Test
+    public void noWillMessageIsFiredOnNormalDisconnection() throws InterruptedException {
+        final String clientId = "simple_client";
+        // create a client with will delay greater than session expiry
+        final Mqtt5BlockingClient clientWithWill = createAndConnectClientWithWillTestament(clientId,  10, 60);
+
+        final Mqtt5BlockingClient testamentSubscriber = createAndConnectClientListeningToTestament();
+
+        // normal session disconnection
+        clientWithWill.disconnect(Mqtt5Disconnect.builder().build());
+
+        // wait no will is published
+        verifyNoTestamentIsPublished(testamentSubscriber, Duration.ofSeconds(10));
+    }
+
     private void scheduleDisconnectWithErrorCode(Mqtt5BlockingClient clientWithWill, Duration delay) {
         scheduleTasks.schedule(() -> {
             // disconnect in a way that the will is triggered

--- a/broker/src/test/java/io/moquette/integration/mqtt5/ConnectTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/ConnectTest.java
@@ -16,7 +16,6 @@ import io.netty.handler.codec.mqtt.MqttConnAckMessage;
 import io.netty.handler.codec.mqtt.MqttConnectReturnCode;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.handler.codec.mqtt.MqttQoS;
-import org.assertj.core.api.Condition;
 import org.awaitility.Awaitility;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
@@ -32,8 +31,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class ConnectTest extends AbstractServerIntegrationTest {
     private static final Logger LOG = LoggerFactory.getLogger(ConnectTest.class);
@@ -156,8 +156,11 @@ class ConnectTest extends AbstractServerIntegrationTest {
 
         final Mqtt5BlockingClient testamentSubscriber = createAndConnectClientListeningToTestament();
 
-        // schedule a bad disconnect
-        scheduleDisconnectWithErrorCode(clientWithWill, Duration.ofMillis(500));
+        // client trigger a will message, disconnecting with bad reason code
+        final Mqtt5Disconnect malformedPacketReason = Mqtt5Disconnect.builder()
+            .reasonCode(Mqtt5DisconnectReasonCode.MALFORMED_PACKET)
+            .build();
+        clientWithWill.disconnect(malformedPacketReason);
 
         // reconnect another client with same clientId
         final Mqtt5BlockingClient client = MqttClient.builder()

--- a/broker/src/test/java/io/moquette/integration/mqtt5/ConnectTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/ConnectTest.java
@@ -303,6 +303,10 @@ class ConnectTest extends AbstractServerIntegrationTest {
                 .topic("/will_testament")
                 .payload("Goodbye".getBytes(StandardCharsets.UTF_8))
                 .delayInterval(delayInSeconds) // 1 second
+                .contentType("something content type here")
+                .userProperties()
+                    .add("test_property", "value of a property")
+                .applyUserProperties()
             .applyWillPublish();
 
         return createAndConnectWithBuilder(clientId, connectBuilder);
@@ -334,26 +338,6 @@ class ConnectTest extends AbstractServerIntegrationTest {
         Mqtt5ConnAck connectAck = clientWithWill.connect(connectBuilder.build());
         assertEquals(Mqtt5ConnAckReasonCode.SUCCESS, connectAck.getReasonCode(), "Client must result connected");
         return clientWithWill;
-    }
-
-    private static boolean checkUTF8Validity(byte[] rawBytes) {
-        java.nio.charset.CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
-        try {
-            decoder.decode(ByteBuffer.wrap(rawBytes));
-        } catch (java.nio.charset.CharacterCodingException ex) {
-            return false;
-        }
-        return true;
-    }
-
-    @Test
-    public void validUTF8RawBytesShouldBePositivelyValidated() {
-        assertTrue(checkUTF8Validity(new byte[]{0x31, 0x32}));
-    }
-
-    @Test
-    public void invalidUTF8RawBytesShouldNegativelyValidated() {
-        assertFalse(checkUTF8Validity(new byte[]{(byte) 0xC0, (byte) 0xC1, (byte) 0xF5, (byte) 0xFF}));
     }
 
 }

--- a/broker/src/test/java/io/moquette/integration/mqtt5/ConnectTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/ConnectTest.java
@@ -228,8 +228,6 @@ class ConnectTest extends AbstractServerIntegrationTest {
         final String clientId = "simple_client";
         final Mqtt5BlockingClient clientWithWill = createAndConnectClientWithWillTestament(clientId, 10);
 
-//        final Mqtt5BlockingClient testamentSubscriber = createAndConnectClientListeningToTestament();
-
         // client trigger a will message, disconnecting with bad reason code
         final Mqtt5Disconnect malformedPacketReason = Mqtt5Disconnect.builder()
             .reasonCode(Mqtt5DisconnectReasonCode.MALFORMED_PACKET)

--- a/broker/src/test/java/io/moquette/integration/mqtt5/ConnectTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/ConnectTest.java
@@ -209,7 +209,7 @@ class ConnectTest extends AbstractServerIntegrationTest {
 
     @NotNull
     private Mqtt5BlockingClient createAndConnectClientWithWillTestament(String clientId) {
-        int delayInSeconds = 1_000;
+        int delayInSeconds = 1;
         return createAndConnectClientWithWillTestament(clientId, delayInSeconds);
     }
 

--- a/broker/src/test/java/io/moquette/integration/mqtt5/ConnectTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/ConnectTest.java
@@ -224,6 +224,23 @@ class ConnectTest extends AbstractServerIntegrationTest {
     }
 
     @Test
+    public void givenClientWithWillThatCleanlyDisconnectsWithWillShouldTriggerTheTestamentMessage() throws InterruptedException {
+        final String clientId = "simple_client";
+        // create a client with will delay greater than session expiry
+        final Mqtt5BlockingClient clientWithWill = createAndConnectClientWithWillTestament(clientId,  10, 60);
+
+        final Mqtt5BlockingClient testamentSubscriber = createAndConnectClientListeningToTestament();
+
+        // normal session disconnection with will
+        clientWithWill.disconnect(Mqtt5Disconnect.builder()
+            .reasonCode(Mqtt5DisconnectReasonCode.DISCONNECT_WITH_WILL_MESSAGE)
+            .build());
+
+        // wait no will is published
+        verifyNoTestamentIsPublished(testamentSubscriber, Duration.ofSeconds(10));
+    }
+
+    @Test
     public void delayedWillIsSentAlsoAfterAServerRestart() throws InterruptedException, IOException {
         final String clientId = "simple_client";
         final Mqtt5BlockingClient clientWithWill = createAndConnectClientWithWillTestament(clientId, 10);


### PR DESCRIPTION
## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Handle will delay interval property and update Will attributes for MQTT5 specification

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.

Example:
  Expose 'xpack.monitoring.elasticsearch.proxy' in the docker environment variables and update logstash.yml to surface this config option.
  
  This commit exposes the 'xpack.monitoring.elasticsearch.proxy' variable in the docker by adding it in env2yaml.go, which translates from
  being an environment variable to a proper yaml config.
  
  Additionally, this PR exposes this setting for both xpack monitoring & management to the logstash.yml file.
-->
Create a DelayQueue to track all the Will specifications that should be fired after a delay interval. It creates a scheduled task tuns every second and pull out of the queue the expired items. The items are Will instances contained in a Tracker instance. The Tracker is in charge of handling the calculation of the delay between the instant they are created and the expected expiry instant, this is used by the DelayQueue to sort out the things, by expiration time.
Introduce also the serdes (H2 DataTypes) for the Will to be stored and loaded in H2.
During server restart the Will specification are reloaded.



## Why is it important/What is the impact to the user?

<!-- Mandatory
Explain here the WHY or the IMPACT to the user, or the rationale/motivation for the changes.

Example:
  This PR fixes an issue that was preventing the docker image from using the proxy setting when sending xpack monitoring information.
  and/or
  This PR now allows the user to define the xpack monitoring proxy setting in the docker container.
-->
Permit to the broker to be adherent to MQTT5 specification, and handling correctly the will delay interval passed in connect message.



## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #767

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

## Screenshots

<!-- Optional
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
-->

## Logs

<!-- Recommended
Paste here output logs discovered while creating this PR, such as stack traces or integration logs, or any other output you consider important to be shared with the team.
-->

