### PR TITLE
feat: peer cert as username

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.18-SNAPSHOT:
+   [feature] Introduce a new option "PEER_CERTIFICATE_AS_USERNAME". When enabled, the client certificate is provided as the username to the authenticator.
 
 Version 0.17:
    [feature] Introduced DSL FluentConfig to simplify Server's API instantiation #761.

--- a/broker/src/main/java/io/moquette/broker/BrokerConfiguration.java
+++ b/broker/src/main/java/io/moquette/broker/BrokerConfiguration.java
@@ -23,12 +23,14 @@ import java.util.Locale;
 class BrokerConfiguration {
 
     private final boolean allowAnonymous;
+    private final boolean peerCertificateAsUsername;
     private final boolean allowZeroByteClientId;
     private final boolean reauthorizeSubscriptionsOnConnect;
     private final int bufferFlushMillis;
 
     BrokerConfiguration(IConfig props) {
         allowAnonymous = props.boolProp(BrokerConstants.ALLOW_ANONYMOUS_PROPERTY_NAME, true);
+        peerCertificateAsUsername = props.boolProp(IConfig.PEER_CERTIFICATE_AS_USERNAME, false);
         allowZeroByteClientId = props.boolProp(BrokerConstants.ALLOW_ZERO_BYTE_CLIENT_ID_PROPERTY_NAME, false);
         reauthorizeSubscriptionsOnConnect = props.boolProp(BrokerConstants.REAUTHORIZE_SUBSCRIPTIONS_ON_CONNECT, false);
 
@@ -65,7 +67,14 @@ class BrokerConfiguration {
 
     public BrokerConfiguration(boolean allowAnonymous, boolean allowZeroByteClientId,
                                boolean reauthorizeSubscriptionsOnConnect, int bufferFlushMillis) {
+        this(allowAnonymous, false, allowZeroByteClientId,
+            reauthorizeSubscriptionsOnConnect, bufferFlushMillis);
+    }
+
+    public BrokerConfiguration(boolean allowAnonymous, boolean peerCertificateAsUsername, boolean allowZeroByteClientId,
+                               boolean reauthorizeSubscriptionsOnConnect, int bufferFlushMillis) {
         this.allowAnonymous = allowAnonymous;
+        this.peerCertificateAsUsername = peerCertificateAsUsername;
         this.allowZeroByteClientId = allowZeroByteClientId;
         this.reauthorizeSubscriptionsOnConnect = reauthorizeSubscriptionsOnConnect;
         this.bufferFlushMillis = bufferFlushMillis;
@@ -73,6 +82,10 @@ class BrokerConfiguration {
 
     public boolean isAllowAnonymous() {
         return allowAnonymous;
+    }
+
+    public boolean isPeerCertificateAsUsername() {
+        return peerCertificateAsUsername;
     }
 
     public boolean isAllowZeroByteClientId() {

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -16,8 +16,9 @@
 package io.moquette.broker;
 
 import io.moquette.BrokerConstants;
-import io.moquette.broker.subscriptions.Topic;
 import io.moquette.broker.security.IAuthenticator;
+import io.moquette.broker.security.PemUtils;
+import io.moquette.broker.subscriptions.Topic;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufHolder;
 import io.netty.channel.Channel;
@@ -44,16 +45,21 @@ import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
 import io.netty.handler.codec.mqtt.MqttUnsubAckMessage;
 import io.netty.handler.codec.mqtt.MqttUnsubscribeMessage;
 import io.netty.handler.codec.mqtt.MqttVersion;
+import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.timeout.IdleStateHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.net.ssl.SSLPeerUnverifiedException;
 
 import static io.moquette.BrokerConstants.INFLIGHT_WINDOW_SIZE;
 import static io.netty.channel.ChannelFutureListener.CLOSE_ON_FAILURE;
@@ -396,25 +402,46 @@ final class MQTTConnection {
     }
 
     private boolean login(MqttConnectMessage msg, final String clientId) {
-        // handle user authentication
+        String userName = null;
+        byte[] pwd = null;
+
         if (msg.variableHeader().hasUserName()) {
-            byte[] pwd = null;
+            userName = msg.payload().userName();
+            // MQTT 3.1.2.9 does not mandate that there is a password - let the authenticator determine if it's needed
             if (msg.variableHeader().hasPassword()) {
                 pwd = msg.payload().passwordInBytes();
-            } else if (!brokerConfig.isAllowAnonymous()) {
-                LOG.info("Client didn't supply any password and MQTT anonymous mode is disabled CId={}", clientId);
+            }
+        }
+
+        if (brokerConfig.isPeerCertificateAsUsername()) {
+            try {
+                // Use peer cert as username
+                SslHandler sslhandler = (SslHandler) channel.pipeline().get("ssl");
+                if (sslhandler != null) {
+                    Certificate[] certificateChain = sslhandler.engine().getSession().getPeerCertificates();
+                    userName = PemUtils.certificatesToPem(certificateChain);
+                }
+            } catch (SSLPeerUnverifiedException e) {
+                LOG.debug("No peer cert provided. CId={}", clientId);
+            } catch (CertificateEncodingException | IOException e) {
+                LOG.warn("Unable to decode client certificate. CId={}", clientId);
+            }
+        }
+
+        if (userName == null || userName.isEmpty()) {
+            if (brokerConfig.isAllowAnonymous()) {
+                return true;
+            } else {
+                LOG.info("Client didn't supply any credentials and MQTT anonymous mode is disabled. CId={}", clientId);
                 return false;
             }
-            final String login = msg.payload().userName();
-            if (!authenticator.checkValid(clientId, login, pwd)) {
-                LOG.info("Authenticator has rejected the MQTT credentials CId={}, username={}", clientId, login);
-                return false;
-            }
-            NettyUtils.userName(channel, login);
-        } else if (!brokerConfig.isAllowAnonymous()) {
-            LOG.info("Client didn't supply any credentials and MQTT anonymous mode is disabled. CId={}", clientId);
+        }
+
+        if (!authenticator.checkValid(clientId, userName, pwd)) {
+            LOG.info("Authenticator has rejected the MQTT credentials CId={}, username={}", clientId, userName);
             return false;
         }
+        NettyUtils.userName(channel, userName);
         return true;
     }
 

--- a/broker/src/main/java/io/moquette/broker/config/FluentConfig.java
+++ b/broker/src/main/java/io/moquette/broker/config/FluentConfig.java
@@ -17,6 +17,7 @@ import static io.moquette.broker.config.IConfig.BUFFER_FLUSH_MS_PROPERTY_NAME;
 import static io.moquette.broker.config.IConfig.DATA_PATH_PROPERTY_NAME;
 import static io.moquette.broker.config.IConfig.DEFAULT_NETTY_MAX_BYTES_IN_MESSAGE;
 import static io.moquette.broker.config.IConfig.ENABLE_TELEMETRY_NAME;
+import static io.moquette.broker.config.IConfig.PEER_CERTIFICATE_AS_USERNAME;
 import static io.moquette.broker.config.IConfig.PORT_PROPERTY_NAME;
 import static io.moquette.broker.config.IConfig.JKS_PATH_PROPERTY_NAME;
 import static io.moquette.broker.config.IConfig.KEY_MANAGER_PASSWORD_PROPERTY_NAME;
@@ -84,6 +85,7 @@ public class FluentConfig {
         configAccumulator.put(PORT_PROPERTY_NAME, Integer.toString(BrokerConstants.PORT));
         configAccumulator.put(HOST_PROPERTY_NAME, BrokerConstants.HOST);
         configAccumulator.put(PASSWORD_FILE_PROPERTY_NAME, "");
+        configAccumulator.put(PEER_CERTIFICATE_AS_USERNAME, Boolean.FALSE.toString());
         configAccumulator.put(ALLOW_ANONYMOUS_PROPERTY_NAME, Boolean.TRUE.toString());
         configAccumulator.put(AUTHENTICATOR_CLASS_NAME, "");
         configAccumulator.put(AUTHORIZATOR_CLASS_NAME, "");
@@ -141,8 +143,13 @@ public class FluentConfig {
         return this;
     }
 
-    public FluentConfig allowAnonymous() {
-        configAccumulator.put(ALLOW_ANONYMOUS_PROPERTY_NAME, "true");
+    public FluentConfig enablePeerCertificateAsUsername() {
+        configAccumulator.put(PEER_CERTIFICATE_AS_USERNAME, "true");
+        return this;
+    }
+
+    public FluentConfig disablePeerCertificateAsUsername() {
+        configAccumulator.put(PEER_CERTIFICATE_AS_USERNAME, "false");
         return this;
     }
 

--- a/broker/src/main/java/io/moquette/broker/config/IConfig.java
+++ b/broker/src/main/java/io/moquette/broker/config/IConfig.java
@@ -32,6 +32,7 @@ public abstract class IConfig {
     public static final String HOST_PROPERTY_NAME = "host";
     public static final String PASSWORD_FILE_PROPERTY_NAME = "password_file";
     public static final String ALLOW_ANONYMOUS_PROPERTY_NAME = "allow_anonymous";
+    public static final String PEER_CERTIFICATE_AS_USERNAME = "peer_certificate_as_username";
     public static final String AUTHENTICATOR_CLASS_NAME = "authenticator_class";
     public static final String AUTHORIZATOR_CLASS_NAME = "authorizator_class";
     public static final String PERSISTENT_QUEUE_TYPE_PROPERTY_NAME = "persistent_queue_type"; // h2 or segmented, default h2

--- a/broker/src/main/java/io/moquette/broker/security/PemUtils.java
+++ b/broker/src/main/java/io/moquette/broker/security/PemUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 The original author or authors
+ * Copyright (c) 2023 The original author or authors
  * ------------------------------------------------------
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -30,7 +30,7 @@ public final class PemUtils {
     public static String certificatesToPem(Certificate... certificates)
         throws CertificateEncodingException, IOException {
         try (StringWriter str = new StringWriter();
-             PemWriter pemWriter = new PemWriter(str)) {
+               PemWriter pemWriter = new PemWriter(str)) {
             for (Certificate certificate : certificates) {
                 pemWriter.writeObject(certificateBoundaryType, certificate.getEncoded());
             }
@@ -49,6 +49,7 @@ public final class PemUtils {
     public static class PemWriter extends BufferedWriter {
         private static final int LINE_LENGTH = 64;
         private final char[] buf = new char[LINE_LENGTH];
+
         /**
          * Base constructor.
          *
@@ -57,6 +58,7 @@ public final class PemUtils {
         public PemWriter(Writer out) {
             super(out);
         }
+
         /**
          * Writes a pem encoded string.
          *
@@ -69,6 +71,7 @@ public final class PemUtils {
             writeEncoded(bytes);
             writePostEncapsulationBoundary(type);
         }
+
         private void writeEncoded(byte[] bytes) throws IOException {
             bytes = Base64.getEncoder().encode(bytes);
             for (int i = 0; i < bytes.length; i += buf.length) {
@@ -84,10 +87,12 @@ public final class PemUtils {
                 this.newLine();
             }
         }
+
         private void writePreEncapsulationBoundary(String type) throws IOException {
             this.write("-----BEGIN " + type + "-----");
             this.newLine();
         }
+
         private void writePostEncapsulationBoundary(String type) throws IOException {
             this.write("-----END " + type + "-----");
             this.newLine();

--- a/broker/src/main/java/io/moquette/broker/security/PemUtils.java
+++ b/broker/src/main/java/io/moquette/broker/security/PemUtils.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2022 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.moquette.broker.security;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+import java.util.Base64;
+
+public final class PemUtils {
+    private static final String certificateBoundaryType = "CERTIFICATE";
+
+    public static String certificatesToPem(Certificate... certificates)
+        throws CertificateEncodingException, IOException {
+        try (StringWriter str = new StringWriter();
+             PemWriter pemWriter = new PemWriter(str)) {
+            for (Certificate certificate : certificates) {
+                pemWriter.writeObject(certificateBoundaryType, certificate.getEncoded());
+            }
+            pemWriter.close();
+            return str.toString();
+        }
+    }
+
+    /**
+     * Copyright (c) 2000 - 2021 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
+     * SPDX-License-Identifier: MIT
+     *
+     * <p>A generic PEM writer, based on RFC 1421
+     * From: https://javadoc.io/static/org.bouncycastle/bcprov-jdk15on/1.62/org/bouncycastle/util/io/pem/PemWriter.html</p>
+     */
+    public static class PemWriter extends BufferedWriter {
+        private static final int LINE_LENGTH = 64;
+        private final char[] buf = new char[LINE_LENGTH];
+        /**
+         * Base constructor.
+         *
+         * @param out output stream to use.
+         */
+        public PemWriter(Writer out) {
+            super(out);
+        }
+        /**
+         * Writes a pem encoded string.
+         *
+         * @param type  key type.
+         * @param bytes encoded string
+         * @throws IOException IO Exception
+         */
+        public void writeObject(String type, byte[] bytes) throws IOException {
+            writePreEncapsulationBoundary(type);
+            writeEncoded(bytes);
+            writePostEncapsulationBoundary(type);
+        }
+        private void writeEncoded(byte[] bytes) throws IOException {
+            bytes = Base64.getEncoder().encode(bytes);
+            for (int i = 0; i < bytes.length; i += buf.length) {
+                int index = 0;
+                while (index != buf.length) {
+                    if ((i + index) >= bytes.length) {
+                        break;
+                    }
+                    buf[index] = (char) bytes[i + index];
+                    index++;
+                }
+                this.write(buf, 0, index);
+                this.newLine();
+            }
+        }
+        private void writePreEncapsulationBoundary(String type) throws IOException {
+            this.write("-----BEGIN " + type + "-----");
+            this.newLine();
+        }
+        private void writePostEncapsulationBoundary(String type) throws IOException {
+            this.write("-----END " + type + "-----");
+            this.newLine();
+        }
+    }
+}

--- a/broker/src/test/java/io/moquette/broker/BrokerConfigurationTest.java
+++ b/broker/src/test/java/io/moquette/broker/BrokerConfigurationTest.java
@@ -16,6 +16,7 @@
 package io.moquette.broker;
 
 import io.moquette.BrokerConstants;
+import io.moquette.broker.config.IConfig;
 import io.moquette.broker.config.MemoryConfig;
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +35,7 @@ public class BrokerConfigurationTest {
         assertFalse(brokerConfiguration.isAllowZeroByteClientId());
         assertFalse(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
         assertEquals(IMMEDIATE_BUFFER_FLUSH, brokerConfiguration.getBufferFlushMillis(), "Immediate flush by default");
+        assertFalse(brokerConfiguration.isPeerCertificateAsUsername());
     }
 
     @Test
@@ -46,6 +48,7 @@ public class BrokerConfigurationTest {
         assertFalse(brokerConfiguration.isAllowZeroByteClientId());
         assertFalse(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
         assertEquals(IMMEDIATE_BUFFER_FLUSH, brokerConfiguration.getBufferFlushMillis(), "Immediate flush by default");
+        assertFalse(brokerConfiguration.isPeerCertificateAsUsername());
     }
 
     @Test
@@ -58,6 +61,7 @@ public class BrokerConfigurationTest {
         assertTrue(brokerConfiguration.isAllowZeroByteClientId());
         assertFalse(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
         assertEquals(IMMEDIATE_BUFFER_FLUSH, brokerConfiguration.getBufferFlushMillis(), "Immediate flush by default");
+        assertFalse(brokerConfiguration.isPeerCertificateAsUsername());
     }
 
     @Test
@@ -70,6 +74,7 @@ public class BrokerConfigurationTest {
         assertFalse(brokerConfiguration.isAllowZeroByteClientId());
         assertTrue(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
         assertEquals(IMMEDIATE_BUFFER_FLUSH, brokerConfiguration.getBufferFlushMillis(), "Immediate flush by default");
+        assertFalse(brokerConfiguration.isPeerCertificateAsUsername());
     }
 
     @Test
@@ -82,5 +87,19 @@ public class BrokerConfigurationTest {
         assertFalse(brokerConfiguration.isAllowZeroByteClientId());
         assertFalse(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
         assertEquals(IMMEDIATE_BUFFER_FLUSH, brokerConfiguration.getBufferFlushMillis(), "No immediate flush by default");
+        assertFalse(brokerConfiguration.isPeerCertificateAsUsername());
+    }
+
+    @Test
+    public void configurePeerCertificateAsUsername() {
+        Properties properties = new Properties();
+        properties.put(IConfig.PEER_CERTIFICATE_AS_USERNAME, "true");
+        MemoryConfig config = new MemoryConfig(properties);
+        BrokerConfiguration brokerConfiguration = new BrokerConfiguration(config);
+        assertTrue(brokerConfiguration.isAllowAnonymous());
+        assertFalse(brokerConfiguration.isAllowZeroByteClientId());
+        assertFalse(brokerConfiguration.isReauthorizeSubscriptionsOnConnect());
+        assertEquals(IMMEDIATE_BUFFER_FLUSH, brokerConfiguration.getBufferFlushMillis(), "No immediate flush by default");
+        assertTrue(brokerConfiguration.isPeerCertificateAsUsername());
     }
 }

--- a/broker/src/test/java/io/moquette/broker/MockAuthenticator.java
+++ b/broker/src/test/java/io/moquette/broker/MockAuthenticator.java
@@ -16,9 +16,10 @@
 
 package io.moquette.broker;
 
+import io.moquette.broker.security.IAuthenticator;
+
 import java.util.Map;
 import java.util.Set;
-import io.moquette.broker.security.IAuthenticator;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -43,10 +44,12 @@ public class MockAuthenticator implements IAuthenticator {
         if (!m_userPwds.containsKey(username)) {
             return false;
         }
-        if (password == null) {
-            return false;
+        if (password != null) {
+            return m_userPwds.get(username).equals(new String(password, UTF_8));
+        } else {
+            // handle null password
+            return m_userPwds.get(username) == null;
         }
-        return m_userPwds.get(username).equals(new String(password, UTF_8));
     }
 
 }

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLClientAuthBase.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLClientAuthBase.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.moquette.integration;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+
+/**
+ * Base class for TLS client authentication tests which check that Moquette could also handle SSL with client
+ * authentication.
+ *
+ * This test verifies client's authentication on server, so the server certificate has to be imported into the
+ * client's keystore and the client's certificate must be imported into server's keystore.
+ *
+ *  the first way is done by:
+ *  <pre>
+ *  keytool -genkeypair -alias testserver -keyalg RSA -validity 3650 -keysize 2048 -dname cn=localhost -keystore serverkeystore.jks -keypass passw0rdsrv -storepass passw0rdsrv
+ *  </pre>
+ *  and
+ *  <pre>
+ *  keytool -exportcert -alias testserver -keystore serverkeystore.jks -keypass passw0rdsrv -storepass passw0rdsrv | \
+ *  keytool -importcert -trustcacerts -noprompt -alias testserver -keystore signedclientkeystore.jks -keypass passw0rd -storepass passw0rd
+ *  </pre>
+ *
+ *  to create the key in the client side:
+ *  <pre>
+ *  keytool -genkeypair -alias signedtestclient -dname cn=client.moquette.io -validity 10000 -keyalg RSA -keysize 2048 -keystore signedclientkeystore.jks -keypass passw0rd -storepass passw0rd
+ *  </pre>
+ *
+ *  to import the client's certificate into server:
+ *  <pre>
+ *  keytool -exportcert -alias signedtestclient -keystore signedclientkeystore.jks -keypass passw0rd -storepass passw0rd | \
+ *  keytool -importcert -trustcacerts -noprompt -alias signedtestclient -keystore serverkeystore.jks -keypass passw0rdsrv -storepass passw0rdsrv
+ *  </pre>
+ *
+ *  To verify that a client's certficate not imported into server, it's necessary to create a client's key:
+ *  <pre>
+ *  keytool -genkeypair -alias unsignedtestclient -dname cn=unverifiedclient.moquette.io -validity 10000 -keyalg RSA -keysize 2048 -keystore unsignedclientkeystore.jks -keypass passw0rd -storepass passw0rd
+ *  </pre>
+ *  and import into it the server's certificate:
+ *  <pre>
+ *  keytool -exportcert -alias testserver -keystore serverkeystore.jks -keypass passw0rdsrv -storepass passw0rdsrv | \
+ *  keytool -importcert -trustcacerts -noprompt -alias testserver -keystore unsignedclientkeystore.jks -keypass passw0rd -storepass passw0rd
+ *  </pre>
+ *
+ *
+ * <p>
+ * Create certificates needed for client authentication
+ *
+ * <pre>
+ * # generate integration certificate chain (valid for 10000 days)
+ * keytool -genkeypair -alias signedtestserver -dname cn=moquette.eclipse.org -keyalg RSA -keysize 2048 \
+ * -keystore signedserverkeystore.jks -keypass passw0rdsrv -storepass passw0rdsrv -validity 10000
+ * keytool -genkeypair -alias signedtestserver_sub -dname cn=moquette.eclipse.org -keyalg RSA -keysize 2048 \
+ * -keystore signedserverkeystore.jks -keypass passw0rdsrv -storepass passw0rdsrv
+ *
+ * # sign integration subcertificate with integration certificate (valid for 10000 days)
+ * keytool -certreq -alias signedtestserver_sub -keystore signedserverkeystore.jks -keypass passw0rdsrv \
+ * -storepass passw0rdsrv | \
+ * keytool -gencert -alias signedtestserver -keystore signedserverkeystore.jks -keypass passw0rdsrv \
+ * -storepass passw0rdsrv -validity 10000 | \
+ * keytool -importcert -alias signedtestserver_sub -keystore signedserverkeystore.jks -keypass passw0rdsrv \
+ * -storepass passw0rdsrv
+ *
+ * # generate client keypair
+ * keytool -genkeypair -alias signedtestclient -dname cn=moquette.eclipse.org -keyalg RSA -keysize 2048 \
+ * -keystore signedclientkeystore.jks -keypass passw0rd -storepass passw0rd
+ *
+ * # create signed client certificate with integration subcertificate and import to client keystore (valid for 10000 days)
+ * keytool -certreq -alias signedtestclient -keystore signedclientkeystore.jks -keypass passw0rd -storepass passw0rd | \
+ * keytool -gencert -alias signedtestserver_sub -keystore signedserverkeystore.jks -keypass passw0rdsrv \
+ * -storepass passw0rdsrv -validity 10000 | \
+ * keytool -importcert -alias signedtestclient -keystore signedclientkeystore.jks -keypass passw0rd \
+ * -storepass passw0rd -noprompt
+ *
+ * # import integration certificates into signed truststore
+ * keytool -exportcert -alias signedtestserver -keystore signedserverkeystore.jks -keypass passw0rdsrv \
+ * -storepass passw0rdsrv | \
+ * keytool -importcert -trustcacerts -noprompt -alias signedtestserver -keystore signedclientkeystore.jks \
+ * -keypass passw0rd -storepass passw0rd
+ * keytool -exportcert -alias signedtestserver_sub -keystore signedserverkeystore.jks -keypass passw0rdsrv \
+ * -storepass passw0rdsrv | \
+ * keytool -importcert -trustcacerts -noprompt -alias signedtestserver_sub -keystore signedclientkeystore.jks \
+ * -keypass passw0rd -storepass passw0rd
+ *
+ * # create unsigned client certificate (valid for 10000 days)
+ * keytool -genkeypair -alias unsignedtestclient -dname cn=moquette.eclipse.org -validity 10000 -keyalg RSA \
+ * -keysize 2048 -keystore unsignedclientkeystore.jks -keypass passw0rd -storepass passw0rd
+ *
+ * # import integration certificates into unsigned truststore
+ * keytool -exportcert -alias signedtestserver -keystore signedserverkeystore.jks -keypass passw0rdsrv \
+ * -storepass passw0rdsrv | \
+ * keytool -importcert -trustcacerts -noprompt -alias signedtestserver -keystore unsignedclientkeystore.jks \
+ * -keypass passw0rd -storepass passw0rd
+ * keytool -exportcert -alias signedtestserver_sub -keystore signedserverkeystore.jks -keypass passw0rdsrv \
+ * -storepass passw0rdsrv | \
+ * keytool -importcert -trustcacerts -noprompt -alias signedtestserver_sub -keystore unsignedclientkeystore.jks \
+ * -keypass passw0rd -storepass passw0rd
+ * </pre>
+ * </p>
+ */
+public class ServerIntegrationSSLClientAuthBase {
+    static String backup;
+
+    @BeforeAll
+    public static void beforeTests() {
+        backup = System.getProperty("moquette.path");
+    }
+
+    @AfterAll
+    public static void afterTests() {
+        if (backup == null)
+            System.clearProperty("moquette.path");
+        else
+            System.setProperty("moquette.path", backup);
+    }
+
+    Certificate getClientCert(String keystore, String alias)
+        throws KeyStoreException, CertificateException, IOException, NoSuchAlgorithmException {
+        KeyStore ks = KeyStore.getInstance("JKS");
+        InputStream jksInputStream = getClass().getClassLoader().getResourceAsStream(keystore);
+        ks.load(jksInputStream, "passw0rd".toCharArray());
+        return ks.getCertificate(alias);
+    }
+
+    SSLSocketFactory configureSSLSocketFactory(String keystore) throws KeyManagementException,
+        NoSuchAlgorithmException, UnrecoverableKeyException, IOException, CertificateException, KeyStoreException {
+        KeyStore ks = KeyStore.getInstance("JKS");
+        InputStream jksInputStream = getClass().getClassLoader().getResourceAsStream(keystore);
+        ks.load(jksInputStream, "passw0rd".toCharArray());
+
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(ks, "passw0rd".toCharArray());
+
+        TrustManagerFactory tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        tmf.init(ks);
+
+        SSLContext sc = SSLContext.getInstance("TLS");
+        TrustManager[] trustManagers = tmf.getTrustManagers();
+        sc.init(kmf.getKeyManagers(), trustManagers, null);
+
+        SSLSocketFactory ssf = sc.getSocketFactory();
+        return ssf;
+    }
+}

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLClientAuthBase.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLClientAuthBase.java
@@ -5,6 +5,8 @@
 
 package io.moquette.integration;
 
+import io.moquette.BrokerConstants;
+import io.moquette.broker.config.IConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
@@ -17,6 +19,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
+import java.util.Properties;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
@@ -131,6 +134,19 @@ public class ServerIntegrationSSLClientAuthBase {
             System.clearProperty("moquette.path");
         else
             System.setProperty("moquette.path", backup);
+    }
+
+    static Properties getDefaultServerProperties(String dbPath) {
+        Properties sslProps = new Properties();
+        sslProps.put(IConfig.SSL_PORT_PROPERTY_NAME, "8883");
+        sslProps.put(IConfig.JKS_PATH_PROPERTY_NAME, "src/test/resources/serverkeystore.jks");
+        sslProps.put(IConfig.KEY_STORE_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
+        sslProps.put(IConfig.KEY_MANAGER_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
+        sslProps.put(IConfig.DATA_PATH_PROPERTY_NAME, dbPath);
+        sslProps.put(IConfig.PERSISTENCE_ENABLED_PROPERTY_NAME, "true");
+        sslProps.put(BrokerConstants.NEED_CLIENT_AUTH, "true");
+        sslProps.put(IConfig.ENABLE_TELEMETRY_NAME, "false");
+        return sslProps;
     }
 
     Certificate getClientCert(String keystore, String alias)

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLClientAuthCertAsUsernameTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLClientAuthCertAsUsernameTest.java
@@ -19,11 +19,14 @@ package io.moquette.integration;
 import io.moquette.BrokerConstants;
 import io.moquette.broker.Server;
 import io.moquette.broker.config.IConfig;
+import io.moquette.broker.config.MemoryConfig;
+import io.moquette.broker.security.IAuthenticator;
+import io.moquette.broker.security.PemUtils;
 import org.eclipse.paho.client.mqttv3.IMqttClient;
 import org.eclipse.paho.client.mqttv3.MqttClient;
 import org.eclipse.paho.client.mqttv3.MqttClientPersistence;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
-import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttSecurityException;
 import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,23 +39,24 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLSocketFactory;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+public class ServerIntegrationSSLClientAuthCertAsUsernameTest extends ServerIntegrationSSLClientAuthBase {
 
-public class ServerIntegrationSSLClientAuthTest extends ServerIntegrationSSLClientAuthBase {
-
-    private static final Logger LOG = LoggerFactory.getLogger(ServerIntegrationSSLClientAuthTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ServerIntegrationSSLClientAuthCertAsUsernameTest.class);
 
     Server m_server;
 
     IMqttClient m_client;
-    MessageCollector m_callback;
-
     @TempDir
     Path tempFolder;
+
+    IAuthenticator authenticator;
 
     protected void startServer(String dbPath) throws IOException {
         String file = getClass().getResource("/").getPath();
@@ -68,7 +72,9 @@ public class ServerIntegrationSSLClientAuthTest extends ServerIntegrationSSLClie
         sslProps.put(IConfig.PERSISTENCE_ENABLED_PROPERTY_NAME, "true");
         sslProps.put(BrokerConstants.NEED_CLIENT_AUTH, "true");
         sslProps.put(IConfig.ENABLE_TELEMETRY_NAME, "false");
-        m_server.startServer(sslProps);
+        sslProps.put(IConfig.PEER_CERTIFICATE_AS_USERNAME, "true");
+        m_server.startServer(new MemoryConfig(sslProps), null, null,
+            (clientId, username, password) -> authenticator.checkValid(clientId, username, password), null);
     }
 
     @BeforeEach
@@ -79,11 +85,11 @@ public class ServerIntegrationSSLClientAuthTest extends ServerIntegrationSSLClie
 
         startServer(dbPath);
 
-        MqttClientPersistence subDataStore = new MqttDefaultFilePersistence(IntegrationUtils.newFolder(tempFolder, "client").getAbsolutePath());
+        MqttClientPersistence subDataStore =
+            new MqttDefaultFilePersistence(IntegrationUtils.newFolder(tempFolder, "client").getAbsolutePath());
         m_client = new MqttClient("ssl://localhost:8883", "TestClient", subDataStore);
-        // m_client = new MqttClient("ssl://test.mosquitto.org:8883", "TestClient", s_dataStore);
 
-        m_callback = new MessageCollector();
+        MessageCollector m_callback = new MessageCollector();
         m_client.setCallback(m_callback);
     }
 
@@ -97,8 +103,14 @@ public class ServerIntegrationSSLClientAuthTest extends ServerIntegrationSSLClie
     }
 
     @Test
-    public void checkClientAuthentication() throws Exception {
-        LOG.info("*** checkClientAuthentication ***");
+    public void checkClientAuthenticationPeerCertAsUsername() throws Exception {
+        AtomicReference<String> usernameRef = new AtomicReference<>();
+        authenticator = (clientId, username, password) -> {
+            usernameRef.set(username);
+            return true;
+        };
+
+        LOG.info("*** checkClientAuthenticationPeerCertAsUsername ***");
         SSLSocketFactory ssf = configureSSLSocketFactory("signedclientkeystore.jks");
 
         MqttConnectOptions options = new MqttConnectOptions();
@@ -106,16 +118,28 @@ public class ServerIntegrationSSLClientAuthTest extends ServerIntegrationSSLClie
         m_client.connect(options);
         m_client.subscribe("/topic", 0);
         m_client.disconnect();
+
+        assertEquals(PemUtils.certificatesToPem(getClientCert("signedclientkeystore.jks", "signedtestclient")),
+            usernameRef.get());
     }
 
     @Test
-    public void checkClientAuthenticationFail() throws Exception {
-        LOG.info("*** checkClientAuthenticationFail ***");
-        SSLSocketFactory ssf = configureSSLSocketFactory("unsignedclientkeystore.jks");
+    public void checkClientAuthenticationFailPeerCertAsUsername() throws Exception {
+        AtomicReference<String> usernameRef = new AtomicReference<>();
+        authenticator = (clientId, username, password) -> {
+            usernameRef.set(username);
+            return false;
+        };
+
+        LOG.info("*** checkClientAuthenticationFailPeerCertAsUsername ***");
+        SSLSocketFactory ssf = configureSSLSocketFactory("signedclientkeystore.jks");
 
         MqttConnectOptions options = new MqttConnectOptions();
         options.setSocketFactory(ssf);
-        // actual a "Broken pipe" is thrown, this is not very specific.
-        assertThrows(MqttException.class, () -> m_client.connect(options));
+
+        MqttSecurityException ex = assertThrows(MqttSecurityException.class, () -> m_client.connect(options));
+        assertEquals("Bad user name or password", ex.getMessage());
+        assertEquals(PemUtils.certificatesToPem(getClientCert("signedclientkeystore.jks", "signedtestclient")),
+            usernameRef.get());
     }
 }

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLClientAuthCertAsUsernameTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLClientAuthCertAsUsernameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 The original author or authors
+ * Copyright (c) 2012-2023 The original author or authors
  * ------------------------------------------------------
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,7 +16,6 @@
 
 package io.moquette.integration;
 
-import io.moquette.BrokerConstants;
 import io.moquette.broker.Server;
 import io.moquette.broker.config.IConfig;
 import io.moquette.broker.config.MemoryConfig;
@@ -63,15 +62,7 @@ public class ServerIntegrationSSLClientAuthCertAsUsernameTest extends ServerInte
         System.setProperty("moquette.path", file);
         m_server = new Server();
 
-        Properties sslProps = new Properties();
-        sslProps.put(IConfig.SSL_PORT_PROPERTY_NAME, "8883");
-        sslProps.put(IConfig.JKS_PATH_PROPERTY_NAME, "src/test/resources/serverkeystore.jks");
-        sslProps.put(IConfig.KEY_STORE_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
-        sslProps.put(IConfig.KEY_MANAGER_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
-        sslProps.put(IConfig.DATA_PATH_PROPERTY_NAME, dbPath);
-        sslProps.put(IConfig.PERSISTENCE_ENABLED_PROPERTY_NAME, "true");
-        sslProps.put(BrokerConstants.NEED_CLIENT_AUTH, "true");
-        sslProps.put(IConfig.ENABLE_TELEMETRY_NAME, "false");
+        Properties sslProps = getDefaultServerProperties(dbPath);
         sslProps.put(IConfig.PEER_CERTIFICATE_AS_USERNAME, "true");
         m_server.startServer(new MemoryConfig(sslProps), null, null,
             (clientId, username, password) -> authenticator.checkValid(clientId, username, password), null);

--- a/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLClientAuthTest.java
+++ b/broker/src/test/java/io/moquette/integration/ServerIntegrationSSLClientAuthTest.java
@@ -16,9 +16,7 @@
 
 package io.moquette.integration;
 
-import io.moquette.BrokerConstants;
 import io.moquette.broker.Server;
-import io.moquette.broker.config.IConfig;
 import org.eclipse.paho.client.mqttv3.IMqttClient;
 import org.eclipse.paho.client.mqttv3.MqttClient;
 import org.eclipse.paho.client.mqttv3.MqttClientPersistence;
@@ -35,7 +33,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Properties;
 import javax.net.ssl.SSLSocketFactory;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -59,16 +56,7 @@ public class ServerIntegrationSSLClientAuthTest extends ServerIntegrationSSLClie
         System.setProperty("moquette.path", file);
         m_server = new Server();
 
-        Properties sslProps = new Properties();
-        sslProps.put(IConfig.SSL_PORT_PROPERTY_NAME, "8883");
-        sslProps.put(IConfig.JKS_PATH_PROPERTY_NAME, "src/test/resources/serverkeystore.jks");
-        sslProps.put(IConfig.KEY_STORE_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
-        sslProps.put(IConfig.KEY_MANAGER_PASSWORD_PROPERTY_NAME, "passw0rdsrv");
-        sslProps.put(IConfig.DATA_PATH_PROPERTY_NAME, dbPath);
-        sslProps.put(IConfig.PERSISTENCE_ENABLED_PROPERTY_NAME, "true");
-        sslProps.put(BrokerConstants.NEED_CLIENT_AUTH, "true");
-        sslProps.put(IConfig.ENABLE_TELEMETRY_NAME, "false");
-        m_server.startServer(sslProps);
+        m_server.startServer(getDefaultServerProperties(dbPath));
     }
 
     @BeforeEach


### PR DESCRIPTION
Rebase of https://github.com/moquette-io/moquette/pull/675

This PR adds enables authenticating clients based on their peer certificates without changing the existing authentication interface. This functionality is enabled by the addition of a new configuration option which passes the client certificate PEM in place of `username`. The EMQx broker also has the same configuration option.

There is also a very small change to behavior with this PR. Previously, clients that did not provide a password were immediately rejected if anonymous sessions were disabled. As far as I can tell, the spec allows username without a password. The code will now allow this and pass the username and empty password to the authenticator.

Why is this needed?
The existing auth interfaces are insufficient when clients need to be identified based on their client certificate. The current interfaces only support username, password, and client ID without any ability for authenticators and authorizers to use the client certificate (if provided) for authN/authZ.

By passing in the client certificate as username, this allows the authorizer to uniquely identify clients and authenticate and authorize based on this cryptographically secure identity.


Close #675 