### PR TITLE
chore: keep java 8 compatibility

### DIFF
--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
@@ -2,10 +2,8 @@ package io.moquette.broker.subscriptions;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 public class CTrie {
 
@@ -35,7 +33,7 @@ public class CTrie {
         Token token = topic.headToken();
         while (!topic.isEmpty()) {
             Optional<INode> child = inode.mainNode().childOf(token);
-            if (child.isEmpty()) {
+            if (!child.isPresent()) {
                 break;
             }
             topic = topic.exceptHeadToken();

--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,8 @@
         <target.version>1.8</target.version>
         <junit.version>5.7.0</junit.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
     </properties>
 
     <groupId>io.moquette</groupId>


### PR DESCRIPTION
Maintain java 8 compatibility by just switching `Optional.isEmpty` to `!Optional.isPresent`