### PR TITLE
fix: handle 0 sized collector batches in PostOffice

### DIFF
--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -469,7 +469,15 @@ class PostOffice {
                 collector.add(sub);
             }
         }
-        payload.retain(collector.countBatches());
+
+        int subscriptionCount = collector.countBatches();
+        if (subscriptionCount <= 0) {
+            // no matching subscriptions, clean exit
+            LOG.trace("No matching subscriptions for topic: {}", topic);
+            return new RoutingResults(Collections.emptyList(), Collections.emptyList(), CompletableFuture.completedFuture(null));
+        }
+
+        payload.retain(subscriptionCount);
 
         List<RouteResult> publishResults = collector.routeBatchedPublishes((batch) -> {
             publishToSession(payload, topic, batch, publishingQos);


### PR DESCRIPTION
This change is attempting to resolve #750 where the call to `retain` is 0 and therefore `countBatches` must have returned 0. I know that this change will absolutely avoid the error, however, I'm not clear on why the number of batches would be 0 while this code is running. In this change, I simply treat it exactly the same as the above case where there are no subscriptions (and thus no work to do).