### PR TITLE
fix: remove unused log placeholder

### DIFF
--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -585,7 +585,7 @@ public class Server {
         sessions.close();
 
         if (h2Builder != null) {
-            LOG.trace("Shutting down H2 persistence {}");
+            LOG.trace("Shutting down H2 persistence");
             h2Builder.closeStore();
         }
 


### PR DESCRIPTION
Super small change, just cleaning up a log line with an unused placeholder.