### PR TITLE
Fix a flaky test

### DIFF
--- a/broker/src/test/java/io/moquette/broker/MemoryRetainedRepositoryTest.java
+++ b/broker/src/test/java/io/moquette/broker/MemoryRetainedRepositoryTest.java
@@ -22,6 +22,7 @@ import io.netty.handler.codec.mqtt.MqttMessageBuilders;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import org.junit.jupiter.api.Test;
 
+import java.util.Comparator;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -82,6 +83,7 @@ public class MemoryRetainedRepositoryTest {
         assertEquals("foo/bar/baz", retainedMessages.get(0).getTopic().toString());
 
         retainedMessages = repository.retainedOnTopic("foo/#");
+        retainedMessages.sort(Comparator.comparing(m -> m.getTopic().toString()));
 
         assertEquals(2, retainedMessages.size());
         assertEquals("foo/bar/baz", retainedMessages.get(0).getTopic().toString());


### PR DESCRIPTION
This PR is to fix a flaky test `o.moquette.broker.MemoryRetainedRepositoryTest#testRetainedOnTopicReturnsWildcardTopicMatch` in module `broker`.

## Test failures
- Run the following commands to reproduce the test failure:
```
 mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -pl broker -Dtest=io.moquette.broker.MemoryRetainedRepositoryTest#testRetainedOnTopicReturnsWildcardTopicMatch
```
- Then we get the following test failures:
```
[ERROR]   MemoryRetainedRepositoryTest.testRetainedOnTopicReturnsWildcardTopicMatch:87 expected: <foo/bar/baz> but was: <foo/baz/bar>
```
## Root cause

In line 84 of the test file, `retainedMessages = repository.retainedOnTopic("foo/#");` calls `retainedOnTopic` from [broker/src/main/java/io/moquette/broker/MemoryRetainedRepository.java](https://github.com/dserfe/moquette/blob/main/broker/src/main/java/io/moquette/broker/MemoryRetainedRepository.java).
In line 33 of the main class file provided, `storage` is defined as a `ConcurrentHashMap`, its keys are not in sorted order. Consequently, in line 58, when the `retainedOnTopic` method calls `storage.entrySet()`, the returned elements' order is non-deterministic. This leads to inconsistencies in the order of the elements in `matchingMessages`. 
When it is returned to the test, the assertion in lines 87-88 (in the test file) assumes the orders are consistent, causing the test to fail.

## Fix
To fix the flakiness, we can either change the test code or change the main code:
1) One fix is to sort the elements of `retainedMessages` before making assertions of them in the test, which is the code change in this PR.
2) If you prefer to resolve the flakiness from the main code, the fix is to use `ConcurrentSkipListMap` instead of `ConcurrentMap`. `ConcurrentSkipListMap` is sorted and thread-safe. If you prefer the code changes of the following PR: https://github.com/dserfe/moquette/pull/2/files, please let me know!