### PR TITLE
Updated siganture of retainedOnTopic

### DIFF
--- a/broker/src/main/java/io/moquette/broker/IRetainedRepository.java
+++ b/broker/src/main/java/io/moquette/broker/IRetainedRepository.java
@@ -18,6 +18,7 @@ package io.moquette.broker;
 import io.moquette.broker.subscriptions.Topic;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 
+import java.util.Collection;
 import java.util.List;
 
 public interface IRetainedRepository {
@@ -28,5 +29,11 @@ public interface IRetainedRepository {
 
     boolean isEmpty();
 
-    List<RetainedMessage> retainedOnTopic(String topic);
+    /**
+     * Return the list of messages retained on a specified topic.
+     *
+     * @param topic the topic containing the retained messages.
+     * @return the unordered collection of retained messages on the topic.
+     * */
+    Collection<RetainedMessage> retainedOnTopic(String topic);
 }

--- a/broker/src/main/java/io/moquette/broker/MemoryRetainedRepository.java
+++ b/broker/src/main/java/io/moquette/broker/MemoryRetainedRepository.java
@@ -20,6 +20,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -52,7 +53,7 @@ final class MemoryRetainedRepository implements IRetainedRepository {
     }
 
     @Override
-    public List<RetainedMessage> retainedOnTopic(String topic) {
+    public Collection<RetainedMessage> retainedOnTopic(String topic) {
         final Topic searchTopic = new Topic(topic);
         final List<RetainedMessage> matchingMessages = new ArrayList<>();
         for (Map.Entry<Topic, RetainedMessage> entry : storage.entrySet()) {

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -374,7 +374,7 @@ class PostOffice {
         Session targetSession = this.sessionRegistry.retrieve(clientID);
         for (Subscription subscription : newSubscriptions) {
             final String topicFilter = subscription.getTopicFilter().toString();
-            final List<RetainedMessage> retainedMsgs = retainedRepository.retainedOnTopic(topicFilter);
+            final Collection<RetainedMessage> retainedMsgs = retainedRepository.retainedOnTopic(topicFilter);
 
             if (retainedMsgs.isEmpty()) {
                 // not found

--- a/broker/src/main/java/io/moquette/persistence/H2RetainedRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/H2RetainedRepository.java
@@ -9,6 +9,7 @@ import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -40,7 +41,7 @@ public class H2RetainedRepository implements IRetainedRepository {
     }
 
     @Override
-    public List<RetainedMessage> retainedOnTopic(String topic) {
+    public Collection<RetainedMessage> retainedOnTopic(String topic) {
         final Topic searchTopic = new Topic(topic);
         final List<RetainedMessage> matchingMessages = new ArrayList<>();
         for (Map.Entry<Topic, RetainedMessage> entry : queueMap.entrySet()) {

--- a/broker/src/test/java/io/moquette/broker/MemoryRetainedRepositoryTest.java
+++ b/broker/src/test/java/io/moquette/broker/MemoryRetainedRepositoryTest.java
@@ -20,10 +20,13 @@ import io.moquette.broker.subscriptions.Topic;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.mqtt.MqttMessageBuilders;
 import io.netty.handler.codec.mqtt.MqttQoS;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.MatcherAssert.assertThat;
 import org.junit.jupiter.api.Test;
 
-import java.util.Comparator;
-import java.util.List;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -50,10 +53,10 @@ public class MemoryRetainedRepositoryTest {
             .payload(Unpooled.buffer(0))
             .build());
 
-        List<RetainedMessage> retainedMessages = repository.retainedOnTopic("foo/bar/baz");
+        Collection<RetainedMessage> retainedMessages = repository.retainedOnTopic("foo/bar/baz");
         
         assertEquals(1, retainedMessages.size());
-        assertEquals("foo/bar/baz", retainedMessages.get(0).getTopic().toString());
+        assertEquals("foo/bar/baz", retainedMessages.iterator().next().getTopic().toString());
     }
 
     @Test
@@ -77,17 +80,19 @@ public class MemoryRetainedRepositoryTest {
             .payload(Unpooled.buffer(0))
             .build());
 
-        List<RetainedMessage> retainedMessages = repository.retainedOnTopic("foo/bar/#");
+        Collection<RetainedMessage> retainedMessages = repository.retainedOnTopic("foo/bar/#");
 
         assertEquals(1, retainedMessages.size());
-        assertEquals("foo/bar/baz", retainedMessages.get(0).getTopic().toString());
+        assertEquals("foo/bar/baz", retainedMessages.iterator().next().getTopic().toString());
 
         retainedMessages = repository.retainedOnTopic("foo/#");
-        retainedMessages.sort(Comparator.comparing(m -> m.getTopic().toString()));
 
         assertEquals(2, retainedMessages.size());
-        assertEquals("foo/bar/baz", retainedMessages.get(0).getTopic().toString());
-        assertEquals("foo/baz/bar", retainedMessages.get(1).getTopic().toString());
+        Set<String> topicString = retainedMessages.stream()
+            .map(RetainedMessage::getTopic)
+            .map(Topic::toString)
+            .collect(Collectors.toSet());
+        assertThat(topicString, containsInAnyOrder("foo/bar/baz", "foo/baz/bar"));
     }
 
     @Test
@@ -111,9 +116,9 @@ public class MemoryRetainedRepositoryTest {
             .payload(Unpooled.buffer(0))
             .build());
 
-        List<RetainedMessage> retainedMessages = repository.retainedOnTopic("foo/+/baz");
+        Collection<RetainedMessage> retainedMessages = repository.retainedOnTopic("foo/+/baz");
 
         assertEquals(1, retainedMessages.size());
-        assertEquals("foo/bar/baz", retainedMessages.get(0).getTopic().toString());
+        assertEquals("foo/bar/baz", retainedMessages.iterator().next().getTopic().toString());
     }
 }

--- a/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
@@ -443,9 +443,9 @@ public class PostOfficePublishTest {
     }
 
     private void assertMessageIsRetained(String expectedTopicName, ByteBuf expectedPayload) {
-        List<RetainedMessage> msgs = retainedRepository.retainedOnTopic(expectedTopicName);
+        Collection<RetainedMessage> msgs = retainedRepository.retainedOnTopic(expectedTopicName);
         assertEquals(1, msgs.size());
-        RetainedMessage msg = msgs.get(0);
+        RetainedMessage msg = msgs.iterator().next();
         assertEquals(ByteBufUtil.hexDump(expectedPayload), ByteBufUtil.hexDump(msg.getPayload()));
     }
 }


### PR DESCRIPTION
Update return type of `IRetainedRepository.retainedOnTopic` to express that the returned list of retained messages doesn't have any order.

Closes #782