### PR TITLE
Unsubscribe shared subscriptions

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,6 +1,7 @@
 Version 0.18-SNAPSHOT:
    [feature] shared subscriptions:
      - Initial implementation of shared subscription subscribe and publish part. (#796)
+     - Added unsubscribe of shared subscriptions. (#799)
    [fix] Implements requirements on reserved topics (starts with $). Implements the matching rules and avoid to proceed with processing on client's publishes on those topics (#793)
    [feature] Handle will delay interval and MQTT5's Will optional properties (#770)
    [fix] Handle empty collector batches in PostOffice (#777)

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -418,7 +418,13 @@ class PostOffice {
             }
 
             LOG.trace("Removing subscription topic={}", topic);
-            subscriptions.removeSubscription(topic, clientID);
+            if (SharedSubscriptionUtils.isSharedSubscription(t)) {
+                String topicFilterPart = SharedSubscriptionUtils.extractFilterFromShared(t);
+                ShareName shareName = new ShareName(SharedSubscriptionUtils.extractShareName(t));
+                subscriptions.removeSharedSubscription(shareName, Topic.asTopic(topicFilterPart), clientID);
+            } else {
+                subscriptions.removeSubscription(topic, clientID);
+            }
 
             session.removeSubscription(topic);
 

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -164,6 +164,8 @@ public class SessionRegistry {
         LOG.debug("Removing session {}, expired on {}", expiredSession.clientId(), expiredAt);
         remove(expiredSession.clientId());
         sessionsRepository.delete(expiredSession);
+
+        subscriptionsDirectory.removeSharedSubscriptionsForClient(expiredSession.clientId());
     }
 
     private void trackForRemovalOnExpiration(ISessionsRepository.SessionData session) {
@@ -409,6 +411,8 @@ public class SessionRegistry {
 
         unsubscribe(session);
         remove(session.getClientID());
+
+        subscriptionsDirectory.removeSharedSubscriptionsForClient(session.getClientID());
     }
 
     void remove(String clientID) {

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
@@ -20,7 +20,17 @@ import io.moquette.broker.subscriptions.CTrie.UnsubscribeRequest;
 import io.netty.handler.codec.mqtt.MqttQoS;
 
 import java.security.SecureRandom;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 class CNode implements Comparable<CNode> {

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
@@ -166,8 +166,8 @@ class CNode implements Comparable<CNode> {
         boolean result = false;
         for (List<SharedSubscription> sharedForShareName : this.sharedSubscriptions.values()) {
             SharedSubscription keyWrapper = wrapKey(clientId);
-            Comparator<SharedSubscription> comparJustByClientId = Comparator.comparing(SharedSubscription::clientId);
-            int res = Collections.binarySearch(sharedForShareName, keyWrapper, comparJustByClientId);
+            Comparator<SharedSubscription> compareByClientId = Comparator.comparing(SharedSubscription::clientId);
+            int res = Collections.binarySearch(sharedForShareName, keyWrapper, compareByClientId);
             result = res >= 0 || result;
         }
         return result;

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
@@ -312,12 +312,6 @@ public class CTrie {
         return new INode(newLeafCnode);
     }
 
-    public void removeFromTree(Topic topic, String clientID) {
-        // wrapper method, to remove
-        UnsubscribeRequest deletionRequest = UnsubscribeRequest.buildNonShared(clientID, topic);
-        removeFromTree(deletionRequest);
-    }
-
     public void removeFromTree(UnsubscribeRequest request) {
         Action res;
         do {

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
@@ -14,9 +14,9 @@ public class CTrie {
      * */
     public final static class SubscriptionRequest {
 
-        private Topic topicFilter;
-        private String clientId;
-        private MqttQoS requestedQoS;
+        private final Topic topicFilter;
+        private final String clientId;
+        private final MqttQoS requestedQoS;
 
         private boolean shared = false;
         private ShareName shareName;
@@ -32,11 +32,7 @@ public class CTrie {
         }
 
         public static SubscriptionRequest buildNonShared(String clientId, Topic topicFilter, MqttQoS requestedQoS) {
-            SubscriptionRequest request = new SubscriptionRequest(clientId, topicFilter, requestedQoS);
-            request.topicFilter = topicFilter;
-            request.clientId = clientId; // ? is it needed ?
-            request.requestedQoS = requestedQoS;
-            return request;
+            return new SubscriptionRequest(clientId, topicFilter, requestedQoS);
         }
 
         public static SubscriptionRequest buildShared(ShareName shareName, Topic topicFilter, String clientId, MqttQoS requestedQoS) {
@@ -80,8 +76,8 @@ public class CTrie {
      * Models a request to unsubscribe a client, it's carrier for the Subscription
      * */
     public final static class UnsubscribeRequest {
-        private Topic topicFilter;
-        private String clientId;
+        private final Topic topicFilter;
+        private final String clientId;
         private boolean shared = false;
         private ShareName shareName;
 

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
@@ -21,11 +21,6 @@ public class CTrie {
         private boolean shared = false;
         private ShareName shareName;
 
-//        private SubscriptionRequest(String clientId, Topic topicFilter) {
-//            this.topicFilter = topicFilter;
-//            this.clientId = clientId;
-//        }
-
         private SubscriptionRequest(String clientId, Topic topicFilter, MqttQoS requestedQoS) {
             this.topicFilter = topicFilter;
             this.clientId = clientId;
@@ -113,14 +108,6 @@ public class CTrie {
         public Topic getTopicFilter() {
             return topicFilter;
         }
-//
-//        public Subscription subscription() {
-//            return new Subscription(clientId, topicFilter, requestedQoS);
-//        }
-//
-//        public SharedSubscription sharedSubscription() {
-//            return new SharedSubscription(shareName, topicFilter, clientId, requestedQoS);
-//        }
 
         public boolean isShared() {
             return shared;

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
@@ -22,7 +22,14 @@ import io.netty.handler.codec.mqtt.MqttQoS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
@@ -17,6 +17,7 @@ package io.moquette.broker.subscriptions;
 
 import io.moquette.broker.ISubscriptionsRepository;
 import io.moquette.broker.subscriptions.CTrie.SubscriptionRequest;
+import io.moquette.broker.subscriptions.CTrie.UnsubscribeRequest;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -123,8 +124,15 @@ public class CTrieSubscriptionDirectory implements ISubscriptionsDirectory {
      */
     @Override
     public void removeSubscription(Topic topic, String clientID) {
-        ctrie.removeFromTree(topic, clientID);
+        UnsubscribeRequest request = UnsubscribeRequest.buildNonShared(clientID, topic);
+        ctrie.removeFromTree(request);
         this.subscriptionsRepository.removeSubscription(topic.toString(), clientID);
+    }
+
+    @Override
+    public void removeSharedSubscription(ShareName name, Topic topicFilter, String clientId) {
+        UnsubscribeRequest request = UnsubscribeRequest.buildShared(name, topicFilter, clientId);
+        ctrie.removeFromTree(request);
     }
 
     @Override

--- a/broker/src/main/java/io/moquette/broker/subscriptions/ISubscriptionsDirectory.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/ISubscriptionsDirectory.java
@@ -52,4 +52,11 @@ public interface ISubscriptionsDirectory {
     int size();
 
     String dumpTree();
+
+    /**
+     * Removes all the shared subscriptions for the given session.
+     *
+     * @param clientId The session identifier.
+     * */
+    void removeSharedSubscriptionsForClient(String clientId);
 }

--- a/broker/src/main/java/io/moquette/broker/subscriptions/ISubscriptionsDirectory.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/ISubscriptionsDirectory.java
@@ -40,6 +40,15 @@ public interface ISubscriptionsDirectory {
 
     void removeSubscription(Topic topic, String clientID);
 
+    /**
+     * Removes shared subscription.
+     *
+     * @param name part of the shared subscription.
+     * @param topicFilter topic filter part.
+     * @param clientId the client session to unsubscribe.
+     * */
+    void removeSharedSubscription(ShareName name, Topic topicFilter, String clientId);
+
     int size();
 
     String dumpTree();

--- a/broker/src/main/java/io/moquette/broker/subscriptions/SharedSubscription.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/SharedSubscription.java
@@ -48,6 +48,10 @@ class SharedSubscription implements Comparable<SharedSubscription> {
         return requestedQoS;
     }
 
+    public ShareName getShareName() {
+        return shareName;
+    }
+
     @Override
     public int compareTo(SharedSubscription o) {
         return this.clientId.compareTo(o.clientId);

--- a/broker/src/main/java/io/moquette/broker/subscriptions/TNode.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/TNode.java
@@ -54,7 +54,7 @@ class TNode extends CNode {
     }
 
     @Override
-    void removeSubscriptionsFor(String clientId) {
+    void removeSubscriptionsFor(CTrie.UnsubscribeRequest request) {
         throw new IllegalStateException("Can't be invoked on TNode");
     }
 

--- a/broker/src/test/java/io/moquette/broker/subscriptions/CTrieSharedSubscriptionDirectoryMatchingTest.java
+++ b/broker/src/test/java/io/moquette/broker/subscriptions/CTrieSharedSubscriptionDirectoryMatchingTest.java
@@ -51,4 +51,18 @@ public class CTrieSharedSubscriptionDirectoryMatchingTest extends CTrieSubscript
                 SubscriptionTestUtils.asSubscription("TempSensor1", "/livingroom", "livingroom_devices"))
             .as("One shared subscription for each share name must be present");
     }
+
+    @Test
+    public void givenSessionHasMultipleSharedSubscriptionWhenTheClientIsRemovedThenNoMatchingShouldHappen() {
+        String clientId = "TempSensor1";
+        sut.addShared(clientId, new ShareName("temp_sensors"), asTopic("/livingroom"), MqttQoS.AT_MOST_ONCE);
+        sut.addShared(clientId, new ShareName("livingroom_devices"), asTopic("/livingroom"), MqttQoS.AT_MOST_ONCE);
+
+        // Exercise
+        sut.removeSharedSubscriptionsForClient(clientId);
+
+        // Verify
+        List<Subscription> matchingSubscriptions = sut.matchWithoutQosSharpening(asTopic("/livingroom"));
+        assertThat(matchingSubscriptions).isEmpty();
+    }
 }

--- a/broker/src/test/java/io/moquette/broker/subscriptions/CTrieTest.java
+++ b/broker/src/test/java/io/moquette/broker/subscriptions/CTrieTest.java
@@ -130,7 +130,7 @@ public class CTrieTest {
         sut.addToTree(newSubscription);
 
         //Exercise
-        sut.removeFromTree(asTopic("/temp"), "TempSensor1");
+        sut.removeFromTree(CTrie.UnsubscribeRequest.buildNonShared("TempSensor1", asTopic("/temp")));
 
         //Verify
         final Optional<CNode> matchedNode = sut.lookup(asTopic("/temp"));
@@ -141,7 +141,7 @@ public class CTrieTest {
     public void givenTreeWithSomeNodeUnsubscribeAndResubscribeCleanTomb() {
         SubscriptionRequest newSubscription1 = clientSubOnTopic("TempSensor1", "test");
         sut.addToTree(newSubscription1);
-        sut.removeFromTree(asTopic("test"), "TempSensor1");
+        sut.removeFromTree(CTrie.UnsubscribeRequest.buildNonShared("TempSensor1", asTopic("test")));
 
         SubscriptionRequest newSubscription = clientSubOnTopic("TempSensor1", "test");
         sut.addToTree(newSubscription);
@@ -154,10 +154,10 @@ public class CTrieTest {
         sut.addToTree(newSubscription);
 
         // make sure no TNode exceptions
-        sut.removeFromTree(asTopic("test"), "TempSensor1");
-        sut.removeFromTree(asTopic("test"), "TempSensor1");
-        sut.removeFromTree(asTopic("test"), "TempSensor1");
-        sut.removeFromTree(asTopic("test"), "TempSensor1");
+        sut.removeFromTree(CTrie.UnsubscribeRequest.buildNonShared("TempSensor1", asTopic("test")));
+        sut.removeFromTree(CTrie.UnsubscribeRequest.buildNonShared("TempSensor1", asTopic("test")));
+        sut.removeFromTree(CTrie.UnsubscribeRequest.buildNonShared("TempSensor1", asTopic("test")));
+        sut.removeFromTree(CTrie.UnsubscribeRequest.buildNonShared("TempSensor1", asTopic("test")));
 
         //Verify
         final Optional<CNode> matchedNode = sut.lookup(asTopic("/temp"));
@@ -170,9 +170,9 @@ public class CTrieTest {
         sut.addToTree(newSubscription);
 
         // make sure no TNode exceptions
-        sut.removeFromTree(asTopic("/test/me/1/2/3"), "TempSensor1");
-        sut.removeFromTree(asTopic("/test/me/1/2/3"), "TempSensor1");
-        sut.removeFromTree(asTopic("/test/me/1/2/3"), "TempSensor1");
+        sut.removeFromTree(CTrie.UnsubscribeRequest.buildNonShared("TempSensor1", asTopic("/test/me/1/2/3")));
+        sut.removeFromTree(CTrie.UnsubscribeRequest.buildNonShared("TempSensor1", asTopic("/test/me/1/2/3")));
+        sut.removeFromTree(CTrie.UnsubscribeRequest.buildNonShared("TempSensor1", asTopic("/test/me/1/2/3")));
 
         //Verify
         final Optional<CNode> matchedNode = sut.lookup(asTopic("/temp"));
@@ -187,9 +187,9 @@ public class CTrieTest {
         sut.addToTree(newSubscription);
 
         //Exercise
-        sut.removeFromTree(asTopic("/temp/1"), "TempSensor1");
+        sut.removeFromTree(CTrie.UnsubscribeRequest.buildNonShared("TempSensor1", asTopic("/temp/1")));
 
-        sut.removeFromTree(asTopic("/temp/1"), "TempSensor1");
+        sut.removeFromTree(CTrie.UnsubscribeRequest.buildNonShared("TempSensor1", asTopic("/temp/1")));
         final List<Subscription> matchingSubs = sut.recursiveMatch(asTopic("/temp/2"));
 
         //Verify
@@ -205,7 +205,7 @@ public class CTrieTest {
         sut.addToTree(newSubscription);
 
         //Exercise
-        sut.removeFromTree(asTopic("/temp"), "TempSensor1");
+        sut.removeFromTree(CTrie.UnsubscribeRequest.buildNonShared("TempSensor1", asTopic("/temp")));
 
         final List<Subscription> matchingSubs1 = sut.recursiveMatch(asTopic("/temp/1"));
         final List<Subscription> matchingSubs2 = sut.recursiveMatch(asTopic("/temp/2"));
@@ -223,7 +223,7 @@ public class CTrieTest {
         SubscriptionRequest newSubscription = clientSubOnTopic("TempSensor1", "/bah/bin/bash");
         sut.addToTree(newSubscription);
 
-        sut.removeFromTree(asTopic("/bah/bin/bash"), "TempSensor1");
+        sut.removeFromTree(CTrie.UnsubscribeRequest.buildNonShared("TempSensor1", asTopic("/bah/bin/bash")));
 
         //Verify
         final Optional<CNode> matchedNode = sut.lookup(asTopic("/bah/bin/bash"));
@@ -261,7 +261,7 @@ public class CTrieTest {
         assertThat(matchingSubs1).contains(expectedMatchingsub1);
         assertThat(matchingSubs2).contains(expectedMatchingsub2);
 
-        sut.removeFromTree(asTopic("temp"), "TempSensor1");
+        sut.removeFromTree(CTrie.UnsubscribeRequest.buildNonShared("TempSensor1", asTopic("temp")));
 
         //Exercise
         final List<Subscription> matchingSubs3 = sut.recursiveMatch(asTopic("temp"));
@@ -289,7 +289,7 @@ public class CTrieTest {
         assertThat(matchingSubs1).contains(expectedMatchingsub1);
         assertThat(matchingSubs2).contains(expectedMatchingsub2);
 
-        sut.removeFromTree(asTopic("temp"), "TempSensor1");
+        sut.removeFromTree(CTrie.UnsubscribeRequest.buildNonShared("TempSensor1", asTopic("temp")));
 
         //Exercise
         final List<Subscription> matchingSubs3 = sut.recursiveMatch(asTopic("temp"));
@@ -317,7 +317,7 @@ public class CTrieTest {
         assertThat(matchingSubs1).contains(expectedMatchingsub1);
         assertThat(matchingSubs2).contains(expectedMatchingsub2);
 
-        sut.removeFromTree(asTopic("temp/1"), "TempSensor2");
+        sut.removeFromTree(CTrie.UnsubscribeRequest.buildNonShared("TempSensor2", asTopic("temp/1")));
 
         //Exercise
         final List<Subscription> matchingSubs3 = sut.recursiveMatch(asTopic("temp"));

--- a/broker/src/test/java/io/moquette/integration/mqtt5/SharedSubscriptionTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/SharedSubscriptionTest.java
@@ -359,4 +359,14 @@ public class SharedSubscriptionTest extends AbstractServerIntegrationTest {
             }, MqttQos.AT_LEAST_ONCE, "18", "Shared message must be received", 2);
         }
     }
+
+    @Test
+    public void givenASharedSubscriptionWhenLastSubscribedClientUnsubscribeThenTheSharedSubscriptionTerminates() {
+        fail("TODO implement");
+    }
+
+    @Test
+    public void givenASharedSubscriptionWhenLastSubscribedClientSessionTerminatesThenTheSharedSubscriptionTerminates() {
+        fail("TODO implement");
+    }
 }

--- a/broker/src/test/java/io/moquette/integration/mqtt5/SharedSubscriptionTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/SharedSubscriptionTest.java
@@ -4,6 +4,9 @@ import com.hivemq.client.mqtt.MqttClient;
 import com.hivemq.client.mqtt.MqttGlobalPublishFilter;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5BlockingClient;
+import com.hivemq.client.mqtt.mqtt5.message.connect.Mqtt5Connect;
+import com.hivemq.client.mqtt.mqtt5.message.connect.Mqtt5ConnectBuilder;
+import com.hivemq.client.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAck;
 import com.hivemq.client.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAckReasonCode;
 import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish;
 import com.hivemq.client.mqtt.mqtt5.message.unsubscribe.unsuback.Mqtt5UnsubAck;
@@ -221,6 +224,22 @@ public class SharedSubscriptionTest extends AbstractServerIntegrationTest {
     }
 
     @NotNull
+    private static Mqtt5BlockingClient createCleanStartClient(String clientId) {
+        final Mqtt5BlockingClient client = MqttClient.builder()
+            .useMqttVersion5()
+            .identifier(clientId)
+            .serverHost("localhost")
+            .serverPort(1883)
+            .buildBlocking();
+        Mqtt5Connect connectRequest = Mqtt5Connect.builder()
+            .cleanStart(true)
+            .build();
+        Mqtt5ConnAck connectAck = client.connect(connectRequest);
+        assertEquals(Mqtt5ConnAckReasonCode.SUCCESS, connectAck.getReasonCode(), clientId + " connected");
+        return client;
+    }
+
+    @NotNull
     private Mqtt5BlockingClient createPublisherClient() {
         final Mqtt5BlockingClient client = MqttClient.builder()
             .useMqttVersion5()
@@ -378,7 +397,27 @@ public class SharedSubscriptionTest extends AbstractServerIntegrationTest {
     }
 
     @Test
-    public void givenASharedSubscriptionWhenLastSubscribedClientSessionTerminatesThenTheSharedSubscriptionCeasesToExist() {
-        fail("TODO implement");
+    public void givenASharedSubscriptionWhenLastSubscribedClientSessionTerminatesThenTheSharedSubscriptionCeasesToExist() throws Exception {
+        String fullSharedSubscriptionTopicFilter = "$share/collectors/metric/temperature/living";
+
+        // subscribe client to shared subscription
+        final Mqtt5BlockingClient subscriber = createCleanStartClient("subscriber1");
+        subscribe(subscriber, fullSharedSubscriptionTopicFilter, MqttQos.AT_LEAST_ONCE);
+
+        // verify subscribed to the shared receives a message
+        Mqtt5BlockingClient publisherClient = createPublisherClient();
+        verifyPublishedMessage(subscriber, v -> {
+            // push a message to the shared subscription
+            publish(publisherClient, "metric/temperature/living", MqttQos.AT_LEAST_ONCE);
+        }, MqttQos.AT_LEAST_ONCE, "18", "Shared message must be received", 2);
+
+        // disconnect the subscriber, so becuase it's clean, wipe all shared subscriptions
+        subscriber.disconnect();
+
+        // verify that a publish on shared topic doesn't have any side effect
+        verifyNoPublish(subscriber, v -> {
+            // push a message to the shared subscription
+            publish(publisherClient, "metric/temperature/living", MqttQos.AT_LEAST_ONCE);
+        }, Duration.ofSeconds(2), "Shared message must be received");
     }
 }


### PR DESCRIPTION


## Release notes
<!-- Add content to appear in  [Release Notes](https://www.elastic.co/guide/en/logstash/current/releasenotes.html), or add [rn:skip] to leave this PR out of release notes -->
Implemented the unsubscribe for shared subscriptions.

## What does this PR do?
Updates the `CTrie.removeSubscriptionsFor` to accept an UnsubscribeRequest instead of simple parameters, customizing the method to handle a shared subscription's unsubscribe request.
Adds a method `removeSharedSubscriptionsForClient` to remove in one step all the shared subscriptions of a session, in doing so it introduces a mapping cache clientId -> list of subscription to avoid a full tree traversal.


## Why is it important/What is the impact to the user?
Implements part of MQTT5 shared subscription feature

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [ x I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the Changelog if it's a feature or a fix that has to be reported


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #791
