### PR TITLE
Persistence for shared subscriptions

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -2,6 +2,7 @@ Version 0.18-SNAPSHOT:
    [feature] shared subscriptions:
      - Initial implementation of shared subscription subscribe and publish part. (#796)
      - Added unsubscribe of shared subscriptions. (#799)
+     - Implemented persistence for shared subscriptions to sustain broker restarts (#802)
    [fix] Implements requirements on reserved topics (starts with $). Implements the matching rules and avoid to proceed with processing on client's publishes on those topics (#793)
    [feature] Handle will delay interval and MQTT5's Will optional properties (#770)
    [fix] Handle empty collector batches in PostOffice (#777)

--- a/broker/src/main/java/io/moquette/broker/ISubscriptionsRepository.java
+++ b/broker/src/main/java/io/moquette/broker/ISubscriptionsRepository.java
@@ -15,8 +15,13 @@
  */
 package io.moquette.broker;
 
+import io.moquette.broker.subscriptions.ShareName;
+import io.moquette.broker.subscriptions.SharedSubscription;
 import io.moquette.broker.subscriptions.Subscription;
+import io.moquette.broker.subscriptions.Topic;
+import io.netty.handler.codec.mqtt.MqttQoS;
 
+import java.util.Collection;
 import java.util.Set;
 
 public interface ISubscriptionsRepository {
@@ -26,4 +31,24 @@ public interface ISubscriptionsRepository {
     void addNewSubscription(Subscription subscription);
 
     void removeSubscription(String topic, String clientID);
+
+    /**
+     * Remove all shared subscription from Storage for a client.
+     * */
+    void removeAllSharedSubscriptions(String clientId);
+
+    /**
+     * Remove shared subscription from Storage.
+     * */
+    void removeSharedSubscription(String clientId, ShareName share, Topic topicFilter);
+
+    /**
+     * Add shared subscription from Storage.
+     * */
+    void addNewSharedSubscription(String clientId, ShareName share, Topic topicFilter, MqttQoS requestedQoS);
+
+    /**
+     * List all shared subscriptions to re-add to the tree during a restart.
+     * */
+    Collection<SharedSubscription> listAllSharedSubscription();
 }

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -38,7 +37,7 @@ public class CTrieSubscriptionDirectory implements ISubscriptionsDirectory {
     private CTrie ctrie;
     private volatile ISubscriptionsRepository subscriptionsRepository;
 
-    private ConcurrentMap<String, List<SharedSubscription>> clientSharedSubscriptions = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, List<SharedSubscription>> clientSharedSubscriptions = new ConcurrentHashMap<>();
 
     @Override
     public void init(ISubscriptionsRepository subscriptionsRepository) {
@@ -66,23 +65,6 @@ public class CTrieSubscriptionDirectory implements ISubscriptionsDirectory {
         if (LOG.isTraceEnabled()) {
             LOG.trace("Stored subscriptions have been reloaded. SubscriptionTree = {}", dumpTree());
         }
-    }
-
-//    /**
-//     * @return the set of client ids that has a subscription stored.
-//     */
-//    @Override
-//    public Set<String> listAllSessionIds() {
-//        final Set<Subscription> subscriptions = subscriptionsRepository.listAllSubscriptions();
-//        final Set<String> clientIds = new HashSet<>(subscriptions.size());
-//        for (Subscription subscription : subscriptions) {
-//            clientIds.add(subscription.clientId);
-//        }
-//        return clientIds;
-//    }
-
-    Optional<CNode> lookup(Topic topic) {
-        return ctrie.lookup(topic);
     }
 
     /**

--- a/broker/src/main/java/io/moquette/broker/subscriptions/ISubscriptionsDirectory.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/ISubscriptionsDirectory.java
@@ -28,7 +28,7 @@ public interface ISubscriptionsDirectory {
 
     void init(ISubscriptionsRepository sessionsRepository);
 
-    Set<String> listAllSessionIds();
+//    Set<String> listAllSessionIds();
 
     List<Subscription> matchWithoutQosSharpening(Topic topic);
 

--- a/broker/src/main/java/io/moquette/broker/subscriptions/ISubscriptionsDirectory.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/ISubscriptionsDirectory.java
@@ -28,8 +28,6 @@ public interface ISubscriptionsDirectory {
 
     void init(ISubscriptionsRepository sessionsRepository);
 
-//    Set<String> listAllSessionIds();
-
     List<Subscription> matchWithoutQosSharpening(Topic topic);
 
     List<Subscription> matchQosSharpening(Topic topic);

--- a/broker/src/main/java/io/moquette/broker/subscriptions/SharedSubscription.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/SharedSubscription.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 /**
  * Shared subscription data class.
  * */
-class SharedSubscription implements Comparable<SharedSubscription> {
+public final class SharedSubscription implements Comparable<SharedSubscription> {
     private final ShareName shareName;
     private final Topic topicFilter;
     private final String clientId;

--- a/broker/src/main/java/io/moquette/persistence/Couple.java
+++ b/broker/src/main/java/io/moquette/persistence/Couple.java
@@ -1,0 +1,30 @@
+package io.moquette.persistence;
+
+import java.util.Objects;
+
+final class Couple<K, L> {
+    final K v1;
+    final L v2;
+
+    public Couple(K v1, L v2) {
+        this.v1 = v1;
+        this.v2 = v2;
+    }
+
+    public static <K, L> Couple<K, L> of(K v1, L v2) {
+        return new Couple<>(v1, v2);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Couple<?, ?> couple = (Couple<?, ?>) o;
+        return Objects.equals(v1, couple.v1) && Objects.equals(v2, couple.v2);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(v1, v2);
+    }
+}

--- a/broker/src/main/java/io/moquette/persistence/H2SubscriptionsRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/H2SubscriptionsRepository.java
@@ -1,25 +1,43 @@
 package io.moquette.persistence;
 
 import io.moquette.broker.ISubscriptionsRepository;
+import io.moquette.broker.subscriptions.ShareName;
+import io.moquette.broker.subscriptions.SharedSubscription;
 import io.moquette.broker.subscriptions.Subscription;
+import io.moquette.broker.subscriptions.Topic;
+import io.netty.handler.codec.mqtt.MqttQoS;
 import org.h2.mvstore.Cursor;
 import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
+import org.h2.mvstore.WriteBuffer;
+import org.h2.mvstore.type.BasicDataType;
+import org.h2.mvstore.type.StringDataType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.nio.ByteBuffer;
+import java.util.*;
 
 public class H2SubscriptionsRepository implements ISubscriptionsRepository {
 
     private static final Logger LOG = LoggerFactory.getLogger(H2SubscriptionsRepository.class);
     private static final String SUBSCRIPTIONS_MAP = "subscriptions";
+    private static final String SHARED_SUBSCRIPTIONS_MAP = "shared_subscriptions";
+    private final MVStore mvStore;
+    private final MVMap.Builder<Couple<ShareName, Topic>, Integer> submapBuilder;
 
     private MVMap<String, Subscription> subscriptions;
+    // clientId -> shared subscription map name
+    private MVMap<String, String> sharedSubscriptions;
 
     H2SubscriptionsRepository(MVStore mvStore) {
+        this.mvStore = mvStore;
+
+        submapBuilder = new MVMap.Builder<Couple<ShareName, Topic>, Integer>()
+            .keyType(new CoupleValueType());
+
         this.subscriptions = mvStore.openMap(SUBSCRIPTIONS_MAP);
+        sharedSubscriptions = mvStore.openMap(SHARED_SUBSCRIPTIONS_MAP);
     }
 
     @Override
@@ -44,5 +62,112 @@ public class H2SubscriptionsRepository implements ISubscriptionsRepository {
     @Override
     public void removeSubscription(String topicFilter, String clientID) {
         subscriptions.remove(topicFilter + "-" + clientID);
+    }
+
+    @Override
+    public void removeAllSharedSubscriptions(String clientId) {
+        final String sharedSubsMapName = sharedSubscriptions.get(clientId);
+        if (sharedSubsMapName == null) {
+            LOG.info("Removing all shared subscription of a non existing client: {}", clientId);
+            return;
+        }
+        wipeAllSharedSubscripptions(clientId, sharedSubsMapName);
+    }
+
+    private void wipeAllSharedSubscripptions(String clientId, String sharedSubsMapName) {
+        mvStore.removeMap(sharedSubsMapName);
+        sharedSubscriptions.remove(clientId);
+    }
+
+    @Override
+    public void removeSharedSubscription(String clientId, ShareName share, Topic topicFilter) {
+        final String sharedSubsMapName = sharedSubscriptions.get(clientId);
+        if (sharedSubsMapName == null) {
+            LOG.info("Removing a non existing shared subscription for client: {}", clientId);
+            return;
+        }
+        MVMap<Couple<ShareName, Topic>, Integer> subMap = mvStore.openMap(sharedSubsMapName, submapBuilder);
+        Couple<ShareName, Topic> sharedSubKey = Couple.of(share, topicFilter);
+
+        // remove from submap, null means the key didn't exist
+        if (subMap.remove(sharedSubKey) == null) {
+            LOG.info("Removing non existing shared subscription name: {} filter: {} for client: {}", share, topicFilter, clientId);
+            return;
+        }
+        // if the submap is empty, clean up all the things
+        if (subMap.isEmpty()) {
+            LOG.debug("Removing all references for share subscription clientId: {} share: {} filter: {}", clientId, share, topicFilter);
+            wipeAllSharedSubscripptions(clientId, sharedSubsMapName);
+        }
+    }
+
+    @Override
+    public void addNewSharedSubscription(String clientId, ShareName share, Topic topicFilter, MqttQoS requestedQoS) {
+        String sharedSubsMapName = sharedSubscriptions.computeIfAbsent(clientId,
+            H2SubscriptionsRepository::computeShareSubscriptionSubMap);
+
+        // maps the couple (share name, topic) to requested qos
+        MVMap<Couple<ShareName, Topic>, Integer> subMap = mvStore.openMap(sharedSubsMapName, submapBuilder);
+        subMap.put(Couple.of(share, topicFilter), requestedQoS.value());
+    }
+
+    @Override
+    public Collection<SharedSubscription> listAllSharedSubscription() {
+        List<SharedSubscription> result = new ArrayList<>();
+
+        for (Map.Entry<String, String> entry : sharedSubscriptions.entrySet()) {
+            String clientId = entry.getKey();
+            String sharedSubsMapName = entry.getValue();
+
+            MVMap<Couple<ShareName, Topic>, Integer> subMap = mvStore.openMap(sharedSubsMapName, submapBuilder);
+            for (Map.Entry<Couple<ShareName, Topic>, Integer> subEntry : subMap.entrySet()) {
+                final ShareName shareName = subEntry.getKey().v1;
+                final Topic topicFilter = subEntry.getKey().v2;
+                final MqttQoS qos = MqttQoS.valueOf(subEntry.getValue());
+                result.add(new SharedSubscription(shareName, topicFilter, clientId, qos));
+            }
+        }
+
+        return result;
+    }
+
+    private static String computeShareSubscriptionSubMap(String sessionId) {
+        return SHARED_SUBSCRIPTIONS_MAP + "_" + sessionId;
+    }
+
+    static final class CoupleValueType extends BasicDataType<Couple<ShareName, Topic>> {
+
+        private final Comparator<Couple<ShareName, Topic>> coupleComparator =
+            Comparator.<Couple<ShareName, Topic>, String>comparing(c -> c.v1.getShareName())
+            .thenComparing(c -> c.v2.toString());
+
+        @Override
+        public int compare(Couple<ShareName, Topic> var1, Couple<ShareName, Topic> var2) {
+            return coupleComparator.compare(var1, var2);
+        }
+
+        @Override
+        public int getMemory(Couple<ShareName, Topic> couple) {
+            return StringDataType.INSTANCE.getMemory(couple.v1.getShareName()) +
+                   StringDataType.INSTANCE.getMemory(couple.v2.toString());
+        }
+
+        @Override
+        public void write(WriteBuffer buff, Couple<ShareName, Topic> couple) {
+            StringDataType.INSTANCE.write(buff, couple.v1.getShareName());
+            StringDataType.INSTANCE.write(buff, couple.v2.toString());
+        }
+
+        @Override
+        public Couple<ShareName, Topic> read(ByteBuffer buffer) {
+            String shareName = StringDataType.INSTANCE.read(buffer);
+            String topicFilter = StringDataType.INSTANCE.read(buffer);
+            return new Couple<>(new ShareName(shareName), Topic.asTopic(topicFilter));
+        }
+
+        @Override
+        public Couple<ShareName, Topic>[] createStorage(int i) {
+            return new Couple[i];
+        }
     }
 }

--- a/broker/src/test/java/io/moquette/integration/mqtt5/AbstractServerIntegrationTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/AbstractServerIntegrationTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Properties;
 
 public abstract class AbstractServerIntegrationTest {
@@ -56,5 +57,11 @@ public abstract class AbstractServerIntegrationTest {
 
     protected void stopServer() {
         broker.stopServer();
+    }
+
+    void restartServerWithSuspension(Duration timeout) throws InterruptedException, IOException {
+        stopServer();
+        Thread.sleep(timeout.toMillis());
+        startServer(dbPath);
     }
 }

--- a/broker/src/test/java/io/moquette/integration/mqtt5/ConnectTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/ConnectTest.java
@@ -263,12 +263,6 @@ class ConnectTest extends AbstractServerIntegrationTest {
         verifyPublishedMessage(testamentSubscriber, 10, "Will message must be received after server restart");
     }
 
-    private void restartServerWithSuspension(Duration timeout) throws InterruptedException, IOException {
-        stopServer();
-        Thread.sleep(timeout.toMillis());
-        startServer(dbPath);
-    }
-
     private void scheduleDisconnectWithErrorCode(Mqtt5BlockingClient clientWithWill, Duration delay) {
         scheduleTasks.schedule(() -> {
             // disconnect in a way that the will is triggered

--- a/broker/src/test/java/io/moquette/persistence/H2BaseTest.java
+++ b/broker/src/test/java/io/moquette/persistence/H2BaseTest.java
@@ -1,0 +1,32 @@
+package io.moquette.persistence;
+
+import io.moquette.BrokerConstants;
+import org.h2.mvstore.MVStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+abstract class H2BaseTest {
+    MVStore mvStore;
+
+    @BeforeEach
+    public void setUp() {
+        this.mvStore = new MVStore.Builder()
+            .fileName(BrokerConstants.DEFAULT_PERSISTENT_PATH)
+            .autoCommitDisabled()
+            .open();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        this.mvStore.close();
+        File dbFile = new File(BrokerConstants.DEFAULT_PERSISTENT_PATH);
+        if (dbFile.exists()) {
+            dbFile.delete();
+        }
+        assertFalse(dbFile.exists());
+    }
+}

--- a/broker/src/test/java/io/moquette/persistence/H2PersistentQueueTest.java
+++ b/broker/src/test/java/io/moquette/persistence/H2PersistentQueueTest.java
@@ -32,27 +32,7 @@ import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class H2PersistentQueueTest {
-
-    private MVStore mvStore;
-
-    @BeforeEach
-    public void setUp() {
-        this.mvStore = new MVStore.Builder()
-            .fileName(BrokerConstants.DEFAULT_PERSISTENT_PATH)
-            .autoCommitDisabled()
-            .open();
-    }
-
-    @AfterEach
-    public void tearDown() {
-        this.mvStore.close();
-        File dbFile = new File(BrokerConstants.DEFAULT_PERSISTENT_PATH);
-        if (dbFile.exists()) {
-            dbFile.delete();
-        }
-        assertFalse(dbFile.exists());
-    }
+public class H2PersistentQueueTest extends H2BaseTest {
 
     @Test
     public void testAdd() {

--- a/broker/src/test/java/io/moquette/persistence/H2SubscriptionsRepositorySharedSubscriptionsTest.java
+++ b/broker/src/test/java/io/moquette/persistence/H2SubscriptionsRepositorySharedSubscriptionsTest.java
@@ -1,0 +1,69 @@
+package io.moquette.persistence;
+
+import io.moquette.broker.subscriptions.ShareName;
+import io.moquette.broker.subscriptions.SharedSubscription;
+import io.moquette.broker.subscriptions.Topic;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class H2SubscriptionsRepositorySharedSubscriptionsTest extends H2BaseTest {
+
+    private H2SubscriptionsRepository sut;
+
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+        sut = new H2SubscriptionsRepository(mvStore);
+    }
+
+    @Test
+    public void givenAPersistedSharedSubscriptionWhenListedThenItAppears() {
+        sut.addNewSharedSubscription("subscriber", new ShareName("thermometers"),
+            Topic.asTopic("/first_floor/living/temp"), MqttQoS.AT_MOST_ONCE);
+
+        Collection<SharedSubscription> subscriptions = sut.listAllSharedSubscription();
+        assertThat(subscriptions).hasSize(1);
+        SharedSubscription subscription = subscriptions.iterator().next();
+        Assertions.assertAll("First subscription match the previously stored",
+            () -> Assertions.assertEquals("subscriber", subscription.clientId()),
+            () -> Assertions.assertEquals("thermometers", subscription.getShareName().getShareName()));
+    }
+
+    @Test
+    public void givenAPersistedSubscriptionWhenItsDeletedThenItNotAnymoreListed() {
+        sut.addNewSharedSubscription("subscriber", new ShareName("thermometers"),
+            Topic.asTopic("/first_floor/living/temp"), MqttQoS.AT_MOST_ONCE);
+        assertThat(sut.listAllSharedSubscription()).hasSize(1);
+
+        // remove the shared subscription
+        sut.removeSharedSubscription("subscriber", new ShareName("thermometers"),
+            Topic.asTopic("/first_floor/living/temp"));
+
+        // verify it's not listed
+        assertThat(sut.listAllSharedSubscription()).isEmpty();
+    }
+
+    @Test
+    public void givenMultipleSharedSubscriptionForSameClientIdWhenTheyAreRemovedInBlockThenArentAnymoreListed() {
+        String clientId = "subscriber";
+        sut.addNewSharedSubscription(clientId, new ShareName("thermometers"),
+            Topic.asTopic("/first_floor/living/temp"), MqttQoS.AT_MOST_ONCE);
+        sut.addNewSharedSubscription(clientId, new ShareName("anemometers"),
+            Topic.asTopic("/garden/wind/speed"), MqttQoS.AT_MOST_ONCE);
+        sut.addNewSharedSubscription(clientId, new ShareName("anemometers"),
+            Topic.asTopic("/garden/wind/direction"), MqttQoS.AT_MOST_ONCE);
+        assertThat(sut.listAllSharedSubscription()).hasSize(3);
+
+        // remove all shared subscriptions for client
+        sut.removeAllSharedSubscriptions(clientId);
+
+        // verify no shared subscriptions is listed
+        assertThat(sut.listAllSharedSubscription()).isEmpty();
+    }
+}


### PR DESCRIPTION
## Release notes

Implemented persistence for shared subscriptions to sustain broker restarts

## What does this PR do?

Defines and implements a series of methods () in Subscription Persistence so that shared subscription can be:
- added singularly on subscribe
- removed on unsubscribe
- listed when broker restarts and has to recreate all the shared subscription in the Subscriptions directory structure
- remove all the shared subscriptions for a client when its session terminates

## Why is it important/What is the impact to the user?

Permit to shared subscriptions to survive broker restart

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the Changelog if it's a feature or a fix that has to be reported

## Related issues

- Relates #791

