### PR TITLE
Store subscription indentifier into subscriptions trie

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,6 +1,7 @@
 Version 0.18-SNAPSHOT:
    [feature] subscription identifiers: (issue #801)
      - Implements the validation of subscription identifier properties in SUBSCRIBE. (#803)
+     - Store and retrieve the subscription identifier into the subscriptions directory. (#804)
    [feature] shared subscriptions:
      - Initial implementation of shared subscription subscribe and publish part. (#796)
      - Added unsubscribe of shared subscriptions. (#799)

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
@@ -144,7 +144,6 @@ class CNode implements Comparable<CNode> {
             if (idx >= 0) {
                 // Subscription already exists
                 final Subscription existing = subscriptions.get(idx);
-                // TODO has to update also if subscription identifier changes!
                 if (needsToUpdateExistingSubscription(newSubscription, existing)) {
                     subscriptions.set(idx, newSubscription);
                 }
@@ -160,9 +159,8 @@ class CNode implements Comparable<CNode> {
         if ((newSubscription.hasSubscriptionIdentifier() && existing.hasSubscriptionIdentifier()) &&
             newSubscription.getSubscriptionIdentifier().equals(existing.getSubscriptionIdentifier())
         ) {
-            // if subscription identifier hasn't changed, then check QoS
-//            return false;
-            // don't lower the requested QoS level
+            // if subscription identifier hasn't changed,
+            // then check QoS but don't lower the requested QoS level
             return existing.getRequestedQos().value() < newSubscription.getRequestedQos().value();
         }
 

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
@@ -144,15 +144,33 @@ class CNode implements Comparable<CNode> {
             if (idx >= 0) {
                 // Subscription already exists
                 final Subscription existing = subscriptions.get(idx);
-                if (existing.getRequestedQos().value() < newSubscription.getRequestedQos().value()) {
+                // TODO has to update also if subscription identifier changes!
+                if (needsToUpdateExistingSubscription(newSubscription, existing)) {
                     subscriptions.set(idx, newSubscription);
                 }
             } else {
                 // insert into the expected index so that the sorting is maintained
-                this.subscriptions.add(-1 - idx, new Subscription(newSubscription));
+                this.subscriptions.add(-1 - idx, newSubscription);
             }
         }
         return this;
+    }
+
+    private static boolean needsToUpdateExistingSubscription(Subscription newSubscription, Subscription existing) {
+        if ((newSubscription.hasSubscriptionIdentifier() && existing.hasSubscriptionIdentifier()) &&
+            newSubscription.getSubscriptionIdentifier().equals(existing.getSubscriptionIdentifier())
+        ) {
+            // if subscription identifier hasn't changed, then check QoS
+//            return false;
+            // don't lower the requested QoS level
+            return existing.getRequestedQos().value() < newSubscription.getRequestedQos().value();
+        }
+
+        // subscription identifier changed
+        // TODO need to understand if requestedQoS has to be also replaced or not, if not
+        // the existing QoS has to be copied. This to avoid that a subscription identifier
+        // change silently break the rule of existing qos never lowered.
+        return true;
     }
 
     /**

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
@@ -112,7 +112,7 @@ class CNode implements Comparable<CNode> {
             // select a subscription randomly
             int randIdx = SECURE_RANDOM.nextInt(list.size());
             SharedSubscription sub = list.get(randIdx);
-            selectedSubscriptions.add(new Subscription(sub.clientId(), sub.topicFilter(), sub.requestedQoS(), shareName));
+            selectedSubscriptions.add(sub.createSubscription());
         }
         return selectedSubscriptions;
     }

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
@@ -2,10 +2,9 @@ package io.moquette.broker.subscriptions;
 
 import io.netty.handler.codec.mqtt.MqttQoS;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 public class CTrie {
 
@@ -20,11 +19,20 @@ public class CTrie {
 
         private boolean shared = false;
         private ShareName shareName;
+        private Optional<SubscriptionIdentifier> subscriptionIdOpt;
+
+        private SubscriptionRequest(String clientId, Topic topicFilter, MqttQoS requestedQoS, SubscriptionIdentifier subscriptionId) {
+            this.topicFilter = topicFilter;
+            this.clientId = clientId;
+            this.requestedQoS = requestedQoS;
+            this.subscriptionIdOpt = Optional.of(subscriptionId);
+        }
 
         private SubscriptionRequest(String clientId, Topic topicFilter, MqttQoS requestedQoS) {
             this.topicFilter = topicFilter;
             this.clientId = clientId;
             this.requestedQoS = requestedQoS;
+            this.subscriptionIdOpt = Optional.empty();
         }
 
         public static SubscriptionRequest buildNonShared(Subscription subscription) {
@@ -35,12 +43,29 @@ public class CTrie {
             return new SubscriptionRequest(clientId, topicFilter, requestedQoS);
         }
 
+        public static SubscriptionRequest buildNonShared(String clientId, Topic topicFilter, MqttQoS requestedQoS,
+                                                         SubscriptionIdentifier subscriptionId) {
+            Objects.requireNonNull(subscriptionId, "SubscriptionId param can't be null");
+            return new SubscriptionRequest(clientId, topicFilter, requestedQoS, subscriptionId);
+        }
+
+        public static SubscriptionRequest buildShared(ShareName shareName, Topic topicFilter, String clientId,
+                                                      MqttQoS requestedQoS, SubscriptionIdentifier subscriptionId) {
+            Objects.requireNonNull(subscriptionId, "SubscriptionId param can't be null");
+            return buildSharedHelper(shareName, topicFilter,
+                () -> new SubscriptionRequest(clientId, topicFilter, requestedQoS, subscriptionId));
+        }
+
         public static SubscriptionRequest buildShared(ShareName shareName, Topic topicFilter, String clientId, MqttQoS requestedQoS) {
+            return buildSharedHelper(shareName, topicFilter,
+                () -> new SubscriptionRequest(clientId, topicFilter, requestedQoS));
+        }
+
+        private static SubscriptionRequest buildSharedHelper(ShareName shareName, Topic topicFilter, Supplier<SubscriptionRequest> instantiator) {
             if (topicFilter.headToken().name().startsWith("$share")) {
                 throw new IllegalArgumentException("Topic filter of a shared subscription can't contains $share and share name");
             }
-
-            SubscriptionRequest request = new SubscriptionRequest(clientId, topicFilter, requestedQoS);
+            SubscriptionRequest request = instantiator.get();
             request.shared = true;
             request.shareName = shareName;
             return request;
@@ -50,12 +75,20 @@ public class CTrie {
             return topicFilter;
         }
 
+        public MqttQoS getRequestedQoS() {
+            return requestedQoS;
+        }
+
         public Subscription subscription() {
-            return new Subscription(clientId, topicFilter, requestedQoS);
+            return subscriptionIdOpt
+                .map(subscriptionIdentifier -> new Subscription(clientId, topicFilter, requestedQoS, subscriptionIdentifier))
+                .orElseGet(() -> new Subscription(clientId, topicFilter, requestedQoS));
         }
 
         public SharedSubscription sharedSubscription() {
-            return new SharedSubscription(shareName, topicFilter, clientId, requestedQoS);
+            return subscriptionIdOpt
+                .map(subId -> new SharedSubscription(shareName, topicFilter, clientId, requestedQoS, subId))
+                .orElseGet(() -> new SharedSubscription(shareName, topicFilter, clientId, requestedQoS));
         }
 
         public boolean isShared() {

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
@@ -2,8 +2,11 @@ package io.moquette.broker.subscriptions;
 
 import io.netty.handler.codec.mqtt.MqttQoS;
 
-import java.util.*;
-import java.util.function.Function;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 public class CTrie {

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
@@ -103,31 +103,41 @@ public class CTrieSubscriptionDirectory implements ISubscriptionsDirectory {
     @Override
     public void add(String clientId, Topic filter, MqttQoS requestedQoS) {
         SubscriptionRequest subRequest = SubscriptionRequest.buildNonShared(clientId, filter, requestedQoS);
+        addNonSharedSubscriptionRequest(subRequest);
+    }
+
+    @Override
+    public void add(String clientId, Topic filter, MqttQoS requestedQoS, SubscriptionIdentifier subscriptionId) {
+        SubscriptionRequest subRequest = SubscriptionRequest.buildNonShared(clientId, filter, requestedQoS, subscriptionId);
+        addNonSharedSubscriptionRequest(subRequest);
+    }
+
+    private void addNonSharedSubscriptionRequest(SubscriptionRequest subRequest) {
         ctrie.addToTree(subRequest);
         subscriptionsRepository.addNewSubscription(subRequest.subscription());
     }
 
     @Override
-    public void add(String clientId, Topic filter, MqttQoS requestedQoS, SubscriptionIdentifier subscriptionId) {
-        // TODO implement, save the subscription Id into the ctrie
-        throw new IllegalStateException("Implement this");
-    }
-
-    @Override
     public void addShared(String clientId, ShareName name, Topic topicFilter, MqttQoS requestedQoS) {
         SubscriptionRequest shareSubRequest = SubscriptionRequest.buildShared(name, topicFilter, clientId, requestedQoS);
+        addSharedSubscriptionRequest(shareSubRequest);
+    }
+
+    private void addSharedSubscriptionRequest(SubscriptionRequest shareSubRequest) {
         ctrie.addToTree(shareSubRequest);
 
-        subscriptionsRepository.addNewSharedSubscription(clientId, name, topicFilter, requestedQoS);
+        subscriptionsRepository.addNewSharedSubscription(shareSubRequest.getClientId(), shareSubRequest.getSharedName(),
+            shareSubRequest.getTopicFilter(), shareSubRequest.getRequestedQoS());
 
-        List<SharedSubscription> sharedSubscriptions = clientSharedSubscriptions.computeIfAbsent(clientId, unused -> new ArrayList<>());
+        List<SharedSubscription> sharedSubscriptions = clientSharedSubscriptions.computeIfAbsent(shareSubRequest.getClientId(), unused -> new ArrayList<>());
         sharedSubscriptions.add(shareSubRequest.sharedSubscription());
     }
 
     @Override
-    public void addShared(String clientId, ShareName name, Topic topicFilter, MqttQoS requestedQoS, SubscriptionIdentifier subscriptionId) {
-        // TODO implement, save the subscription Id into the ctrie
-        throw new IllegalStateException("Implement this");
+    public void addShared(String clientId, ShareName name, Topic topicFilter, MqttQoS requestedQoS,
+                          SubscriptionIdentifier subscriptionId) {
+        SubscriptionRequest shareSubRequest = SubscriptionRequest.buildShared(name, topicFilter, clientId, requestedQoS, subscriptionId);
+        addSharedSubscriptionRequest(shareSubRequest);
     }
 
     /**

--- a/broker/src/main/java/io/moquette/broker/subscriptions/SharedSubscription.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/SharedSubscription.java
@@ -18,6 +18,7 @@ package io.moquette.broker.subscriptions;
 import io.netty.handler.codec.mqtt.MqttQoS;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Shared subscription data class.
@@ -27,6 +28,7 @@ public final class SharedSubscription implements Comparable<SharedSubscription> 
     private final Topic topicFilter;
     private final String clientId;
     private final MqttQoS requestedQoS;
+    private final Optional<SubscriptionIdentifier> subscriptionId;
 
     public SharedSubscription(ShareName shareName, Topic topicFilter, String clientId, MqttQoS requestedQoS) {
         Objects.requireNonNull(requestedQoS, "qos parameter can't be null");
@@ -34,6 +36,17 @@ public final class SharedSubscription implements Comparable<SharedSubscription> 
         this.topicFilter = topicFilter;
         this.clientId = clientId;
         this.requestedQoS = requestedQoS;
+        this.subscriptionId = Optional.empty();
+    }
+
+    public SharedSubscription(ShareName shareName, Topic topicFilter, String clientId, MqttQoS requestedQoS
+        , SubscriptionIdentifier subscriptionId) {
+        Objects.requireNonNull(requestedQoS, "qos parameter can't be null");
+        this.shareName = shareName;
+        this.topicFilter = topicFilter;
+        this.clientId = clientId;
+        this.requestedQoS = requestedQoS;
+        this.subscriptionId = Optional.of(subscriptionId);
     }
 
     public String clientId() {

--- a/broker/src/main/java/io/moquette/broker/subscriptions/SharedSubscription.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/SharedSubscription.java
@@ -65,6 +65,18 @@ public final class SharedSubscription implements Comparable<SharedSubscription> 
         return shareName;
     }
 
+    /**
+     * Create a new Subscription instance from the data present in SharedSubscription
+     * */
+    Subscription createSubscription() {
+        if (subscriptionId.isPresent()) {
+            return new Subscription(clientId, topicFilter, requestedQoS, shareName.getShareName(), subscriptionId.get());
+        } else {
+            return new Subscription(clientId, topicFilter, requestedQoS, shareName.getShareName());
+        }
+    }
+
+
     @Override
     public int compareTo(SharedSubscription o) {
         return this.clientId.compareTo(o.clientId);

--- a/broker/src/main/java/io/moquette/broker/subscriptions/Subscription.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/Subscription.java
@@ -20,6 +20,7 @@ import io.netty.handler.codec.mqtt.MqttQoS;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Maintain the information about which Topic a certain ClientID is subscribed and at which QoS
@@ -32,15 +33,28 @@ public final class Subscription implements Serializable, Comparable<Subscription
     final Topic topicFilter;
     final String shareName;
 
+    // TODO remove transient when the subscription identifier has to be persisted
+    private transient final Optional<SubscriptionIdentifier> subscriptionId;
+
     public Subscription(String clientId, Topic topicFilter, MqttQoS requestedQos) {
-        this(clientId, topicFilter, requestedQos, "");
+        this(clientId, topicFilter, requestedQos, "", null);
+    }
+
+    public Subscription(String clientId, Topic topicFilter, MqttQoS requestedQos, SubscriptionIdentifier subscriptionId) {
+        this(clientId, topicFilter, requestedQos, "", subscriptionId);
     }
 
     public Subscription(String clientId, Topic topicFilter, MqttQoS requestedQos, String shareName) {
+        this(clientId, topicFilter, requestedQos, shareName, null);
+    }
+
+    public Subscription(String clientId, Topic topicFilter, MqttQoS requestedQos, String shareName,
+                        SubscriptionIdentifier subscriptionId) {
         this.requestedQos = requestedQos;
         this.clientId = clientId;
         this.topicFilter = topicFilter;
         this.shareName = shareName;
+        this.subscriptionId = Optional.ofNullable(subscriptionId);
     }
 
     public Subscription(Subscription orig) {
@@ -48,6 +62,7 @@ public final class Subscription implements Serializable, Comparable<Subscription
         this.clientId = orig.clientId;
         this.topicFilter = orig.topicFilter;
         this.shareName = orig.shareName;
+        this.subscriptionId = orig.subscriptionId;
     }
 
     public String getClientId() {
@@ -64,6 +79,14 @@ public final class Subscription implements Serializable, Comparable<Subscription
 
     public boolean qosLessThan(Subscription sub) {
         return requestedQos.value() < sub.requestedQos.value();
+    }
+
+    public boolean hasSubscriptionIdentifier() {
+        return subscriptionId.isPresent();
+    }
+
+    public SubscriptionIdentifier getSubscriptionIdentifier() {
+        return subscriptionId.get();
     }
 
     @Override

--- a/broker/src/main/java/io/moquette/broker/subscriptions/SubscriptionIdentifier.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/SubscriptionIdentifier.java
@@ -1,5 +1,7 @@
 package io.moquette.broker.subscriptions;
 
+import java.util.Objects;
+
 /**
  * Models the subscription identifier for MQTT5 Subscription.
  * */
@@ -17,5 +19,21 @@ public final class SubscriptionIdentifier {
         return subscriptionId;
     }
 
+    @Override
+    public String toString() {
+        return "SubscriptionIdentifier: " + subscriptionId;
+    }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SubscriptionIdentifier that = (SubscriptionIdentifier) o;
+        return subscriptionId == that.subscriptionId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(subscriptionId);
+    }
 }


### PR DESCRIPTION
## Release notes
Store and retrieve the subscription identifier into the subscriptions directory.


## What does this PR do?
Spread the `SubscriptionIdentifier` of a subscription request down to the SubscriptionDirectory.
Updated the `CNode` 's `addSubscription`to update subscriptions stored also if the subscription identifier changes (by value, removing or adding int).

## Why is it important/What is the impact to the user?

It's a step in the implementation of subscription id functionality

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the Changelog if it's a feature or a fix that has to be reported

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #801 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->
