### PR TITLE
Implements serialization and deserialization for Subscription in H2

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -2,6 +2,7 @@ Version 0.18-SNAPSHOT:
    [feature] subscription identifiers: (issue #801)
      - Implements the validation of subscription identifier properties in SUBSCRIBE. (#803)
      - Store and retrieve the subscription identifier into the subscriptions directory. (#804)
+     - Update H2 storage to persist and reload subscription identifiers for shared and non-shared subscriptions. (#805)
    [feature] shared subscriptions:
      - Initial implementation of shared subscription subscribe and publish part. (#796)
      - Added unsubscribe of shared subscriptions. (#799)

--- a/broker/src/main/java/io/moquette/broker/ISubscriptionsRepository.java
+++ b/broker/src/main/java/io/moquette/broker/ISubscriptionsRepository.java
@@ -15,10 +15,7 @@
  */
 package io.moquette.broker;
 
-import io.moquette.broker.subscriptions.ShareName;
-import io.moquette.broker.subscriptions.SharedSubscription;
-import io.moquette.broker.subscriptions.Subscription;
-import io.moquette.broker.subscriptions.Topic;
+import io.moquette.broker.subscriptions.*;
 import io.netty.handler.codec.mqtt.MqttQoS;
 
 import java.util.Collection;
@@ -43,9 +40,15 @@ public interface ISubscriptionsRepository {
     void removeSharedSubscription(String clientId, ShareName share, Topic topicFilter);
 
     /**
-     * Add shared subscription from Storage.
+     * Add shared subscription to storage.
      * */
     void addNewSharedSubscription(String clientId, ShareName share, Topic topicFilter, MqttQoS requestedQoS);
+
+    /**
+     * Add shared subscription with subscription identifier to storage.
+     * */
+    void addNewSharedSubscription(String clientId, ShareName share, Topic topicFilter, MqttQoS requestedQoS,
+                                  SubscriptionIdentifier subscriptionIdentifier);
 
     /**
      * List all shared subscriptions to re-add to the tree during a restart.

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
@@ -106,6 +106,13 @@ public class CTrie {
             return clientId;
         }
 
+        public boolean hasSubscriptionIdentifier() {
+            return subscriptionIdOpt.isPresent();
+        }
+
+        public SubscriptionIdentifier getSubscriptionIdentifier() {
+            return subscriptionIdOpt.get();
+        }
     }
 
     /**

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
@@ -126,9 +126,13 @@ public class CTrieSubscriptionDirectory implements ISubscriptionsDirectory {
     private void addSharedSubscriptionRequest(SubscriptionRequest shareSubRequest) {
         ctrie.addToTree(shareSubRequest);
 
-        subscriptionsRepository.addNewSharedSubscription(shareSubRequest.getClientId(), shareSubRequest.getSharedName(),
-            shareSubRequest.getTopicFilter(), shareSubRequest.getRequestedQoS());
-
+        if (shareSubRequest.hasSubscriptionIdentifier()) {
+            subscriptionsRepository.addNewSharedSubscription(shareSubRequest.getClientId(), shareSubRequest.getSharedName(),
+                shareSubRequest.getTopicFilter(), shareSubRequest.getRequestedQoS(), shareSubRequest.getSubscriptionIdentifier());
+        } else {
+            subscriptionsRepository.addNewSharedSubscription(shareSubRequest.getClientId(), shareSubRequest.getSharedName(),
+                shareSubRequest.getTopicFilter(), shareSubRequest.getRequestedQoS());
+        }
         List<SharedSubscription> sharedSubscriptions = clientSharedSubscriptions.computeIfAbsent(shareSubRequest.getClientId(), unused -> new ArrayList<>());
         sharedSubscriptions.add(shareSubRequest.sharedSubscription());
     }

--- a/broker/src/main/java/io/moquette/broker/subscriptions/SharedSubscription.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/SharedSubscription.java
@@ -39,8 +39,8 @@ public final class SharedSubscription implements Comparable<SharedSubscription> 
         this.subscriptionId = Optional.empty();
     }
 
-    public SharedSubscription(ShareName shareName, Topic topicFilter, String clientId, MqttQoS requestedQoS
-        , SubscriptionIdentifier subscriptionId) {
+    public SharedSubscription(ShareName shareName, Topic topicFilter, String clientId, MqttQoS requestedQoS,
+                              SubscriptionIdentifier subscriptionId) {
         Objects.requireNonNull(requestedQoS, "qos parameter can't be null");
         this.shareName = shareName;
         this.topicFilter = topicFilter;
@@ -76,6 +76,13 @@ public final class SharedSubscription implements Comparable<SharedSubscription> 
         }
     }
 
+    public boolean hasSubscriptionIdentifier() {
+        return subscriptionId.isPresent();
+    }
+
+    public SubscriptionIdentifier getSubscriptionIdentifier() {
+        return subscriptionId.get();
+    }
 
     @Override
     public int compareTo(SharedSubscription o) {

--- a/broker/src/main/java/io/moquette/broker/subscriptions/Subscription.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/Subscription.java
@@ -33,8 +33,7 @@ public final class Subscription implements Serializable, Comparable<Subscription
     final Topic topicFilter;
     final String shareName;
 
-    // TODO remove transient when the subscription identifier has to be persisted
-    private transient final Optional<SubscriptionIdentifier> subscriptionId;
+    private final Optional<SubscriptionIdentifier> subscriptionId;
 
     public Subscription(String clientId, Topic topicFilter, MqttQoS requestedQos) {
         this(clientId, topicFilter, requestedQos, "", null);
@@ -134,5 +133,13 @@ public final class Subscription implements Serializable, Comparable<Subscription
 
     public String clientAndShareName() {
         return clientId + (shareName.isEmpty() ? "" : "-" + shareName);
+    }
+
+    public boolean hasShareName() {
+        return shareName != null;
+    }
+
+    public String getShareName() {
+        return shareName;
     }
 }

--- a/broker/src/main/java/io/moquette/persistence/MemorySubscriptionsRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/MemorySubscriptionsRepository.java
@@ -19,19 +19,26 @@ import io.moquette.broker.ISubscriptionsRepository;
 import io.moquette.broker.subscriptions.ShareName;
 import io.moquette.broker.subscriptions.SharedSubscription;
 import io.moquette.broker.subscriptions.Subscription;
+import io.moquette.broker.subscriptions.SubscriptionIdentifier;
 import io.moquette.broker.subscriptions.Topic;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
 
 public class MemorySubscriptionsRepository implements ISubscriptionsRepository {
 
     private static final Logger LOG = LoggerFactory.getLogger(MemorySubscriptionsRepository.class);
     private final Set<Subscription> subscriptions = new ConcurrentSkipListSet<>();
-    private final Map<String, Map<Couple<ShareName, Topic>, MqttQoS>> sharedSubscriptions = new HashMap<>();
+    private final Map<String, Map<Couple<ShareName, Topic>, SharedSubscription>> sharedSubscriptions = new HashMap<>();
 
     @Override
     public Set<Subscription> listAllSubscriptions() {
@@ -58,7 +65,7 @@ public class MemorySubscriptionsRepository implements ISubscriptionsRepository {
 
     @Override
     public void removeSharedSubscription(String clientId, ShareName share, Topic topicFilter) {
-        Map<Couple<ShareName, Topic>, MqttQoS> subsMap = sharedSubscriptions.get(clientId);
+        Map<Couple<ShareName, Topic>, SharedSubscription> subsMap = sharedSubscriptions.get(clientId);
         if (subsMap == null) {
             LOG.info("Removing a non existing shared subscription for client: {}", clientId);
             return;
@@ -72,20 +79,28 @@ public class MemorySubscriptionsRepository implements ISubscriptionsRepository {
 
     @Override
     public void addNewSharedSubscription(String clientId, ShareName share, Topic topicFilter, MqttQoS requestedQoS) {
-        Map<Couple<ShareName, Topic>, MqttQoS> subsMap = sharedSubscriptions.computeIfAbsent(clientId, unused -> new HashMap<>());
-        subsMap.put(Couple.of(share, topicFilter), requestedQoS);
+        SharedSubscription sharedSub = new SharedSubscription(share, topicFilter, clientId, requestedQoS);
+        storeNewSharedSubscription(clientId, share, topicFilter, sharedSub);
+    }
+
+    private void storeNewSharedSubscription(String clientId, ShareName share, Topic topicFilter, SharedSubscription sharedSub) {
+        Map<Couple<ShareName, Topic>, SharedSubscription> subsMap = sharedSubscriptions.computeIfAbsent(clientId, unused -> new HashMap<>());
+        subsMap.put(Couple.of(share, topicFilter), sharedSub);
+    }
+
+    @Override
+    public void addNewSharedSubscription(String clientId, ShareName share, Topic topicFilter, MqttQoS requestedQoS,
+                                         SubscriptionIdentifier subscriptionIdentifier) {
+        SharedSubscription sharedSub = new SharedSubscription(share, topicFilter, clientId, requestedQoS, subscriptionIdentifier);
+        storeNewSharedSubscription(clientId, share, topicFilter, sharedSub);
     }
 
     @Override
     public Collection<SharedSubscription> listAllSharedSubscription() {
         final List<SharedSubscription> result = new ArrayList<>();
-        for (Map.Entry<String, Map<Couple<ShareName, Topic>, MqttQoS>> entry : sharedSubscriptions.entrySet()) {
-            final String clientId = entry.getKey();
-            for (Map.Entry<Couple<ShareName, Topic>, MqttQoS> nestedEntry : entry.getValue().entrySet()) {
-                final ShareName share = nestedEntry.getKey().v1;
-                final Topic filter = nestedEntry.getKey().v2;
-                final MqttQoS qos = nestedEntry.getValue();
-                result.add(new SharedSubscription(share, filter, clientId, qos));
+        for (Map.Entry<String, Map<Couple<ShareName, Topic>, SharedSubscription>> entry : sharedSubscriptions.entrySet()) {
+            for (Map.Entry<Couple<ShareName, Topic>, SharedSubscription> nestedEntry : entry.getValue().entrySet()) {
+                result.add(nestedEntry.getValue());
             }
         }
         return result;

--- a/broker/src/test/java/io/moquette/persistence/H2SubscriptionsRepositorySharedSubscriptionsTest.java
+++ b/broker/src/test/java/io/moquette/persistence/H2SubscriptionsRepositorySharedSubscriptionsTest.java
@@ -1,6 +1,10 @@
 package io.moquette.persistence;
 
-import io.moquette.broker.subscriptions.*;
+import io.moquette.broker.subscriptions.ShareName;
+import io.moquette.broker.subscriptions.SharedSubscription;
+import io.moquette.broker.subscriptions.Subscription;
+import io.moquette.broker.subscriptions.SubscriptionIdentifier;
+import io.moquette.broker.subscriptions.Topic;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,6 +15,7 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class H2SubscriptionsRepositorySharedSubscriptionsTest extends H2BaseTest {
 
@@ -30,8 +35,21 @@ class H2SubscriptionsRepositorySharedSubscriptionsTest extends H2BaseTest {
 
         // verify deserialize
         Set<Subscription> subs = sut.listAllSubscriptions();
-        assertEquals(1, subs.size());
+        assertThat(subs).hasSize(1);
         Subscription reloadedSub = subs.iterator().next();
+        assertEquals(1, reloadedSub.getSubscriptionIdentifier().value());
+    }
+
+    @Test
+    public void givenNewSharedSubscriptionWhenItsStoredThenCanGetRetrieved() {
+        sut.addNewSharedSubscription("subscriber", new ShareName("thermometers"),
+            Topic.asTopic("/first_floor/living/temp"), MqttQoS.AT_MOST_ONCE, new SubscriptionIdentifier(1));
+
+        // verify deserialize
+        Collection<SharedSubscription> subs = sut.listAllSharedSubscription();
+        assertThat(subs).hasSize(1);
+        SharedSubscription reloadedSub = subs.iterator().next();
+        assertTrue(reloadedSub.hasSubscriptionIdentifier());
         assertEquals(1, reloadedSub.getSubscriptionIdentifier().value());
     }
 

--- a/broker/src/test/java/io/moquette/persistence/H2SubscriptionsRepositorySharedSubscriptionsTest.java
+++ b/broker/src/test/java/io/moquette/persistence/H2SubscriptionsRepositorySharedSubscriptionsTest.java
@@ -1,16 +1,16 @@
 package io.moquette.persistence;
 
-import io.moquette.broker.subscriptions.ShareName;
-import io.moquette.broker.subscriptions.SharedSubscription;
-import io.moquette.broker.subscriptions.Topic;
+import io.moquette.broker.subscriptions.*;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class H2SubscriptionsRepositorySharedSubscriptionsTest extends H2BaseTest {
 
@@ -23,6 +23,19 @@ class H2SubscriptionsRepositorySharedSubscriptionsTest extends H2BaseTest {
     }
 
     @Test
+    public void givenNewSubscriptionWhenItsStoredThenCanGetRetrieved() {
+        Subscription subscription = new Subscription("subscriber", Topic.asTopic("metering/temperature"),
+            MqttQoS.AT_MOST_ONCE, new SubscriptionIdentifier(1));
+        sut.addNewSubscription(subscription);
+
+        // verify deserialize
+        Set<Subscription> subs = sut.listAllSubscriptions();
+        assertEquals(1, subs.size());
+        Subscription reloadedSub = subs.iterator().next();
+        assertEquals(1, reloadedSub.getSubscriptionIdentifier().value());
+    }
+
+    @Test
     public void givenAPersistedSharedSubscriptionWhenListedThenItAppears() {
         sut.addNewSharedSubscription("subscriber", new ShareName("thermometers"),
             Topic.asTopic("/first_floor/living/temp"), MqttQoS.AT_MOST_ONCE);
@@ -31,8 +44,8 @@ class H2SubscriptionsRepositorySharedSubscriptionsTest extends H2BaseTest {
         assertThat(subscriptions).hasSize(1);
         SharedSubscription subscription = subscriptions.iterator().next();
         Assertions.assertAll("First subscription match the previously stored",
-            () -> Assertions.assertEquals("subscriber", subscription.clientId()),
-            () -> Assertions.assertEquals("thermometers", subscription.getShareName().getShareName()));
+            () -> assertEquals("subscriber", subscription.clientId()),
+            () -> assertEquals("thermometers", subscription.getShareName().getShareName()));
     }
 
     @Test


### PR DESCRIPTION
## Release notes
Update H2 storage to persist and reload subscription identifiers for shared and non-shared subscriptions.

## What does this PR do?

Adds subscription identifier to SubscriptionRequest, SharedSubscription classes. 
Updates H2SubscriptionsRepository to persists and reload subscription identifier for shared and non-shared subscriptions.
Updates CTrieSubscriptionDirectory to store subscription identifier contained in SharedSubscription into the H2 storage.

## Why is it important/What is the impact to the user?

Permit to the subscription identifier to resists to broker restarts.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the Changelog if it's a feature or a fix that has to be reported

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #801 
