### PR TITLE
Add Netty native transport support on MacOS.

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.18-SNAPSHOT:
+   [feature] Add Netty native trsansport support on MacOS. Bundle all the native transport module by default (#806)
    [feature] message expiry interval: (issue #818)
      - Implements the management of message expiry for retained part. (#819)
    [feature] subscription option handling: (issue #808)

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -81,12 +81,65 @@
             <version>${netty.version}</version>
         </dependency>
 
+
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
             <version>${netty.version}</version>
             <classifier>linux-x86_64</classifier>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>${netty.version}</version>
+            <classifier>linux-aarch_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-kqueue</artifactId>
+            <version>${netty.version}</version>
+            <classifier>osx-aarch_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-kqueue</artifactId>
+            <version>${netty.version}</version>
+            <classifier>osx-x86_64</classifier>
+        </dependency>
+
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>${netty.tcnative.version}</version>
+            <classifier>linux-x86_64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>${netty.tcnative.version}</version>
+            <classifier>linux-aarch_64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>${netty.tcnative.version}</version>
+            <classifier>osx-x86_64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>${netty.tcnative.version}</version>
+            <classifier>osx-aarch_64</classifier>
+            <scope>runtime</scope>
+        </dependency>
+
 
         <dependency>
             <groupId>com.h2database</groupId>
@@ -169,13 +222,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>${netty.tcnative.version}</version>
-            <classifier>linux-x86_64</classifier>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>com.h2database</groupId>

--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -98,7 +98,7 @@ public final class BrokerConstants {
     public static final String NETTY_TCP_NODELAY_PROPERTY_NAME = "netty.tcp_nodelay";
     public static final String NETTY_SO_KEEPALIVE_PROPERTY_NAME = "netty.so_keepalive";
     public static final String NETTY_CHANNEL_TIMEOUT_SECONDS_PROPERTY_NAME = "netty.channel_timeout.seconds";
-    public static final String NETTY_EPOLL_PROPERTY_NAME = "netty.epoll";
+    public static final String NETTY_NATIVE_PROPERTY_NAME = "netty.native";
     @Deprecated
     public static final String NETTY_MAX_BYTES_PROPERTY_NAME = IConfig.NETTY_MAX_BYTES_PROPERTY_NAME;
     @Deprecated

--- a/distribution/src/main/resources/moquette.conf
+++ b/distribution/src/main/resources/moquette.conf
@@ -135,14 +135,14 @@ password_file config/password_file.conf
 #*********************************************************************
 # Netty Configuration
 #
-# netty.epoll: Linux systems can use epoll instead of nio. To get a performance
-# gain and reduced GC.
+# netty.native: Linux systems can use epoll, while MacOS can use kqueue
+# instead of nio. To get a performance gain and reduced GC.
 # http://netty.io/wiki/native-transports.html for more information
 # netty.mqtt.message_size : by default the max size of message is set at 8092 bytes
 # http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/errata01/os/mqtt-v3.1.1-errata01-os-complete.html#_Toc442180836
 # Fore more information about payload size specs.
 #*********************************************************************
-# netty.epoll true
+# netty.native true
 # netty.mqtt.message_size 8092
 
 #*********************************************************************


### PR DESCRIPTION
## Release notes

[rn:skip] 

## What does this PR do?

- Add Netty native trsansport support on MacOS. Bundle all the native transport module by default.

## Why is it important/What is the impact to the user?

To facilitate development on MacOS,  support for the Netty KQueue native transport was added.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the Changelog if it's a feature or a fix that has to be reported

## Author's Checklist

- [ ]

## How to test this PR locally

If you enable `netty.native` in the config file on MacOS, you should see the message "Netty is using KQueue" in the console output when starting the Moquette server.

## Related issues

- 

## Use cases

