### PR TITLE
Move from qos to subscription option

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,6 +1,7 @@
 Version 0.18-SNAPSHOT:
    [feature] subscription option handling: (issue #808)
      - Move from qos to subscription option implementing the persistence of SubscriptionOption to/from storage. (#810)
+     
    [feature] subscription identifiers: (issue #801)
      - Implements the validation of subscription identifier properties in SUBSCRIBE. (#803)
      - Store and retrieve the subscription identifier into the subscriptions directory. (#804)

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,6 @@
 Version 0.18-SNAPSHOT:
+   [feature] subscription option handling: (issue #808)
+     - Move from qos to subscription option implementing the persistence of SubscriptionOption to/from storage. (#810)
    [feature] subscription identifiers: (issue #801)
      - Implements the validation of subscription identifier properties in SUBSCRIBE. (#803)
      - Store and retrieve the subscription identifier into the subscriptions directory. (#804)

--- a/broker/src/main/java/io/moquette/broker/ISubscriptionsRepository.java
+++ b/broker/src/main/java/io/moquette/broker/ISubscriptionsRepository.java
@@ -17,6 +17,7 @@ package io.moquette.broker;
 
 import io.moquette.broker.subscriptions.*;
 import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
 
 import java.util.Collection;
 import java.util.Set;
@@ -42,12 +43,12 @@ public interface ISubscriptionsRepository {
     /**
      * Add shared subscription to storage.
      * */
-    void addNewSharedSubscription(String clientId, ShareName share, Topic topicFilter, MqttQoS requestedQoS);
+    void addNewSharedSubscription(String clientId, ShareName share, Topic topicFilter, MqttSubscriptionOption option);
 
     /**
      * Add shared subscription with subscription identifier to storage.
      * */
-    void addNewSharedSubscription(String clientId, ShareName share, Topic topicFilter, MqttQoS requestedQoS,
+    void addNewSharedSubscription(String clientId, ShareName share, Topic topicFilter, MqttSubscriptionOption option,
                                   SubscriptionIdentifier subscriptionIdentifier);
 
     /**

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -157,7 +157,7 @@ class Session {
     }
 
     public void removeSubscription(Topic topic) {
-        subscriptions.remove(new Subscription(data.clientId(), topic, MqttQoS.EXACTLY_ONCE));
+        subscriptions.remove(new Subscription(data.clientId(), topic, MqttSubscriptionOption.onlyFromQos(MqttQoS.EXACTLY_ONCE)));
     }
 
     public boolean hasWill() {

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
@@ -18,6 +18,7 @@ package io.moquette.broker.subscriptions;
 import io.moquette.broker.subscriptions.CTrie.SubscriptionRequest;
 import io.moquette.broker.subscriptions.CTrie.UnsubscribeRequest;
 import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
 
 import java.security.SecureRandom;
 import java.util.ArrayList;
@@ -161,7 +162,7 @@ class CNode implements Comparable<CNode> {
         ) {
             // if subscription identifier hasn't changed,
             // then check QoS but don't lower the requested QoS level
-            return existing.getRequestedQos().value() < newSubscription.getRequestedQos().value();
+            return existing.option().qos().value() < newSubscription.option().qos().value();
         }
 
         // subscription identifier changed
@@ -201,7 +202,7 @@ class CNode implements Comparable<CNode> {
 
     private static SharedSubscription wrapKey(String clientId) {
         MqttQoS unusedQoS = MqttQoS.AT_MOST_ONCE;
-        return new SharedSubscription(null, Topic.asTopic("unused"), clientId, unusedQoS);
+        return new SharedSubscription(null, Topic.asTopic("unused"), clientId, MqttSubscriptionOption.onlyFromQos(unusedQoS));
     }
 
     //TODO this is equivalent to negate(containsOnly(clientId))

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
@@ -19,6 +19,7 @@ import io.moquette.broker.ISubscriptionsRepository;
 import io.moquette.broker.subscriptions.CTrie.SubscriptionRequest;
 import io.moquette.broker.subscriptions.CTrie.UnsubscribeRequest;
 import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +60,7 @@ public class CTrieSubscriptionDirectory implements ISubscriptionsDirectory {
         for (SharedSubscription shared : subscriptionsRepository.listAllSharedSubscription()) {
             LOG.debug("Re-subscribing shared {}", shared);
             ctrie.addToTree(SubscriptionRequest.buildShared(shared.getShareName(), shared.topicFilter(),
-                shared.clientId(), shared.requestedQoS()));
+                shared.clientId(), MqttSubscriptionOption.onlyFromQos(shared.requestedQoS())));
         }
 
         if (LOG.isTraceEnabled()) {
@@ -101,14 +102,14 @@ public class CTrieSubscriptionDirectory implements ISubscriptionsDirectory {
     }
 
     @Override
-    public void add(String clientId, Topic filter, MqttQoS requestedQoS) {
-        SubscriptionRequest subRequest = SubscriptionRequest.buildNonShared(clientId, filter, requestedQoS);
+    public void add(String clientId, Topic filter, MqttSubscriptionOption option) {
+        SubscriptionRequest subRequest = SubscriptionRequest.buildNonShared(clientId, filter, option);
         addNonSharedSubscriptionRequest(subRequest);
     }
 
     @Override
-    public void add(String clientId, Topic filter, MqttQoS requestedQoS, SubscriptionIdentifier subscriptionId) {
-        SubscriptionRequest subRequest = SubscriptionRequest.buildNonShared(clientId, filter, requestedQoS, subscriptionId);
+    public void add(String clientId, Topic filter, MqttSubscriptionOption option, SubscriptionIdentifier subscriptionId) {
+        SubscriptionRequest subRequest = SubscriptionRequest.buildNonShared(clientId, filter, option, subscriptionId);
         addNonSharedSubscriptionRequest(subRequest);
     }
 
@@ -118,8 +119,8 @@ public class CTrieSubscriptionDirectory implements ISubscriptionsDirectory {
     }
 
     @Override
-    public void addShared(String clientId, ShareName name, Topic topicFilter, MqttQoS requestedQoS) {
-        SubscriptionRequest shareSubRequest = SubscriptionRequest.buildShared(name, topicFilter, clientId, requestedQoS);
+    public void addShared(String clientId, ShareName name, Topic topicFilter, MqttSubscriptionOption option) {
+        SubscriptionRequest shareSubRequest = SubscriptionRequest.buildShared(name, topicFilter, clientId, option);
         addSharedSubscriptionRequest(shareSubRequest);
     }
 
@@ -128,19 +129,19 @@ public class CTrieSubscriptionDirectory implements ISubscriptionsDirectory {
 
         if (shareSubRequest.hasSubscriptionIdentifier()) {
             subscriptionsRepository.addNewSharedSubscription(shareSubRequest.getClientId(), shareSubRequest.getSharedName(),
-                shareSubRequest.getTopicFilter(), shareSubRequest.getRequestedQoS(), shareSubRequest.getSubscriptionIdentifier());
+                shareSubRequest.getTopicFilter(), shareSubRequest.getOption(), shareSubRequest.getSubscriptionIdentifier());
         } else {
             subscriptionsRepository.addNewSharedSubscription(shareSubRequest.getClientId(), shareSubRequest.getSharedName(),
-                shareSubRequest.getTopicFilter(), shareSubRequest.getRequestedQoS());
+                shareSubRequest.getTopicFilter(), shareSubRequest.getOption());
         }
         List<SharedSubscription> sharedSubscriptions = clientSharedSubscriptions.computeIfAbsent(shareSubRequest.getClientId(), unused -> new ArrayList<>());
         sharedSubscriptions.add(shareSubRequest.sharedSubscription());
     }
 
     @Override
-    public void addShared(String clientId, ShareName name, Topic topicFilter, MqttQoS requestedQoS,
+    public void addShared(String clientId, ShareName name, Topic topicFilter, MqttSubscriptionOption option,
                           SubscriptionIdentifier subscriptionId) {
-        SubscriptionRequest shareSubRequest = SubscriptionRequest.buildShared(name, topicFilter, clientId, requestedQoS, subscriptionId);
+        SubscriptionRequest shareSubRequest = SubscriptionRequest.buildShared(name, topicFilter, clientId, option, subscriptionId);
         addSharedSubscriptionRequest(shareSubRequest);
     }
 
@@ -165,7 +166,7 @@ public class CTrieSubscriptionDirectory implements ISubscriptionsDirectory {
 
         subscriptionsRepository.removeSharedSubscription(clientId, name, topicFilter);
 
-        SharedSubscription sharedSubscription = new SharedSubscription(name, topicFilter, clientId, MqttQoS.AT_MOST_ONCE /* UNUSED in compare */);
+        SharedSubscription sharedSubscription = new SharedSubscription(name, topicFilter, clientId, MqttSubscriptionOption.onlyFromQos(MqttQoS.AT_MOST_ONCE) /* UNUSED in compare */);
         List<SharedSubscription> sharedSubscriptions = clientSharedSubscriptions.get(clientId);
         if (sharedSubscriptions != null && !sharedSubscriptions.isEmpty()) {
             sharedSubscriptions.remove(sharedSubscription);

--- a/broker/src/main/java/io/moquette/broker/subscriptions/DumpTreeVisitor.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/DumpTreeVisitor.java
@@ -39,7 +39,7 @@ class DumpTreeVisitor implements CTrie.IVisitor<String> {
         for (Subscription couple : node.subscriptions()) {
             subScriptionsStr
                 .append("{filter=").append(couple.topicFilter).append(", ")
-                .append("qos=").append(couple.getRequestedQos()).append(", ")
+                .append("option=").append(couple.option()).append(", ")
                 .append("client='").append(couple.clientId).append("'}");
             counter++;
             if (counter < node.subscriptions().size()) {

--- a/broker/src/main/java/io/moquette/broker/subscriptions/ISubscriptionsDirectory.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/ISubscriptionsDirectory.java
@@ -17,6 +17,7 @@ package io.moquette.broker.subscriptions;
 
 import io.moquette.broker.ISubscriptionsRepository;
 import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
 
 import java.util.List;
 import java.util.Set;
@@ -32,13 +33,13 @@ public interface ISubscriptionsDirectory {
 
     List<Subscription> matchQosSharpening(Topic topic);
 
-    void add(String clientId, Topic filter, MqttQoS requestedQoS);
+    void add(String clientId, Topic filter, MqttSubscriptionOption option);
 
-    void add(String clientId, Topic filter, MqttQoS requestedQoS, SubscriptionIdentifier subscriptionId);
+    void add(String clientId, Topic filter, MqttSubscriptionOption option, SubscriptionIdentifier subscriptionId);
 
-    void addShared(String clientId, ShareName name, Topic topicFilter, MqttQoS requestedQoS);
+    void addShared(String clientId, ShareName name, Topic topicFilter, MqttSubscriptionOption option);
 
-    void addShared(String clientId, ShareName name, Topic topicFilter, MqttQoS requestedQoS, SubscriptionIdentifier subscriptionId);
+    void addShared(String clientId, ShareName name, Topic topicFilter, MqttSubscriptionOption option, SubscriptionIdentifier subscriptionId);
 
     void removeSubscription(Topic topic, String clientID);
 

--- a/broker/src/main/java/io/moquette/broker/subscriptions/SharedSubscription.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/SharedSubscription.java
@@ -16,6 +16,7 @@
 package io.moquette.broker.subscriptions;
 
 import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -27,25 +28,25 @@ public final class SharedSubscription implements Comparable<SharedSubscription> 
     private final ShareName shareName;
     private final Topic topicFilter;
     private final String clientId;
-    private final MqttQoS requestedQoS;
+    private final MqttSubscriptionOption option;
     private final Optional<SubscriptionIdentifier> subscriptionId;
 
-    public SharedSubscription(ShareName shareName, Topic topicFilter, String clientId, MqttQoS requestedQoS) {
-        Objects.requireNonNull(requestedQoS, "qos parameter can't be null");
+    public SharedSubscription(ShareName shareName, Topic topicFilter, String clientId, MqttSubscriptionOption option) {
+        Objects.requireNonNull(option, "option parameter can't be null");
         this.shareName = shareName;
         this.topicFilter = topicFilter;
         this.clientId = clientId;
-        this.requestedQoS = requestedQoS;
+        this.option = option;
         this.subscriptionId = Optional.empty();
     }
 
-    public SharedSubscription(ShareName shareName, Topic topicFilter, String clientId, MqttQoS requestedQoS,
-                              SubscriptionIdentifier subscriptionId) {
-        Objects.requireNonNull(requestedQoS, "qos parameter can't be null");
+    public SharedSubscription(ShareName shareName, Topic topicFilter, String clientId,
+                              MqttSubscriptionOption option, SubscriptionIdentifier subscriptionId) {
+        Objects.requireNonNull(option, "option parameter can't be null");
         this.shareName = shareName;
         this.topicFilter = topicFilter;
         this.clientId = clientId;
-        this.requestedQoS = requestedQoS;
+        this.option = option;
         this.subscriptionId = Optional.of(subscriptionId);
     }
 
@@ -58,7 +59,11 @@ public final class SharedSubscription implements Comparable<SharedSubscription> 
     }
 
     public MqttQoS requestedQoS() {
-        return requestedQoS;
+        return option.qos();
+    }
+
+    public MqttSubscriptionOption getOption() {
+        return option;
     }
 
     public ShareName getShareName() {
@@ -70,9 +75,9 @@ public final class SharedSubscription implements Comparable<SharedSubscription> 
      * */
     Subscription createSubscription() {
         if (subscriptionId.isPresent()) {
-            return new Subscription(clientId, topicFilter, requestedQoS, shareName.getShareName(), subscriptionId.get());
+            return new Subscription(clientId, topicFilter, option, shareName.getShareName(), subscriptionId.get());
         } else {
-            return new Subscription(clientId, topicFilter, requestedQoS, shareName.getShareName());
+            return new Subscription(clientId, topicFilter, option, shareName.getShareName());
         }
     }
 
@@ -97,11 +102,11 @@ public final class SharedSubscription implements Comparable<SharedSubscription> 
         return Objects.equals(shareName, that.shareName) &&
             Objects.equals(topicFilter, that.topicFilter) &&
             Objects.equals(clientId, that.clientId) &&
-            Objects.equals(requestedQoS, that.requestedQoS);
+            Objects.equals(option, that.option);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(shareName, topicFilter, clientId, requestedQoS);
+        return Objects.hash(shareName, topicFilter, clientId, option);
     }
 }

--- a/broker/src/main/java/io/moquette/broker/subscriptions/Subscription.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/Subscription.java
@@ -17,6 +17,7 @@
 package io.moquette.broker.subscriptions;
 
 import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -25,51 +26,47 @@ import java.util.Optional;
 /**
  * Maintain the information about which Topic a certain ClientID is subscribed and at which QoS
  */
-public final class Subscription implements Serializable, Comparable<Subscription> {
+public final class Subscription implements Serializable, Comparable<Subscription>{
 
     private static final long serialVersionUID = -3383457629635732794L;
-    private final MqttQoS requestedQos; // max QoS acceptable
+    private final MqttSubscriptionOption option;
     final String clientId;
     final Topic topicFilter;
     final String shareName;
 
     private final Optional<SubscriptionIdentifier> subscriptionId;
 
-    public Subscription(String clientId, Topic topicFilter, MqttQoS requestedQos) {
-        this(clientId, topicFilter, requestedQos, "", null);
+    public Subscription(String clientId, Topic topicFilter, MqttSubscriptionOption options) {
+        this(clientId, topicFilter, options, "");
     }
 
-    public Subscription(String clientId, Topic topicFilter, MqttQoS requestedQos, SubscriptionIdentifier subscriptionId) {
-        this(clientId, topicFilter, requestedQos, "", subscriptionId);
+    public Subscription(String clientId, Topic topicFilter, MqttSubscriptionOption options, SubscriptionIdentifier subscriptionId) {
+        this(clientId, topicFilter, options, "", subscriptionId);
     }
 
-    public Subscription(String clientId, Topic topicFilter, MqttQoS requestedQos, String shareName) {
-        this(clientId, topicFilter, requestedQos, shareName, null);
+    public Subscription(String clientId, Topic topicFilter, MqttSubscriptionOption options, String shareName) {
+        this(clientId, topicFilter, options, shareName, null);
     }
 
-    public Subscription(String clientId, Topic topicFilter, MqttQoS requestedQos, String shareName,
+    public Subscription(String clientId, Topic topicFilter, MqttSubscriptionOption options, String shareName,
                         SubscriptionIdentifier subscriptionId) {
-        this.requestedQos = requestedQos;
         this.clientId = clientId;
         this.topicFilter = topicFilter;
         this.shareName = shareName;
         this.subscriptionId = Optional.ofNullable(subscriptionId);
+        this.option = options;
     }
 
     public Subscription(Subscription orig) {
-        this.requestedQos = orig.requestedQos;
         this.clientId = orig.clientId;
         this.topicFilter = orig.topicFilter;
         this.shareName = orig.shareName;
         this.subscriptionId = orig.subscriptionId;
+        this.option = orig.option;
     }
 
     public String getClientId() {
         return clientId;
-    }
-
-    public MqttQoS getRequestedQos() {
-        return requestedQos;
     }
 
     public Topic getTopicFilter() {
@@ -77,7 +74,7 @@ public final class Subscription implements Serializable, Comparable<Subscription
     }
 
     public boolean qosLessThan(Subscription sub) {
-        return requestedQos.value() < sub.requestedQos.value();
+        return option.qos().value() < sub.option.qos().value();
     }
 
     public boolean hasSubscriptionIdentifier() {
@@ -105,7 +102,7 @@ public final class Subscription implements Serializable, Comparable<Subscription
 
     @Override
     public String toString() {
-        return String.format("[filter:%s, clientID: %s, qos: %s - shareName: %s]", topicFilter, clientId, requestedQos, shareName);
+        return String.format("[filter:%s, clientID: %s, options: %s - shareName: %s]", topicFilter, clientId, option, shareName);
     }
 
     @Override
@@ -141,5 +138,9 @@ public final class Subscription implements Serializable, Comparable<Subscription
 
     public String getShareName() {
         return shareName;
+    }
+
+    public MqttSubscriptionOption option() {
+        return option;
     }
 }

--- a/broker/src/main/java/io/moquette/interception/messages/InterceptSubscribeMessage.java
+++ b/broker/src/main/java/io/moquette/interception/messages/InterceptSubscribeMessage.java
@@ -18,6 +18,7 @@ package io.moquette.interception.messages;
 
 import io.moquette.broker.subscriptions.Subscription;
 import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
 
 public class InterceptSubscribeMessage implements InterceptMessage {
 
@@ -34,7 +35,11 @@ public class InterceptSubscribeMessage implements InterceptMessage {
     }
 
     public MqttQoS getRequestedQos() {
-        return subscription.getRequestedQos();
+        return subscription.option().qos();
+    }
+
+    public MqttSubscriptionOption getOption() {
+        return subscription.option();
     }
 
     public String getTopicFilter() {

--- a/broker/src/main/java/io/moquette/persistence/MemorySubscriptionsRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/MemorySubscriptionsRepository.java
@@ -22,6 +22,7 @@ import io.moquette.broker.subscriptions.Subscription;
 import io.moquette.broker.subscriptions.SubscriptionIdentifier;
 import io.moquette.broker.subscriptions.Topic;
 import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,8 +79,8 @@ public class MemorySubscriptionsRepository implements ISubscriptionsRepository {
     }
 
     @Override
-    public void addNewSharedSubscription(String clientId, ShareName share, Topic topicFilter, MqttQoS requestedQoS) {
-        SharedSubscription sharedSub = new SharedSubscription(share, topicFilter, clientId, requestedQoS);
+    public void addNewSharedSubscription(String clientId, ShareName share, Topic topicFilter, MqttSubscriptionOption option) {
+        SharedSubscription sharedSub = new SharedSubscription(share, topicFilter, clientId, option);
         storeNewSharedSubscription(clientId, share, topicFilter, sharedSub);
     }
 
@@ -89,9 +90,9 @@ public class MemorySubscriptionsRepository implements ISubscriptionsRepository {
     }
 
     @Override
-    public void addNewSharedSubscription(String clientId, ShareName share, Topic topicFilter, MqttQoS requestedQoS,
+    public void addNewSharedSubscription(String clientId, ShareName share, Topic topicFilter, MqttSubscriptionOption option,
                                          SubscriptionIdentifier subscriptionIdentifier) {
-        SharedSubscription sharedSub = new SharedSubscription(share, topicFilter, clientId, requestedQoS, subscriptionIdentifier);
+        SharedSubscription sharedSub = new SharedSubscription(share, topicFilter, clientId, option, subscriptionIdentifier);
         storeNewSharedSubscription(clientId, share, topicFilter, sharedSub);
     }
 

--- a/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeInternalPublishTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -337,7 +336,7 @@ public class PostOfficeInternalPublishTest {
         assertEquals(desiredQos.value(), (int) subAck.payload().grantedQoSLevels().get(0));
 
         final String clientId = connection.getClientId();
-        Subscription expectedSubscription = new Subscription(clientId, new Topic(topic), desiredQos);
+        Subscription expectedSubscription = new Subscription(clientId, new Topic(topic), MqttSubscriptionOption.onlyFromQos(desiredQos));
 
         final List<Subscription> matchedSubscriptions = subscriptions.matchWithoutQosSharpening(new Topic(topic));
         assertEquals(1, matchedSubscriptions.size());

--- a/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
@@ -195,7 +195,7 @@ public class PostOfficePublishTest {
         assertEquals(desiredQos.value(), (int) subAck.payload().grantedQoSLevels().get(0));
 
         final String clientId = connection.getClientId();
-        Subscription expectedSubscription = new Subscription(clientId, new Topic(topic), desiredQos);
+        Subscription expectedSubscription = new Subscription(clientId, new Topic(topic), MqttSubscriptionOption.onlyFromQos(desiredQos));
 
         final List<Subscription> matchedSubscriptions = subscriptions.matchWithoutQosSharpening(new Topic(topic));
         assertEquals(1, matchedSubscriptions.size());

--- a/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
@@ -143,7 +143,7 @@ public class PostOfficeSubscribeTest {
         assertEquals(desiredQos.value(), (int) subAck.payload().grantedQoSLevels().get(0));
 
         final String clientId = NettyUtils.clientID(channel);
-        Subscription expectedSubscription = new Subscription(clientId, new Topic(topic), desiredQos);
+        Subscription expectedSubscription = new Subscription(clientId, new Topic(topic), MqttSubscriptionOption.onlyFromQos(desiredQos));
 
         final List<Subscription> matchedSubscriptions = subscriptions.matchWithoutQosSharpening(new Topic(topic));
         assertEquals(1, matchedSubscriptions.size());
@@ -163,7 +163,7 @@ public class PostOfficeSubscribeTest {
         assertEquals(desiredQos.value(), (int) subAck.payload().grantedQoSLevels().get(0));
 
         final String clientId = connection.getClientId();
-        Subscription expectedSubscription = new Subscription(clientId, new Topic(topic), desiredQos);
+        Subscription expectedSubscription = new Subscription(clientId, new Topic(topic), MqttSubscriptionOption.onlyFromQos(desiredQos));
 
         final List<Subscription> matchedSubscriptions = subscriptions.matchWithoutQosSharpening(new Topic(topic));
         assertEquals(1, matchedSubscriptions.size());
@@ -337,10 +337,10 @@ public class PostOfficeSubscribeTest {
 
     @Test
     public void testLowerTheQosToTheRequestedBySubscription() {
-        Subscription subQos1 = new Subscription("Sub A", new Topic("a/b"), MqttQoS.AT_LEAST_ONCE);
+        Subscription subQos1 = new Subscription("Sub A", new Topic("a/b"), MqttSubscriptionOption.onlyFromQos(MqttQoS.AT_LEAST_ONCE));
         assertEquals(MqttQoS.AT_LEAST_ONCE, PostOffice.lowerQosToTheSubscriptionDesired(subQos1, EXACTLY_ONCE));
 
-        Subscription subQos2 = new Subscription("Sub B", new Topic("a/+"), EXACTLY_ONCE);
+        Subscription subQos2 = new Subscription("Sub B", new Topic("a/+"), MqttSubscriptionOption.onlyFromQos(EXACTLY_ONCE));
         assertEquals(EXACTLY_ONCE, PostOffice.lowerQosToTheSubscriptionDesired(subQos2, EXACTLY_ONCE));
     }
 

--- a/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
 import java.util.Collections;
-import java.util.Set;
 import java.util.concurrent.*;
 
 import static io.moquette.broker.MQTTConnectionPublishTest.memorySessionsRepository;
@@ -123,7 +122,7 @@ public class PostOfficeUnsubscribeTest {
         assertEquals(desiredQos.value(), (int) subAck.payload().grantedQoSLevels().get(0));
 
         final String clientId = connection.getClientId();
-        Subscription expectedSubscription = new Subscription(clientId, new Topic(topic), desiredQos);
+        Subscription expectedSubscription = new Subscription(clientId, new Topic(topic), MqttSubscriptionOption.onlyFromQos(desiredQos));
 
         final List<Subscription> matchedSubscriptions = subscriptions.matchQosSharpening(new Topic(topic));
         assertEquals(1, matchedSubscriptions.size());

--- a/broker/src/test/java/io/moquette/broker/SessionTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionTest.java
@@ -6,6 +6,7 @@ import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
 import io.netty.handler.codec.mqtt.MqttVersion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,6 @@ import static io.moquette.broker.Session.INFINITE_EXPIRY;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static io.moquette.BrokerConstants.NO_BUFFER_FLUSH;
-import static org.junit.jupiter.api.Assertions.*;
 
 public class SessionTest {
 
@@ -115,9 +115,9 @@ public class SessionTest {
 
     @Test
     public void testRemoveSubscription() {
-        client.addSubscriptions(Arrays.asList(new Subscription(CLIENT_ID, new Topic("topic/one"), MqttQoS.AT_MOST_ONCE)));
+        client.addSubscriptions(Arrays.asList(new Subscription(CLIENT_ID, new Topic("topic/one"), MqttSubscriptionOption.onlyFromQos(MqttQoS.AT_MOST_ONCE))));
         Assertions.assertThat(client.getSubscriptions()).hasSize(1);
-        client.addSubscriptions(Arrays.asList(new Subscription(CLIENT_ID, new Topic("topic/one"), MqttQoS.EXACTLY_ONCE)));
+        client.addSubscriptions(Arrays.asList(new Subscription(CLIENT_ID, new Topic("topic/one"), MqttSubscriptionOption.onlyFromQos(MqttQoS.EXACTLY_ONCE))));
         Assertions.assertThat(client.getSubscriptions()).hasSize(1);
         client.removeSubscription(new Topic("topic/one"));
         Assertions.assertThat(client.getSubscriptions()).isEmpty();

--- a/broker/src/test/java/io/moquette/broker/subscriptions/CTrieSpeedTest.java
+++ b/broker/src/test/java/io/moquette/broker/subscriptions/CTrieSpeedTest.java
@@ -22,6 +22,8 @@ import io.netty.handler.codec.mqtt.MqttQoS;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+
+import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
@@ -36,7 +38,7 @@ public class CTrieSpeedTest {
     private static final int TOTAL_SUBSCRIPTIONS = 500_000;
 
     static SubscriptionRequest clientSubOnTopic(String clientID, String topicName) {
-        return SubscriptionRequest.buildNonShared(clientID, asTopic(topicName), MqttQoS.AT_MOST_ONCE);
+        return SubscriptionRequest.buildNonShared(clientID, asTopic(topicName), MqttSubscriptionOption.onlyFromQos(MqttQoS.AT_MOST_ONCE));
     }
 
     @Test
@@ -88,7 +90,7 @@ public class CTrieSpeedTest {
         List<SubscriptionRequest> subscriptionList = new ArrayList<>(TOTAL_SUBSCRIPTIONS);
         for (int i = 0; i < TOTAL_SUBSCRIPTIONS; i++) {
             Topic topic = asTopic("topic/test/" + new Random().nextInt(1 + i % 10) + "/test");
-            subscriptionList.add(SubscriptionRequest.buildNonShared("TestClient-" + i, topic, MqttQoS.AT_LEAST_ONCE));
+            subscriptionList.add(SubscriptionRequest.buildNonShared("TestClient-" + i, topic, MqttSubscriptionOption.onlyFromQos(MqttQoS.AT_LEAST_ONCE)));
         }
         return subscriptionList;
     }

--- a/broker/src/test/java/io/moquette/broker/subscriptions/CTrieTest.java
+++ b/broker/src/test/java/io/moquette/broker/subscriptions/CTrieTest.java
@@ -18,6 +18,7 @@ package io.moquette.broker.subscriptions;
 
 import io.moquette.broker.subscriptions.CTrie.SubscriptionRequest;
 import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -121,7 +122,7 @@ public class CTrieTest {
     }
 
     static SubscriptionRequest clientSubOnTopic(String clientID, String topicFilter) {
-        return SubscriptionRequest.buildNonShared(clientID, asTopic(topicFilter), null);
+        return SubscriptionRequest.buildNonShared(clientID, asTopic(topicFilter), MqttSubscriptionOption.onlyFromQos(null));
     }
 
     @Test
@@ -193,7 +194,7 @@ public class CTrieTest {
         final List<Subscription> matchingSubs = sut.recursiveMatch(asTopic("/temp/2"));
 
         //Verify
-        final Subscription expectedMatchingsub = new Subscription("TempSensor1", asTopic("/temp/2"), MqttQoS.AT_MOST_ONCE);
+        final Subscription expectedMatchingsub = new Subscription("TempSensor1", asTopic("/temp/2"), MqttSubscriptionOption.onlyFromQos(MqttQoS.AT_MOST_ONCE));
         assertThat(matchingSubs).contains(expectedMatchingsub);
     }
 
@@ -212,9 +213,9 @@ public class CTrieTest {
 
         //Verify
         // not clear to me, but I believe /temp unsubscribe should not unsub you from downstream /temp/1 or /temp/2
-        final Subscription expectedMatchingsub1 = new Subscription("TempSensor1", asTopic("/temp/1"), MqttQoS.AT_MOST_ONCE);
+        final Subscription expectedMatchingsub1 = new Subscription("TempSensor1", asTopic("/temp/1"), MqttSubscriptionOption.onlyFromQos(MqttQoS.AT_MOST_ONCE));
         assertThat(matchingSubs1).contains(expectedMatchingsub1);
-        final Subscription expectedMatchingsub2 = new Subscription("TempSensor1", asTopic("/temp/2"), MqttQoS.AT_MOST_ONCE);
+        final Subscription expectedMatchingsub2 = new Subscription("TempSensor1", asTopic("/temp/2"), MqttSubscriptionOption.onlyFromQos(MqttQoS.AT_MOST_ONCE));
         assertThat(matchingSubs2).contains(expectedMatchingsub2);
     }
 
@@ -239,7 +240,7 @@ public class CTrieTest {
         final List<Subscription> matchingSubs = sut.recursiveMatch(asTopic("/temp"));
 
         //Verify
-        final Subscription expectedMatchingsub = new Subscription("TempSensor1", asTopic("/temp"), MqttQoS.AT_MOST_ONCE);
+        final Subscription expectedMatchingsub = new Subscription("TempSensor1", asTopic("/temp"), MqttSubscriptionOption.onlyFromQos(MqttQoS.AT_MOST_ONCE));
         assertThat(matchingSubs).contains(expectedMatchingsub);
     }
 
@@ -255,8 +256,8 @@ public class CTrieTest {
         final List<Subscription> matchingSubs2 = sut.recursiveMatch(asTopic("temp/1"));
 
         //Verify
-        final Subscription expectedMatchingsub1 = new Subscription("TempSensor1", asTopic("temp"), MqttQoS.AT_MOST_ONCE);
-        final Subscription expectedMatchingsub2 = new Subscription("TempSensor1", asTopic("temp/1"), MqttQoS.AT_MOST_ONCE);
+        final Subscription expectedMatchingsub1 = new Subscription("TempSensor1", asTopic("temp"), MqttSubscriptionOption.onlyFromQos(MqttQoS.AT_MOST_ONCE));
+        final Subscription expectedMatchingsub2 = new Subscription("TempSensor1", asTopic("temp/1"), MqttSubscriptionOption.onlyFromQos(MqttQoS.AT_MOST_ONCE));
 
         assertThat(matchingSubs1).contains(expectedMatchingsub1);
         assertThat(matchingSubs2).contains(expectedMatchingsub2);
@@ -283,8 +284,8 @@ public class CTrieTest {
         final List<Subscription> matchingSubs2 = sut.recursiveMatch(asTopic("temp/1"));
 
         //Verify
-        final Subscription expectedMatchingsub1 = new Subscription("TempSensor1", asTopic("temp"), MqttQoS.AT_MOST_ONCE);
-        final Subscription expectedMatchingsub2 = new Subscription("TempSensor2", asTopic("temp/1"), MqttQoS.AT_MOST_ONCE);
+        final Subscription expectedMatchingsub1 = new Subscription("TempSensor1", asTopic("temp"), MqttSubscriptionOption.onlyFromQos(MqttQoS.AT_MOST_ONCE));
+        final Subscription expectedMatchingsub2 = new Subscription("TempSensor2", asTopic("temp/1"), MqttSubscriptionOption.onlyFromQos(MqttQoS.AT_MOST_ONCE));
 
         assertThat(matchingSubs1).contains(expectedMatchingsub1);
         assertThat(matchingSubs2).contains(expectedMatchingsub2);
@@ -311,8 +312,8 @@ public class CTrieTest {
         final List<Subscription> matchingSubs2 = sut.recursiveMatch(asTopic("temp/1"));
 
         //Verify
-        final Subscription expectedMatchingsub1 = new Subscription("TempSensor1", asTopic("temp"), MqttQoS.AT_MOST_ONCE);
-        final Subscription expectedMatchingsub2 = new Subscription("TempSensor2", asTopic("temp/1"), MqttQoS.AT_MOST_ONCE);
+        final Subscription expectedMatchingsub1 = new Subscription("TempSensor1", asTopic("temp"), MqttSubscriptionOption.onlyFromQos(MqttQoS.AT_MOST_ONCE));
+        final Subscription expectedMatchingsub2 = new Subscription("TempSensor2", asTopic("temp/1"), MqttSubscriptionOption.onlyFromQos(MqttQoS.AT_MOST_ONCE));
 
         assertThat(matchingSubs1).contains(expectedMatchingsub1);
         assertThat(matchingSubs2).contains(expectedMatchingsub2);

--- a/broker/src/test/java/io/moquette/broker/subscriptions/SubscriptionTestUtils.java
+++ b/broker/src/test/java/io/moquette/broker/subscriptions/SubscriptionTestUtils.java
@@ -15,6 +15,7 @@
  */
 package io.moquette.broker.subscriptions;
 
+import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
 import org.jetbrains.annotations.NotNull;
 
 import static io.moquette.broker.subscriptions.Topic.asTopic;
@@ -22,11 +23,11 @@ import static io.moquette.broker.subscriptions.Topic.asTopic;
 public class SubscriptionTestUtils {
     @NotNull
     static Subscription asSubscription(String clientId, String topicFilter) {
-        return new Subscription(clientId, asTopic(topicFilter), null);
+        return new Subscription(clientId, asTopic(topicFilter), MqttSubscriptionOption.onlyFromQos(null));
     }
 
     @NotNull
     static Subscription asSubscription(String clientId, String topicFilter, String shareName) {
-        return new Subscription(clientId, asTopic(topicFilter), null, shareName);
+        return new Subscription(clientId, asTopic(topicFilter), MqttSubscriptionOption.onlyFromQos(null), shareName);
     }
 }

--- a/broker/src/test/java/io/moquette/integration/mqtt5/SubscriptionWithIdentifierTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/SubscriptionWithIdentifierTest.java
@@ -30,7 +30,7 @@ public class SubscriptionWithIdentifierTest extends AbstractSubscriptionIntegrat
 
         // subscribe with an identifier
         MqttMessage received = lowLevelClient.subscribeWithIdentifier("/metrics/measures/temp",
-            MqttQoS.AT_LEAST_ONCE, 123);
+            MqttQoS.AT_LEAST_ONCE, 123, 400, TimeUnit.MILLISECONDS);
         verifyOfType(received, MqttMessageType.SUBACK);
 
         Mqtt5BlockingClient publisher = createPublisherClient();

--- a/broker/src/test/java/io/moquette/interception/BrokerInterceptorTest.java
+++ b/broker/src/test/java/io/moquette/interception/BrokerInterceptorTest.java
@@ -23,6 +23,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.mqtt.MqttMessageBuilders;
 import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -145,7 +146,7 @@ public class BrokerInterceptorTest {
 
     @Test
     public void testNotifyTopicSubscribed() throws Exception {
-        interceptor.notifyTopicSubscribed(new Subscription("cli1", new Topic("o2"), MqttQoS.AT_MOST_ONCE), "cli1234");
+        interceptor.notifyTopicSubscribed(new Subscription("cli1", new Topic("o2"), MqttSubscriptionOption.onlyFromQos(MqttQoS.AT_MOST_ONCE)), "cli1234");
         interval();
         assertEquals(70, n.get());
     }
@@ -165,7 +166,7 @@ public class BrokerInterceptorTest {
         interceptor.addInterceptHandler(interceptHandlerMock1);
         interceptor.addInterceptHandler(interceptHandlerMock2);
 
-        Subscription subscription = new Subscription("cli1", new Topic("o2"), MqttQoS.AT_MOST_ONCE);
+        Subscription subscription = new Subscription("cli1", new Topic("o2"), MqttSubscriptionOption.onlyFromQos(MqttQoS.AT_MOST_ONCE));
         interceptor.notifyTopicSubscribed(subscription, "cli1234");
         interval();
 

--- a/broker/src/test/java/io/moquette/testclient/Client.java
+++ b/broker/src/test/java/io/moquette/testclient/Client.java
@@ -257,7 +257,7 @@ public class Client {
         }
 
         if (waitElapsed) {
-            throw new RuntimeException("Cannot receive SubscribeAck in 200 ms");
+            throw new RuntimeException("Cannot receive SubscribeAck in " + timeout + " " + timeUnit);
         }
     }
 


### PR DESCRIPTION
## Release notes
Move from qos to subscription option implementing the persistence of SubscriptionOption to/from storage.

## What does this PR do?
- Modified all places where MqttQos was used in subscription and shared subscription to use the broader SubscriptionOption.
- Updated serialization for H2 to serialize all the fields of MqttSubscriptionOption.
- Adapted all the tests.

## Why is it important/What is the impact to the user?

It's an intermediate step to implement the new subscription option requirements

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the Changelog if it's a feature or a fix that has to be reported

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- #808
