### PR TITLE
Make configurable the maximum qos that a server can handle

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,7 +1,7 @@
 Version 0.18-SNAPSHOT:
    [feature] subscription option handling: (issue #808)
      - Move from qos to subscription option implementing the persistence of SubscriptionOption to/from storage. (#810)
-     
+     - Exposed the maximum granted QoS by the server with the config setting 'max_server_granted_qos'. (#811)
    [feature] subscription identifiers: (issue #801)
      - Implements the validation of subscription identifier properties in SUBSCRIBE. (#803)
      - Store and retrieve the subscription identifier into the subscriptions directory. (#804)

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -405,6 +405,9 @@ class PostOffice {
     }
 
     private static MqttQoS minQos(MqttQoS q1, MqttQoS q2) {
+        if (q1 == FAILURE || q2 == FAILURE) {
+            return FAILURE;
+        }
         return q1.value() < q2.value() ? q1 : q2;
     }
 

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -16,17 +16,38 @@
 package io.moquette.broker;
 
 import io.moquette.broker.scheduler.ScheduledExpirationService;
-import io.moquette.broker.subscriptions.*;
+import io.moquette.broker.subscriptions.ISubscriptionsDirectory;
+import io.moquette.broker.subscriptions.ShareName;
+import io.moquette.broker.subscriptions.Subscription;
+import io.moquette.broker.subscriptions.SubscriptionIdentifier;
+import io.moquette.broker.subscriptions.Topic;
 import io.moquette.interception.BrokerInterceptor;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.handler.codec.mqtt.*;
+import io.netty.handler.codec.mqtt.MqttConnectMessage;
+import io.netty.handler.codec.mqtt.MqttFixedHeader;
+import io.netty.handler.codec.mqtt.MqttMessageType;
+import io.netty.handler.codec.mqtt.MqttProperties;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttSubAckMessage;
+import io.netty.handler.codec.mqtt.MqttSubAckPayload;
+import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
+import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
+import io.netty.handler.codec.mqtt.MqttTopicSubscription;
 import io.netty.util.ReferenceCountUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Clock;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -182,6 +203,7 @@ class PostOffice {
     private final SessionEventLoopGroup sessionLoops;
     private final Clock clock;
     private final ScheduledExpirationService<ISessionsRepository.Will> willExpirationService;
+    private final MqttQoS maxServerGrantedQos;
 
     /**
      * Used only in tests
@@ -196,6 +218,14 @@ class PostOffice {
                SessionRegistry sessionRegistry, ISessionsRepository sessionRepository, BrokerInterceptor interceptor,
                Authorizator authorizator,
                SessionEventLoopGroup sessionLoops, Clock clock) {
+        this(subscriptions, retainedRepository, sessionRegistry, sessionRepository, interceptor, authorizator,
+            sessionLoops, clock, EXACTLY_ONCE);
+    }
+
+    PostOffice(ISubscriptionsDirectory subscriptions, IRetainedRepository retainedRepository,
+               SessionRegistry sessionRegistry, ISessionsRepository sessionRepository, BrokerInterceptor interceptor,
+               Authorizator authorizator,
+               SessionEventLoopGroup sessionLoops, Clock clock, MqttQoS maxServerGrantedQos) {
         this.authorizator = authorizator;
         this.subscriptions = subscriptions;
         this.retainedRepository = retainedRepository;
@@ -204,6 +234,7 @@ class PostOffice {
         this.interceptor = interceptor;
         this.sessionLoops = sessionLoops;
         this.clock = clock;
+        this.maxServerGrantedQos = maxServerGrantedQos;
 
         this.willExpirationService = new ScheduledExpirationService<>(clock, this::publishWill);
         recreateWillExpires(sessionRepository);
@@ -319,6 +350,7 @@ class PostOffice {
         } else {
             ackTopics = authorizator.verifyTopicsReadAccess(clientID, username, msg);
         }
+        ackTopics = updateWithMaximumSupportedQoS(ackTopics);
         MqttSubAckMessage ackMessage = doAckMessageFromValidateFilters(ackTopics, messageID);
 
         // store topics of non-shared subscriptions in session
@@ -364,6 +396,16 @@ class PostOffice {
         for (Subscription subscription : newSubscriptions) {
             interceptor.notifyTopicSubscribed(subscription, username);
         }
+    }
+
+    private List<MqttTopicSubscription> updateWithMaximumSupportedQoS(List<MqttTopicSubscription> subscriptions) {
+        return subscriptions.stream()
+            .map(s -> new MqttTopicSubscription(s.topicName(), minQos(s.qualityOfService(), maxServerGrantedQos)))
+            .collect(Collectors.toList());
+    }
+
+    private static MqttQoS minQos(MqttQoS q1, MqttQoS q2) {
+        return q1.value() < q2.value() ? q1 : q2;
     }
 
     private static Optional<SubscriptionIdentifier> verifyAndExtractMessageIdentifier(MqttSubscribeMessage msg) {

--- a/broker/src/main/java/io/moquette/broker/config/IConfig.java
+++ b/broker/src/main/java/io/moquette/broker/config/IConfig.java
@@ -64,6 +64,7 @@ public abstract class IConfig {
     public static final String KEY_STORE_PASSWORD_PROPERTY_NAME = "key_store_password";
     public static final String KEY_MANAGER_PASSWORD_PROPERTY_NAME = "key_manager_password";
     public static final String NETTY_MAX_BYTES_PROPERTY_NAME = "netty.mqtt.message_size";
+    public static final String MAX_SERVER_GRANTED_QOS_PROPERTY_NAME = "max_server_granted_qos";
     public static final int DEFAULT_NETTY_MAX_BYTES_IN_MESSAGE = 8092;
 
     public abstract void setProperty(String name, String value);

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
@@ -87,6 +87,11 @@ public class CTrieSubscriptionDirectory implements ISubscriptionsDirectory {
         final List<Subscription> subscriptions = matchWithoutQosSharpening(topicName);
 
         // for each session select the subscription with higher QoS
+        return selectSubscriptionsWithHigherQoSForEachSession(subscriptions);
+    }
+
+    private static List<Subscription> selectSubscriptionsWithHigherQoSForEachSession(List<Subscription> subscriptions) {
+        // for each session select the subscription with higher QoS
         Map<String, Subscription> subsGroupedByClient = new HashMap<>();
         for (Subscription sub : subscriptions) {
             // If same client is subscribed to two different shared subscription that overlaps

--- a/broker/src/test/resources/config/moquette.conf
+++ b/broker/src/test/resources/config/moquette.conf
@@ -23,3 +23,4 @@ allow_anonymous true
 
 reauthorize_subscriptions_on_connect false
 telemetry_enabled false
+max_server_granted_qos exactly_once

--- a/distribution/src/main/resources/moquette.conf
+++ b/distribution/src/main/resources/moquette.conf
@@ -213,3 +213,13 @@ password_file config/password_file.conf
 #*********************************************************************
 # persistent_client_expiration 3d
 
+#*********************************************************************
+# Maximum QoS that the server can grant (byu default it's QoS2)
+#
+# max_server_granted_qos:
+#       This option permit to customize the QoS that the broker can grant. By default it's QoS2 (exactly_once)
+#       but in certain circumstances could be limited by the server itself.
+#       Possible values are 0, 1, 2 or the extended string versions at_most_once, at_least_once, exactly_once.
+# default: 2 (exactly_once)
+#*********************************************************************
+# max_server_granted_qos 2


### PR DESCRIPTION
## Release notes
Exposed the maximum granted QoS by the server with the config setting 'max_server_granted_qos'.


## What does this PR do?
Updates the PostOffice when process the subscribe message to cap the QoS that the server would handle.

## Why is it important/What is the impact to the user?
Permit to the user to limit the capabilities of the server to limit the support qos level.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [x] I have updated the Changelog if it's a feature or a fix that has to be reported

## A
## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #808