### PR TITLE
Update subscription option handling to account no local

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -2,6 +2,7 @@ Version 0.18-SNAPSHOT:
    [feature] subscription option handling: (issue #808)
      - Move from qos to subscription option implementing the persistence of SubscriptionOption to/from storage. (#810)
      - Exposed the maximum granted QoS by the server with the config setting 'max_server_granted_qos'. (#811)
+     - Implements handling of noLocal subscription option on MQTT5 connections. (#814)
    [feature] subscription identifiers: (issue #801)
      - Implements the validation of subscription identifier properties in SUBSCRIBE. (#803)
      - Store and retrieve the subscription identifier into the subscriptions directory. (#804)

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -2,7 +2,7 @@ Version 0.18-SNAPSHOT:
    [feature] subscription option handling: (issue #808)
      - Move from qos to subscription option implementing the persistence of SubscriptionOption to/from storage. (#810)
      - Exposed the maximum granted QoS by the server with the config setting 'max_server_granted_qos'. (#811)
-     - Implements handling of noLocal subscription option on MQTT5 connections. (#814)
+     - Implements handling of noLocal subscription option on MQTT5 connections.  (#814)
    [feature] subscription identifiers: (issue #801)
      - Implements the validation of subscription identifier properties in SUBSCRIBE. (#803)
      - Store and retrieve the subscription identifier into the subscriptions directory. (#804)

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -19,6 +19,7 @@
              https://github.com/netty/netty/blob/netty-4.1.100.Final/pom.xml#L650 -->
         <netty.tcnative.version>2.0.61.Final</netty.tcnative.version>
         <paho.version>1.2.5</paho.version>
+        <paho.mttt5.version>1.2.5</paho.mttt5.version>
         <hivemqclient.version>1.3.3</hivemqclient.version>
         <h2.version>2.1.212</h2.version>
     </properties>
@@ -144,6 +145,13 @@
             <groupId>org.eclipse.paho</groupId>
             <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
             <version>${paho.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.paho</groupId>
+            <artifactId>org.eclipse.paho.mqttv5.client</artifactId>
+            <version>${paho.mttt5.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/broker/src/main/java/io/moquette/broker/Authorizator.java
+++ b/broker/src/main/java/io/moquette/broker/Authorizator.java
@@ -19,6 +19,7 @@ import io.moquette.broker.subscriptions.Topic;
 import io.moquette.broker.security.IAuthorizatorPolicy;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.handler.codec.mqtt.MqttSubscribeMessage;
+import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
 import io.netty.handler.codec.mqtt.MqttTopicSubscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,7 +75,8 @@ final class Authorizator {
             Topic topic = topicExtractor.apply(req.topicName());
             final MqttQoS qos = getQoSCheckingAlsoPermissionsOnTopic(clientID, username, messageId, topic,
                 req.qualityOfService());
-            ackTopics.add(new MqttTopicSubscription(req.topicName(), qos));
+            MqttSubscriptionOption option = PostOffice.optionWithQos(qos, req.option());
+            ackTopics.add(new MqttTopicSubscription(req.topicName(), option));
         }
         return ackTopics;
     }

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -132,7 +132,7 @@ final class MQTTConnection {
         this.postOffice.routeCommand(clientID, "PUBCOMP", () -> {
             checkMatchSessionLoop(clientID);
             bindedSession.processPubComp(messageID);
-            return clientID;
+            return null;
         });
     }
 

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -853,7 +853,7 @@ class PostOffice {
     /**
      * Route the command to the owning SessionEventLoop
      * */
-    public RouteResult routeCommand(String clientId, String actionDescription, Callable<String> action) {
+    public RouteResult routeCommand(String clientId, String actionDescription, Callable<Void> action) {
         return sessionLoops.routeCommand(clientId, actionDescription, action);
     }
 

--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -69,7 +69,6 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import static io.moquette.broker.Session.INFINITE_EXPIRY;
 import static io.moquette.logging.LoggingUtils.getInterceptorIds;
-import static io.netty.handler.codec.mqtt.MqttQoS.EXACTLY_ONCE;
 
 public class Server {
 

--- a/broker/src/main/java/io/moquette/broker/SessionCommand.java
+++ b/broker/src/main/java/io/moquette/broker/SessionCommand.java
@@ -6,10 +6,10 @@ import java.util.concurrent.CompletableFuture;
 final class SessionCommand {
 
     private final String sessionId;
-    private final Callable<String> action;
+    private final Callable<Void> action;
     private final CompletableFuture<String> task;
 
-    public  SessionCommand(String sessionId, Callable<String> action) {
+    public  SessionCommand(String sessionId, Callable<Void> action) {
         this.sessionId = sessionId;
         this.action = action;
         this.task = new CompletableFuture<>();

--- a/broker/src/main/java/io/moquette/broker/SessionEventLoopGroup.java
+++ b/broker/src/main/java/io/moquette/broker/SessionEventLoopGroup.java
@@ -59,7 +59,7 @@ class SessionEventLoopGroup {
     /**
      * Route the command to the owning SessionEventLoop
      */
-    public PostOffice.RouteResult routeCommand(String clientId, String actionDescription, Callable<String> action) {
+    public PostOffice.RouteResult routeCommand(String clientId, String actionDescription, Callable<Void> action) {
         SessionCommand cmd = new SessionCommand(clientId, action);
 
         if (clientId == null) {

--- a/broker/src/test/java/io/moquette/integration/mqtt5/SubscriptionOptionsTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/SubscriptionOptionsTest.java
@@ -1,0 +1,2 @@
+package io.moquette.integration.mqtt5;public class SubscriptionOptionsTest {
+}

--- a/broker/src/test/java/io/moquette/integration/mqtt5/SubscriptionOptionsTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/SubscriptionOptionsTest.java
@@ -1,2 +1,126 @@
-package io.moquette.integration.mqtt5;public class SubscriptionOptionsTest {
+/*
+ *
+ *  * Copyright (c) 2012-2024 The original author or authors
+ *  * ------------------------------------------------------
+ *  * All rights reserved. This program and the accompanying materials
+ *  * are made available under the terms of the Eclipse Public License v1.0
+ *  * and Apache License v2.0 which accompanies this distribution.
+ *  *
+ *  * The Eclipse Public License is available at
+ *  * http://www.eclipse.org/legal/epl-v10.html
+ *  *
+ *  * The Apache License v2.0 is available at
+ *  * http://www.opensource.org/licenses/apache2.0.php
+ *  *
+ *  * You may elect to redistribute this code under either of these licenses.
+ *
+ */
+
+package io.moquette.integration.mqtt5;
+
+import com.hivemq.client.mqtt.datatypes.MqttQos;
+import com.hivemq.client.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAckReasonCode;
+import org.eclipse.paho.mqttv5.client.IMqttMessageListener;
+import org.eclipse.paho.mqttv5.client.IMqttToken;
+import org.eclipse.paho.mqttv5.client.MqttClient;
+import org.eclipse.paho.mqttv5.client.persist.MemoryPersistence;
+import org.eclipse.paho.mqttv5.common.MqttException;
+import org.eclipse.paho.mqttv5.common.MqttMessage;
+import org.eclipse.paho.mqttv5.common.MqttSubscription;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class SubscriptionOptionsTest extends AbstractSubscriptionIntegrationTest {
+
+    @Override
+    public String clientName() {
+        return "client";
+    }
+
+    static class PublishCollector implements IMqttMessageListener {
+        private final CountDownLatch latch = new CountDownLatch(1);
+        private String receivedTopic;
+        private MqttMessage receivedMessage;
+
+        @Override
+        public void messageArrived(String topic, MqttMessage message) throws Exception {
+            latch.countDown();
+            receivedTopic = topic;
+            receivedMessage = message;
+        }
+
+        public String receivedPayload() {
+            return new String(receivedMessage.getPayload(), StandardCharsets.UTF_8);
+        }
+
+        public void assertReceivedMessageIn(int time, TimeUnit unit) {
+            try {
+                assertTrue(latch.await(time, unit), "Publish is received");
+            } catch (InterruptedException e) {
+                fail("Wait for message was interrupted");
+            }
+        }
+
+        public void assertNotReceivedMessageIn(int time, TimeUnit unit) {
+            try {
+                assertFalse(latch.await(time, unit), "Publish MUSTN'T be received");
+            } catch (InterruptedException e) {
+                fail("Wait for message was interrupted");
+            }
+        }
+    }
+
+    @Test
+    public void givenSubscriptionWithNoLocalEnabledWhenTopicMatchPublishByItselfThenNoPublishAreSentBackToSubscriber() throws MqttException {
+        MqttClient client = new MqttClient("tcp://localhost:1883", "subscriber", new MemoryPersistence());
+        client.connect();
+        MqttSubscription subscription = new MqttSubscription("/metering/temp", 1);
+        subscription.setNoLocal(true);
+
+        PublishCollector publishCollector = new PublishCollector();
+        IMqttToken subscribeToken = client.subscribe(new MqttSubscription[]{subscription},
+            new IMqttMessageListener[] {publishCollector});
+        verifySubscribedSuccessfully(subscribeToken);
+
+        // publish a message on same topic the client subscribed
+        client.publish("/metering/temp", new MqttMessage("18".getBytes(StandardCharsets.UTF_8), 1, false, null));
+
+        // Verify no message is reflected back to the sender
+        publishCollector.assertNotReceivedMessageIn(2, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void givenSubscriptionWithNoLocalDisabledWhenTopicMatchPublishByItselfThenAPublishAreSentBackToSubscriber() throws MqttException {
+        MqttClient client = new MqttClient("tcp://localhost:1883", "subscriber", new MemoryPersistence());
+        client.connect();
+        MqttSubscription subscription = new MqttSubscription("/metering/temp", 1);
+//        subscription.setNoLocal(false);
+        PublishCollector publishCollector = new PublishCollector();
+        IMqttToken subscribeToken = client.subscribe(new MqttSubscription[]{subscription},
+            new IMqttMessageListener[] {publishCollector});
+        verifySubscribedSuccessfully(subscribeToken);
+
+        // publish a message on same topic the client subscribed
+        client.publish("/metering/temp", new MqttMessage("18".getBytes(StandardCharsets.UTF_8), 1, false, null));
+
+        // Verify the message is also reflected back to the sender
+        publishCollector.assertReceivedMessageIn(2, TimeUnit.SECONDS);
+        assertEquals("/metering/temp", publishCollector.receivedTopic);
+        assertEquals("18", publishCollector.receivedPayload(), "Payload published on topic should match");
+        assertEquals(MqttQos.AT_LEAST_ONCE.getCode(), publishCollector.receivedMessage.getQos());
+    }
+
+    private static void verifySubscribedSuccessfully(IMqttToken subscribeToken) {
+        assertEquals(1, subscribeToken.getReasonCodes().length);
+        assertEquals(Mqtt5SubAckReasonCode.GRANTED_QOS_1.getCode(), subscribeToken.getReasonCodes()[0],
+            "Client is subscribed to the topic");
+    }
 }


### PR DESCRIPTION
## Release notes
Implements handling of noLocal subscription option on MQTT5 connections.


## What does this PR do?
- Updates the Callable signature used by routing to return Void instead of String.
- Updates the publishing of messages to subscribers to exclude or not from the target the clientId of the sender, depending on the status of `noLocal` in the target subscription.
- Added integration test to proof the change

## Why is it important/What is the impact to the user?
`noLocal` option is handled.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the Changelog if it's a feature or a fix that has to be reported

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #808 

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->
