### PR TITLE
Updates retained messages management to hanbdle message expiry interval

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,6 @@
 Version 0.18-SNAPSHOT:
+   [feature] message expiry interval: (issue #818)
+     - Implements the management of message expiry for retained part. (#819)
    [feature] subscription option handling: (issue #808)
      - Move from qos to subscription option implementing the persistence of SubscriptionOption to/from storage. (#810)
      - Exposed the maximum granted QoS by the server with the config setting 'max_server_granted_qos'. (#811)

--- a/broker/src/main/java/io/moquette/broker/IRetainedRepository.java
+++ b/broker/src/main/java/io/moquette/broker/IRetainedRepository.java
@@ -18,14 +18,16 @@ package io.moquette.broker;
 import io.moquette.broker.subscriptions.Topic;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 
+import java.time.Instant;
 import java.util.Collection;
-import java.util.List;
 
 public interface IRetainedRepository {
 
     void cleanRetained(Topic topic);
 
     void retain(Topic topic, MqttPublishMessage msg);
+
+    void retain(Topic topic, MqttPublishMessage msg, Instant expiryTime);
 
     boolean isEmpty();
 
@@ -36,4 +38,9 @@ public interface IRetainedRepository {
      * @return the unordered collection of retained messages on the topic.
      * */
     Collection<RetainedMessage> retainedOnTopic(String topic);
+
+    /**
+     * @return collection of RetainedMessage with a message expiry time configured.
+     * */
+    Collection<RetainedMessage> listExpirable();
 }

--- a/broker/src/main/java/io/moquette/broker/RetainedMessage.java
+++ b/broker/src/main/java/io/moquette/broker/RetainedMessage.java
@@ -4,17 +4,24 @@ import io.moquette.broker.subscriptions.Topic;
 import io.netty.handler.codec.mqtt.MqttQoS;
 
 import java.io.Serializable;
+import java.time.Instant;
 
 public class RetainedMessage implements Serializable{
 
     private final Topic topic;
     private final MqttQoS qos;
     private final byte[] payload;
+    private Instant expiryTime;
 
     public RetainedMessage(Topic topic, MqttQoS qos, byte[] payload) {
         this.topic = topic;
         this.qos = qos;
         this.payload = payload;
+    }
+
+    public RetainedMessage(Topic topic, MqttQoS qos, byte[] rawPayload, Instant expiryTime) {
+        this(topic, qos, rawPayload);
+        this.expiryTime = expiryTime;
     }
 
     public Topic getTopic() {
@@ -27,5 +34,9 @@ public class RetainedMessage implements Serializable{
 
     public byte[] getPayload() {
         return payload;
+    }
+
+    public Instant getExpiryTime() {
+        return expiryTime;
     }
 }

--- a/broker/src/main/java/io/moquette/persistence/H2RetainedRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/H2RetainedRepository.java
@@ -8,6 +8,7 @@ import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -15,42 +16,69 @@ import java.util.Map;
 
 public class H2RetainedRepository implements IRetainedRepository {
 
-    private final MVMap<Topic, RetainedMessage> queueMap;
+    private final MVMap<Topic, RetainedMessage> retainedMap;
+    private final MVMap<Topic, RetainedMessage> retainedExpireMap;
 
     public H2RetainedRepository(MVStore mvStore) {
-        this.queueMap = mvStore.openMap("retained_store");
+        this.retainedMap = mvStore.openMap("retained_store");
+        this.retainedExpireMap = mvStore.openMap("retained_expiry_store");
     }
 
     @Override
     public void cleanRetained(Topic topic) {
-        queueMap.remove(topic);
+        retainedMap.remove(topic);
+        retainedExpireMap.remove(topic);
     }
 
     @Override
     public void retain(Topic topic, MqttPublishMessage msg) {
+        byte[] rawPayload = payloadToByteArray(msg);
+        final RetainedMessage toStore = new RetainedMessage(topic, msg.fixedHeader().qosLevel(), rawPayload);
+        retainedMap.put(topic, toStore);
+    }
+
+    @Override
+    public void retain(Topic topic, MqttPublishMessage msg, Instant expiryTime) {
+        byte[] rawPayload = payloadToByteArray(msg);
+        final RetainedMessage toStore = new RetainedMessage(topic, msg.fixedHeader().qosLevel(), rawPayload, expiryTime);
+        retainedExpireMap.put(topic, toStore);
+    }
+
+    private static byte[] payloadToByteArray(MqttPublishMessage msg) {
         final ByteBuf payload = msg.content();
         byte[] rawPayload = new byte[payload.readableBytes()];
         payload.getBytes(0, rawPayload);
-        final RetainedMessage toStore = new RetainedMessage(topic, msg.fixedHeader().qosLevel(), rawPayload);
-        queueMap.put(topic, toStore);
+        return rawPayload;
     }
 
     @Override
     public boolean isEmpty() {
-        return queueMap.isEmpty();
+        return retainedMap.isEmpty() && retainedExpireMap.isEmpty();
     }
 
     @Override
     public Collection<RetainedMessage> retainedOnTopic(String topic) {
         final Topic searchTopic = new Topic(topic);
         final List<RetainedMessage> matchingMessages = new ArrayList<>();
-        for (Map.Entry<Topic, RetainedMessage> entry : queueMap.entrySet()) {
+        matchingMessages.addAll(findMatching(searchTopic, retainedMap));
+        matchingMessages.addAll(findMatching(searchTopic, retainedExpireMap));
+
+        return matchingMessages;
+    }
+
+    private List<RetainedMessage> findMatching(Topic searchTopic, MVMap<Topic, RetainedMessage> mapToSearch) {
+        final List<RetainedMessage> matchingMessages = new ArrayList<>();
+        for (Map.Entry<Topic, RetainedMessage> entry : mapToSearch.entrySet()) {
             final Topic scanTopic = entry.getKey();
             if (scanTopic.match(searchTopic)) {
                 matchingMessages.add(entry.getValue());
             }
         }
-
         return matchingMessages;
+    }
+
+    @Override
+    public Collection<RetainedMessage> listExpirable() {
+        return retainedExpireMap.values();
     }
 }

--- a/broker/src/test/java/io/moquette/integration/mqtt5/AbstractServerIntegrationTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/AbstractServerIntegrationTest.java
@@ -1,21 +1,38 @@
 package io.moquette.integration.mqtt5;
 
+import com.hivemq.client.mqtt.MqttClient;
+import com.hivemq.client.mqtt.MqttGlobalPublishFilter;
+import com.hivemq.client.mqtt.datatypes.MqttQos;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5BlockingClient;
+import com.hivemq.client.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAckReasonCode;
+import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish;
 import io.moquette.broker.Server;
 import io.moquette.broker.config.IConfig;
 import io.moquette.broker.config.MemoryConfig;
 import io.moquette.integration.IntegrationUtils;
 import io.moquette.testclient.Client;
+import io.netty.handler.codec.mqtt.MqttConnAckMessage;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttMessageType;
 import org.awaitility.Awaitility;
 import org.awaitility.Durations;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static io.moquette.integration.mqtt5.ConnectTest.assertConnectionAccepted;
+import static org.junit.jupiter.api.Assertions.*;
 
 public abstract class AbstractServerIntegrationTest {
     Server broker;
@@ -26,6 +43,59 @@ public abstract class AbstractServerIntegrationTest {
     protected String dbPath;
 
     Client lowLevelClient;
+
+    @NotNull
+    static Mqtt5BlockingClient createSubscriberClient(String clientId) {
+        final Mqtt5BlockingClient client = MqttClient.builder()
+            .useMqttVersion5()
+            .identifier(clientId)
+            .serverHost("localhost")
+            .serverPort(1883)
+            .buildBlocking();
+        assertEquals(Mqtt5ConnAckReasonCode.SUCCESS, client.connect().getReasonCode(), clientId + " connected");
+        return client;
+    }
+
+    @NotNull
+    static Mqtt5BlockingClient createPublisherClient() {
+        return AbstractSubscriptionIntegrationTest.createClientWithStartFlagAndClientId(true, "publisher");
+    }
+
+    protected static void verifyNoPublish(Mqtt5BlockingClient subscriber, Consumer<Void> action, Duration timeout, String message) throws InterruptedException {
+        try (Mqtt5BlockingClient.Mqtt5Publishes publishes = subscriber.publishes(MqttGlobalPublishFilter.ALL)) {
+            action.accept(null);
+            Optional<Mqtt5Publish> publishedMessage = publishes.receive(timeout.getSeconds(), TimeUnit.SECONDS);
+
+            // verify no published will in 10 seconds
+            assertFalse(publishedMessage.isPresent(), message);
+        }
+    }
+
+    protected static void verifyPublishedMessage(Mqtt5BlockingClient client, Consumer<Void> action, MqttQos expectedQos,
+                                                 String expectedPayload, String errorMessage, int timeoutSeconds) throws Exception {
+        try (Mqtt5BlockingClient.Mqtt5Publishes publishes = client.publishes(MqttGlobalPublishFilter.ALL)) {
+            action.accept(null);
+            Optional<Mqtt5Publish> publishMessage = publishes.receive(timeoutSeconds, TimeUnit.SECONDS);
+            if (!publishMessage.isPresent()) {
+                fail("Expected to receive a publish message");
+                return;
+            }
+            Mqtt5Publish msgPub = publishMessage.get();
+            final String payload = new String(msgPub.getPayloadAsBytes(), StandardCharsets.UTF_8);
+            assertEquals(expectedPayload, payload, errorMessage);
+            assertEquals(expectedQos, msgPub.getQos());
+        }
+    }
+
+    static void verifyOfType(MqttMessage received, MqttMessageType mqttMessageType) {
+        assertEquals(mqttMessageType, received.fixedHeader().messageType());
+    }
+
+    @NotNull
+    Mqtt5BlockingClient createSubscriberClient() {
+        String clientId = clientName();
+        return createSubscriberClient(clientId);
+    }
 
     public abstract String clientName();
 
@@ -63,5 +133,10 @@ public abstract class AbstractServerIntegrationTest {
         stopServer();
         Thread.sleep(timeout.toMillis());
         startServer(dbPath);
+    }
+
+    void connectLowLevel() {
+        MqttConnAckMessage connAck = lowLevelClient.connectV5();
+        assertConnectionAccepted(connAck, "Connection must be accepted");
     }
 }

--- a/broker/src/test/java/io/moquette/integration/mqtt5/AbstractSubscriptionIntegrationTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/AbstractSubscriptionIntegrationTest.java
@@ -4,42 +4,11 @@ import com.hivemq.client.mqtt.MqttClient;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5BlockingClient;
 import com.hivemq.client.mqtt.mqtt5.message.connect.Mqtt5Connect;
 import com.hivemq.client.mqtt.mqtt5.message.connect.connack.Mqtt5ConnAckReasonCode;
-import io.netty.handler.codec.mqtt.MqttConnAckMessage;
-import io.netty.handler.codec.mqtt.MqttMessage;
-import io.netty.handler.codec.mqtt.MqttMessageType;
 import org.jetbrains.annotations.NotNull;
 
-import static io.moquette.integration.mqtt5.ConnectTest.assertConnectionAccepted;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 abstract class AbstractSubscriptionIntegrationTest extends AbstractServerIntegrationTest {
-
-    static void verifyOfType(MqttMessage received, MqttMessageType mqttMessageType) {
-        assertEquals(mqttMessageType, received.fixedHeader().messageType());
-    }
-
-    void connectLowLevel() {
-        MqttConnAckMessage connAck = lowLevelClient.connectV5();
-        assertConnectionAccepted(connAck, "Connection must be accepted");
-    }
-
-    @NotNull
-    static Mqtt5BlockingClient createSubscriberClient(String clientId) {
-        final Mqtt5BlockingClient client = MqttClient.builder()
-            .useMqttVersion5()
-            .identifier(clientId)
-            .serverHost("localhost")
-            .serverPort(1883)
-            .buildBlocking();
-        assertEquals(Mqtt5ConnAckReasonCode.SUCCESS, client.connect().getReasonCode(), clientId + " connected");
-        return client;
-    }
-
-    @NotNull
-    Mqtt5BlockingClient createSubscriberClient() {
-        String clientId = clientName();
-        return createSubscriberClient(clientId);
-    }
 
     @NotNull
     static Mqtt5BlockingClient createCleanStartClient(String clientId) {
@@ -49,11 +18,6 @@ abstract class AbstractSubscriptionIntegrationTest extends AbstractServerIntegra
     @NotNull
     static Mqtt5BlockingClient createNonCleanStartClient(String clientId) {
         return createClientWithStartFlagAndClientId(false, clientId);
-    }
-
-    @NotNull
-    static Mqtt5BlockingClient createPublisherClient() {
-        return createClientWithStartFlagAndClientId(true, "publisher");
     }
 
     @NotNull

--- a/broker/src/test/java/io/moquette/integration/mqtt5/ConnectTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/ConnectTest.java
@@ -186,16 +186,6 @@ class ConnectTest extends AbstractServerIntegrationTest {
         verifyNoPublish(testamentSubscriber, action, timeout, "No will message should be published");
     }
 
-    protected static void verifyNoPublish(Mqtt5BlockingClient subscriber, Consumer<Void> action, Duration timeout, String message) throws InterruptedException {
-        try (Mqtt5BlockingClient.Mqtt5Publishes publishes = subscriber.publishes(MqttGlobalPublishFilter.ALL)) {
-            action.accept(null);
-            Optional<Mqtt5Publish> publishedMessage = publishes.receive(timeout.getSeconds(), TimeUnit.SECONDS);
-
-            // verify no published will in 10 seconds
-            assertFalse(publishedMessage.isPresent(), message);
-        }
-    }
-
     @Test
     public void fireWillWhenSessionExpiresIfItHappenBeforeWillDelay() throws InterruptedException {
         final String clientId = "simple_client";

--- a/broker/src/test/java/io/moquette/integration/mqtt5/MessageExpirationTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/MessageExpirationTest.java
@@ -1,0 +1,102 @@
+/*
+ *
+ *  * Copyright (c) 2012-2024 The original author or authors
+ *  * ------------------------------------------------------
+ *  * All rights reserved. This program and the accompanying materials
+ *  * are made available under the terms of the Eclipse Public License v1.0
+ *  * and Apache License v2.0 which accompanies this distribution.
+ *  *
+ *  * The Eclipse Public License is available at
+ *  * http://www.eclipse.org/legal/epl-v10.html
+ *  *
+ *  * The Apache License v2.0 is available at
+ *  * http://www.opensource.org/licenses/apache2.0.php
+ *  *
+ *  * You may elect to redistribute this code under either of these licenses.
+ *
+ */
+
+package io.moquette.integration.mqtt5;
+
+import com.hivemq.client.mqtt.datatypes.MqttQos;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5BlockingClient;
+import io.netty.handler.codec.mqtt.*;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static io.moquette.integration.mqtt5.ConnectTest.verifyNoPublish;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MessageExpirationTest extends AbstractServerIntegrationTest {
+    @Override
+    public String clientName() {
+        return "subscriber";
+    }
+
+    @Test
+    public void givenPublishWithRetainedAndMessageExpiryWhenTimePassedThenRetainedIsNotForwardedOnSubscription() throws InterruptedException {
+        Mqtt5BlockingClient publisher = createPublisherClient();
+        int messageExpiryInterval = 3; //seconds
+        publisher.publishWith()
+            .topic("temperature/living")
+            .payload("18".getBytes(StandardCharsets.UTF_8))
+            .qos(MqttQos.AT_LEAST_ONCE) // Broker retains only QoS1 and QoS2
+            .retain(true)
+            .messageExpiryInterval(messageExpiryInterval)
+            .send();
+
+        // let the message expire, wait
+        Thread.sleep((messageExpiryInterval + 1) * 1000);
+
+        // subscribe to same topic and verify no message
+        Mqtt5BlockingClient subscriber = createSubscriberClient();
+        subscriber.subscribeWith()
+            .topicFilter("temperature/living")
+            .qos(MqttQos.AT_MOST_ONCE)
+            .send();
+
+        verifyNoPublish(subscriber, v -> {}, Duration.ofSeconds(2),
+            "Subscriber must not receive any retained message");
+    }
+
+    // TODO verify the elapsed
+    @Test
+    public void givenPublishWithRetainedAndMessageExpiryWhenTimeIsNotExpiredAndSubscriberConnectThenPublishWithRemainingExpiryShouldBeSent() throws Exception {
+        Mqtt5BlockingClient publisher = createPublisherClient();
+        int messageExpiryInterval = 3; //seconds
+        publisher.publishWith()
+            .topic("temperature/living")
+            .payload("18".getBytes(StandardCharsets.UTF_8))
+            .qos(MqttQos.AT_LEAST_ONCE) // Broker retains only QoS1 and QoS2
+            .retain(true)
+            .messageExpiryInterval(messageExpiryInterval)
+            .send();
+
+        Thread.sleep(1_000);
+
+        // subscribe to same topic and verify publish message is received
+        connectLowLevel();
+
+        // subscribe with an identifier
+        MqttMessage received = lowLevelClient.subscribeWithIdentifier("temperature/living",
+            MqttQoS.AT_LEAST_ONCE, 123);
+        verifyOfType(received, MqttMessageType.SUBACK);
+
+        // receive a publish message on the subscribed topic
+        Awaitility.await()
+            .atMost(2, TimeUnit.SECONDS)
+            .until(lowLevelClient::hasReceivedMessages);
+        MqttMessage mqttMsg = lowLevelClient.receiveNextMessage(Duration.ofSeconds(1));
+        verifyOfType(mqttMsg, MqttMessageType.PUBLISH);
+        MqttPublishMessage publish = (MqttPublishMessage) mqttMsg;
+        MqttProperties.MqttProperty<Integer> messageExpiryProperty = publish.variableHeader()
+            .properties()
+            .getProperty(MqttProperties.MqttPropertyType.PUBLICATION_EXPIRY_INTERVAL.value());
+        assertNotNull(messageExpiryProperty, "message expiry property must be present");
+        assertTrue(messageExpiryProperty.value() < messageExpiryInterval, "Forwarded message expiry should be lowered");
+    }
+}

--- a/broker/src/test/java/io/moquette/integration/mqtt5/SharedSubscriptionTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/SharedSubscriptionTest.java
@@ -1,9 +1,7 @@
 package io.moquette.integration.mqtt5;
 
-import com.hivemq.client.mqtt.MqttGlobalPublishFilter;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5BlockingClient;
-import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish;
 import com.hivemq.client.mqtt.mqtt5.message.unsubscribe.unsuback.Mqtt5UnsubAck;
 import com.hivemq.client.mqtt.mqtt5.message.unsubscribe.unsuback.Mqtt5UnsubAckReasonCode;
 import io.moquette.broker.Server;
@@ -29,12 +27,8 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
-import static io.moquette.integration.mqtt5.ConnectTest.verifyNoPublish;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -186,22 +180,6 @@ public class SharedSubscriptionTest extends AbstractSubscriptionIntegrationTest 
         String payload = pub.payload().asByteBuf().toString(StandardCharsets.UTF_8);
         assertEquals(expectedPayload, payload);
         assertTrue(pub.release(), "received message must be deallocated");
-    }
-
-    private static void verifyPublishedMessage(Mqtt5BlockingClient client, Consumer<Void> action, MqttQos expectedQos,
-                                               String expectedPayload, String errorMessage, int timeoutSeconds) throws Exception {
-        try (Mqtt5BlockingClient.Mqtt5Publishes publishes = client.publishes(MqttGlobalPublishFilter.ALL)) {
-            action.accept(null);
-            Optional<Mqtt5Publish> publishMessage = publishes.receive(timeoutSeconds, TimeUnit.SECONDS);
-            if (!publishMessage.isPresent()) {
-                fail("Expected to receive a publish message");
-                return;
-            }
-            Mqtt5Publish msgPub = publishMessage.get();
-            final String payload = new String(msgPub.getPayloadAsBytes(), StandardCharsets.UTF_8);
-            assertEquals(expectedPayload, payload, errorMessage);
-            assertEquals(expectedQos, msgPub.getQos());
-        }
     }
 
     @Test


### PR DESCRIPTION
## Release notes
Implements the management of message expiry for retained part.

## What does this PR do?

Update retained messages handling to store and retrieve the message expiry property if present in publish.
- updates retained persistence store, list and retrieve the expiry
- updated PostOffice to track and untrack retained messages that has to be wipe. A new instance of ScheduledExpirationService is reserved for this.
- during push of retained recalculate the message expiry interval

## Why is it important/What is the impact to the user?

Implements message expiry feature for retained messages aspect.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the Changelog if it's a feature or a fix that has to be reported

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #818
