### PR TITLE
Feature/message expiry for queued

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,8 +1,8 @@
 Version 0.18-SNAPSHOT:
-   [feature] Avoid to publish messages that has elapsed its expire property. (#822)
    [feature] Add Netty native trsansport support on MacOS. Bundle all the native transport module by default (#806)
    [feature] message expiry interval: (issue #818)
      - Implements the management of message expiry for retained part. (#819)
+     - Avoid to publish messages that has elapsed its expire property. (#822)
    [feature] subscription option handling: (issue #808)
      - Move from qos to subscription option implementing the persistence of SubscriptionOption to/from storage. (#810)
      - Exposed the maximum granted QoS by the server with the config setting 'max_server_granted_qos'. (#811)

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.18-SNAPSHOT:
+   [feature] Avoid to publish messages that has elapsed its expire property. (#822)
    [feature] Add Netty native trsansport support on MacOS. Bundle all the native transport module by default (#806)
    [feature] message expiry interval: (issue #818)
      - Implements the management of message expiry for retained part. (#819)

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -851,7 +851,8 @@ class PostOffice {
             LOG.debug("Sending PUBLISH message to active subscriber CId: {}, topicFilter: {}, qos: {}",
                       sub.getClientId(), sub.getTopicFilter(), qos);
             final MqttProperties.MqttProperty[] properties = prepareSubscriptionProperties(sub);
-            targetSession.sendPublishOnSessionAtQos(topic, qos, payload, retained, properties);
+            final SessionRegistry.PublishedMessage publishedMessage = new SessionRegistry.PublishedMessage(topic, qos, payload, retained, properties);
+            targetSession.sendPublishOnSessionAtQos(publishedMessage);
         } else {
             // If we are, the subscriber disconnected after the subscriptions tree selected that session as a
             // destination.

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -241,62 +241,60 @@ class Session {
 
     public void sendRetainedPublishOnSessionAtQos(Topic topic, MqttQoS qos, ByteBuf payload,
                                                   MqttProperties.MqttProperty... mqttProperties) {
-        sendPublishOnSessionAtQos(topic, qos, payload, true, mqttProperties);
+        final PublishedMessage publishedMessage = new PublishedMessage(topic, qos, payload, true, mqttProperties);
+        sendPublishOnSessionAtQos(publishedMessage);
     }
 
-    void sendPublishOnSessionAtQos(Topic topic, MqttQoS qos, ByteBuf payload, boolean retained,
-                                   MqttProperties.MqttProperty... mqttProperties) {
-        switch (qos) {
+    void sendPublishOnSessionAtQos(PublishedMessage publishRequest) {
+        switch (publishRequest.getPublishingQos()) {
             case AT_MOST_ONCE:
                 if (connected()) {
-                    sendPublishQos0(topic, qos, payload, retained, mqttProperties);
+                    sendPublishQos0(publishRequest);
                 }
                 break;
             case AT_LEAST_ONCE:
-                sendPublishQos1(topic, qos, payload, retained, mqttProperties);
+                sendPublishQos1(publishRequest);
                 break;
             case EXACTLY_ONCE:
-                sendPublishQos2(topic, qos, payload, retained, mqttProperties);
+                sendPublishQos2(publishRequest);
                 break;
             case FAILURE:
                 LOG.error("Not admissible");
         }
     }
 
-    private void sendPublishQos0(Topic topic, MqttQoS qos, ByteBuf payload, boolean retained,
-                                 MqttProperties.MqttProperty... mqttProperties) {
-        MqttPublishMessage publishMsg = MQTTConnection.createPublishMessage(topic.toString(), qos, payload, 0,
-            retained, false, mqttProperties);
+    private void sendPublishQos0(PublishedMessage publishRequest) {
+        MqttPublishMessage publishMsg = MQTTConnection.createPublishMessage(publishRequest.getTopic().toString(),
+            publishRequest.getPublishingQos(), publishRequest.getPayload(), 0,
+            publishRequest.retained, false, publishRequest.mqttProperties);
         mqttConnection.sendPublish(publishMsg);
     }
 
-    private void sendPublishQos1(Topic topic, MqttQoS qos, ByteBuf payload, boolean retained,
-                                 MqttProperties.MqttProperty... mqttProperties) {
+    private void sendPublishQos1(PublishedMessage publishRequest) {
         if (!connected() && isClean()) {
             //pushing messages to disconnected not clean session
             return;
         }
 
         final MQTTConnection localMqttConnectionRef = mqttConnection;
-        sendPublishInFlightWindowOrQueueing(topic, qos, payload, retained, localMqttConnectionRef, mqttProperties);
+        sendPublishInFlightWindowOrQueueing(localMqttConnectionRef, publishRequest);
     }
 
-    private void sendPublishQos2(Topic topic, MqttQoS qos, ByteBuf payload, boolean retained,
-                                 MqttProperties.MqttProperty... mqttProperties) {
+    private void sendPublishQos2(PublishedMessage publishRequest) {
         final MQTTConnection localMqttConnectionRef = mqttConnection;
-        sendPublishInFlightWindowOrQueueing(topic, qos, payload, retained, localMqttConnectionRef, mqttProperties);
+        sendPublishInFlightWindowOrQueueing(localMqttConnectionRef, publishRequest);
     }
 
-    private void sendPublishInFlightWindowOrQueueing(Topic topic, MqttQoS qos, ByteBuf payload, boolean retained,
-                                                     MQTTConnection localMqttConnectionRef,
-                                                     MqttProperties.MqttProperty... mqttProperties) {
+    private void sendPublishInFlightWindowOrQueueing(MQTTConnection localMqttConnectionRef,
+                                                     PublishedMessage publishRequest) {
+        // retain the payload because it's going to be added to map or to the queue.
+        publishRequest.retain();
+
         if (canSkipQueue(localMqttConnectionRef)) {
             inflightSlots.decrementAndGet();
             int packetId = localMqttConnectionRef.nextPacketId();
 
-            // Retain before adding to map
-            payload.retain();
-            EnqueuedMessage old = inflightWindow.put(packetId, new PublishedMessage(topic, qos, payload, retained, mqttProperties));
+            EnqueuedMessage old = inflightWindow.put(packetId, publishRequest);
             // If there already was something, release it.
             if (old != null) {
                 old.release();
@@ -305,17 +303,15 @@ class Session {
             if (resendInflightOnTimeout) {
                 inflightTimeouts.add(new InFlightPacket(packetId, FLIGHT_BEFORE_RESEND_MS));
             }
-            MqttPublishMessage publishMsg = MQTTConnection.createPublishMessage(topic.toString(), qos,
-                payload, packetId, retained, false, mqttProperties);
+            MqttPublishMessage publishMsg = MQTTConnection.createPublishMessage(
+                publishRequest.topic.toString(), publishRequest.getPublishingQos(),
+                publishRequest.payload, packetId, publishRequest.retained, false, publishRequest.mqttProperties);
             localMqttConnectionRef.sendPublish(publishMsg);
 
             drainQueueToConnection();
         } else {
-            final PublishedMessage msg = new PublishedMessage(topic, qos, payload, retained, mqttProperties);
-            // Adding to a queue, retain.
-            msg.retain();
-            sessionQueue.enqueue(msg);
-            LOG.debug("Enqueue to peer session {} at QoS {}", getClientID(), qos);
+            sessionQueue.enqueue(publishRequest);
+            LOG.debug("Enqueue to peer session {} at QoS {}", getClientID(), publishRequest.getPublishingQos());
         }
     }
 

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -70,14 +70,16 @@ public class SessionRegistry {
         final MqttQoS publishingQos;
         final ByteBuf payload;
         final boolean retained;
+        final Instant messageExpiry;
         final MqttProperties.MqttProperty[] mqttProperties;
 
         public PublishedMessage(Topic topic, MqttQoS publishingQos, ByteBuf payload, boolean retained,
-                                MqttProperties.MqttProperty... mqttProperties) {
+                                Instant messageExpiry, MqttProperties.MqttProperty... mqttProperties) {
             this.topic = topic;
             this.publishingQos = publishingQos;
             this.payload = payload;
             this.retained = retained; // TODO has to store retained param into the field
+            this.messageExpiry = messageExpiry;
             this.mqttProperties = mqttProperties;
         }
 
@@ -105,6 +107,10 @@ public class SessionRegistry {
 
         public MqttProperties.MqttProperty[] getMqttProperties() {
             return mqttProperties;
+        }
+
+        public boolean isExpired() {
+            return messageExpiry != Instant.MAX && Instant.now().isAfter(messageExpiry);
         }
     }
 

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -77,7 +77,7 @@ public class SessionRegistry {
             this.topic = topic;
             this.publishingQos = publishingQos;
             this.payload = payload;
-            this.retained = false; // TODO has to store retained param into the field
+            this.retained = retained; // TODO has to store retained param into the field
             this.mqttProperties = mqttProperties;
         }
 

--- a/broker/src/main/java/io/moquette/persistence/EnqueuedMessageValueType.java
+++ b/broker/src/main/java/io/moquette/persistence/EnqueuedMessageValueType.java
@@ -25,6 +25,7 @@ import org.h2.mvstore.WriteBuffer;
 import org.h2.mvstore.type.StringDataType;
 
 import java.nio.ByteBuffer;
+import java.time.Instant;
 
 import org.h2.mvstore.DataUtils;
 import org.h2.mvstore.type.BasicDataType;
@@ -100,9 +101,9 @@ public final class EnqueuedMessageValueType extends BasicDataType<EnqueuedMessag
             final ByteBuf payload = payloadDataType.read(buff);
             if (SerdesUtils.containsProperties(buff)) {
                 MqttProperties.MqttProperty[] mqttProperties = propertiesDataType.read(buff);
-                return new SessionRegistry.PublishedMessage(Topic.asTopic(topicStr), qos, payload, false, mqttProperties);
+                return new SessionRegistry.PublishedMessage(Topic.asTopic(topicStr), qos, payload, false, Instant.MAX, mqttProperties);
             } else {
-                return new SessionRegistry.PublishedMessage(Topic.asTopic(topicStr), qos, payload, false);
+                return new SessionRegistry.PublishedMessage(Topic.asTopic(topicStr), qos, payload, false, Instant.MAX);
             }
         } else {
             throw new IllegalArgumentException("Can't recognize record of type: " + messageType);

--- a/broker/src/main/java/io/moquette/persistence/SegmentedPersistentQueueSerDes.java
+++ b/broker/src/main/java/io/moquette/persistence/SegmentedPersistentQueueSerDes.java
@@ -9,6 +9,7 @@ import io.netty.handler.codec.mqtt.MqttQoS;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Arrays;
 
 class SegmentedPersistentQueueSerDes {
@@ -166,9 +167,9 @@ class SegmentedPersistentQueueSerDes {
             final ByteBuf payload = readPayload(buff);
             if (SerdesUtils.containsProperties(buff)) {
                 MqttProperties.MqttProperty[] mqttProperties = readProperties(buff);
-                return new SessionRegistry.PublishedMessage(Topic.asTopic(topicStr), qos, payload, false, mqttProperties);
+                return new SessionRegistry.PublishedMessage(Topic.asTopic(topicStr), qos, payload, false, Instant.MAX, mqttProperties);
             } else {
-                return new SessionRegistry.PublishedMessage(Topic.asTopic(topicStr), qos, payload, false);
+                return new SessionRegistry.PublishedMessage(Topic.asTopic(topicStr), qos, payload, false, Instant.MAX);
             }
         } else {
             throw new IllegalArgumentException("Can't recognize record of type: " + messageType);

--- a/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficePublishTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
+import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.*;
 
@@ -128,7 +129,7 @@ public class PostOfficePublishTest {
                 .payload(payload.retainedDuplicate())
                 .qos(MqttQoS.AT_MOST_ONCE)
                 .retained(false)
-                .topicName(NEWS_TOPIC).build()).get(5, TimeUnit.SECONDS);
+                .topicName(NEWS_TOPIC).build(), Instant.MAX).get(5, TimeUnit.SECONDS);
 
         // Verify
         ConnectionTestUtils.verifyReceivePublish(channel, NEWS_TOPIC, "Hello world!");
@@ -146,7 +147,7 @@ public class PostOfficePublishTest {
             .qos(MqttQoS.EXACTLY_ONCE)
             .retained(false)
             .messageId(1)
-            .topicName(NEWS_TOPIC).build(), "username");
+            .topicName(NEWS_TOPIC).build(), "username", Instant.MAX);
 
         final MQTTConnection clientYA = connectAs("subscriber");
         subscribe(clientYA, NEWS_TOPIC, AT_MOST_ONCE);
@@ -158,7 +159,7 @@ public class PostOfficePublishTest {
             .qos(MqttQoS.EXACTLY_ONCE)
             .retained(true)
             .messageId(2)
-            .topicName(NEWS_TOPIC).build(), "username").completableFuture().get(5, TimeUnit.SECONDS);
+            .topicName(NEWS_TOPIC).build(), "username", Instant.MAX).completableFuture().get(5, TimeUnit.SECONDS);
 
         // Verify
         assertFalse(clientXA.channel.isOpen(), "First 'subscriber' channel MUST be closed by the broker");
@@ -230,7 +231,7 @@ public class PostOfficePublishTest {
                 .payload(payload.retainedDuplicate())
                 .qos(MqttQoS.AT_MOST_ONCE)
                 .retained(false)
-                .topicName(NEWS_TOPIC).build()).get(5, TimeUnit.SECONDS);
+                .topicName(NEWS_TOPIC).build(), Instant.MAX).get(5, TimeUnit.SECONDS);
 
         // Verify
         ConnectionTestUtils.verifyReceivePublish(channel1, NEWS_TOPIC, "Hello world!");
@@ -257,7 +258,7 @@ public class PostOfficePublishTest {
                 .payload(anyPayload)
                 .qos(MqttQoS.AT_MOST_ONCE)
                 .retained(true)
-                .topicName(NEWS_TOPIC).build());
+                .topicName(NEWS_TOPIC).build(), Instant.MAX);
         // receivedPublishQos0 does not release payload.
         anyPayload.release();
 
@@ -282,7 +283,7 @@ public class PostOfficePublishTest {
                 .payload(anyPayload)
                 .qos(MqttQoS.AT_LEAST_ONCE)
                 .retained(true)
-                .topicName(NEWS_TOPIC).build()).completableFuture().get(5, TimeUnit.SECONDS);
+                .topicName(NEWS_TOPIC).build(), Instant.MAX).completableFuture().get(5, TimeUnit.SECONDS);
 
         // Verify
         ConnectionTestUtils.verifyPublishIsReceived(channel, AT_LEAST_ONCE, "Any payload");
@@ -305,7 +306,7 @@ public class PostOfficePublishTest {
                 .qos(MqttQoS.EXACTLY_ONCE)
                 .retained(true)
                 .messageId(2)
-                .topicName(NEWS_TOPIC).build(), "username").completableFuture().get(5000, TimeUnit.SECONDS);
+                .topicName(NEWS_TOPIC).build(), "username", Instant.MAX).completableFuture().get(5000, TimeUnit.SECONDS);
 
         // Verify
         ConnectionTestUtils.verifyPublishIsReceived(channel, EXACTLY_ONCE, "Any payload");
@@ -330,7 +331,7 @@ public class PostOfficePublishTest {
             MqttMessageBuilders.publish()
                 .payload(anyPayload.retainedDuplicate())
                 .qos(MqttQoS.AT_LEAST_ONCE)
-                .topicName(NEWS_TOPIC).build());
+                .topicName(NEWS_TOPIC).build(), Instant.MAX);
 
         // simulate a reconnection from the other client
         connection = createMQTTConnection(ALLOW_ANONYMOUS_AND_ZERO_BYTES_CLID);
@@ -370,7 +371,7 @@ public class PostOfficePublishTest {
                 .payload(anyPayload.retainedDuplicate())
                 .qos(MqttQoS.AT_LEAST_ONCE)
                 .retained(true)
-                .topicName(NEWS_TOPIC).build()).completableFuture().get(5, TimeUnit.SECONDS);
+                .topicName(NEWS_TOPIC).build(), Instant.MAX).completableFuture().get(5, TimeUnit.SECONDS);
 
         // Verify that after a reconnection the client receive the message
         ConnectionTestUtils.verifyPublishIsReceived(secondChannel, AT_LEAST_ONCE, "Any payload");
@@ -396,7 +397,7 @@ public class PostOfficePublishTest {
                 .payload(anyPayload)
                 .qos(MqttQoS.AT_LEAST_ONCE)
                 .retained(true)
-                .topicName(NEWS_TOPIC).build());
+                .topicName(NEWS_TOPIC).build(), Instant.MAX);
 
         verifyNoPublishIsReceived(channel);
     }
@@ -424,7 +425,7 @@ public class PostOfficePublishTest {
             .topicName(NEWS_TOPIC)
             .build();
         sut.receivedPublishQos1(senderConnection, new Topic(NEWS_TOPIC), TEST_USER, 1,
-                                publishMsg);
+                                publishMsg, Instant.MAX);
 
         assertMessageIsRetained(NEWS_TOPIC, anyPayload);
 
@@ -436,7 +437,7 @@ public class PostOfficePublishTest {
                 .payload(qos0Payload)
                 .qos(MqttQoS.AT_MOST_ONCE)
                 .retained(true)
-                .topicName(NEWS_TOPIC).build());
+                .topicName(NEWS_TOPIC).build(), Instant.MAX);
 
         // Verify
         assertTrue(retainedRepository.isEmpty(), "Retained message for topic /news must be cleared");

--- a/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeSubscribeTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.*;
 
@@ -259,7 +260,7 @@ public class PostOfficeSubscribeTest {
                 .payload(payload.retainedDuplicate())
                 .qos(MqttQoS.AT_MOST_ONCE)
                 .retained(false)
-                .topicName(NEWS_TOPIC).build()).get(5, TimeUnit.SECONDS);
+                .topicName(NEWS_TOPIC).build(), Instant.MAX).get(5, TimeUnit.SECONDS);
 
         ConnectionTestUtils.verifyPublishIsReceived(anotherChannel, AT_MOST_ONCE, "Hello world!");
     }
@@ -304,7 +305,7 @@ public class PostOfficeSubscribeTest {
                 .payload(payload)
                 .qos(MqttQoS.AT_MOST_ONCE)
                 .retained(false)
-                .topicName(NEWS_TOPIC).build());
+                .topicName(NEWS_TOPIC).build(), Instant.MAX);
 
         // verify no publish is fired
         ConnectionTestUtils.verifyNoPublishIsReceived(channel);
@@ -322,7 +323,7 @@ public class PostOfficeSubscribeTest {
             .retained(true)
             .topicName(NEWS_TOPIC).build();
         sut.receivedPublishQos1(connection, new Topic(NEWS_TOPIC), TEST_USER, 1,
-            retainedPubQoS1Msg);
+            retainedPubQoS1Msg, Instant.MAX);
 
         // subscriber connects subscribe to topic /news and receive the last retained message
         EmbeddedChannel subChannel = new EmbeddedChannel();

--- a/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
+++ b/broker/src/test/java/io/moquette/broker/PostOfficeUnsubscribeTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.Charset;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.concurrent.*;
 
@@ -156,7 +157,7 @@ public class PostOfficeUnsubscribeTest {
                 .payload(payload.retainedDuplicate())
                 .qos(MqttQoS.AT_MOST_ONCE)
                 .retained(false)
-                .topicName(NEWS_TOPIC).build()).get(5, TimeUnit.SECONDS);
+                .topicName(NEWS_TOPIC).build(), Instant.MAX).get(5, TimeUnit.SECONDS);
 
         ConnectionTestUtils.verifyPublishIsReceived(channel, AT_MOST_ONCE, "Hello world!");
 
@@ -169,7 +170,7 @@ public class PostOfficeUnsubscribeTest {
                 .payload(payload2)
                 .qos(MqttQoS.AT_MOST_ONCE)
                 .retained(false)
-                .topicName(NEWS_TOPIC).build());
+                .topicName(NEWS_TOPIC).build(), Instant.MAX);
 
         ConnectionTestUtils.verifyNoPublishIsReceived(channel);
     }
@@ -194,7 +195,7 @@ public class PostOfficeUnsubscribeTest {
                 .payload(payload.retainedDuplicate())
                 .qos(MqttQoS.AT_MOST_ONCE)
                 .retained(false)
-                .topicName(NEWS_TOPIC).build()).get(5, TimeUnit.SECONDS);
+                .topicName(NEWS_TOPIC).build(), Instant.MAX).get(5, TimeUnit.SECONDS);
 
         ConnectionTestUtils.verifyPublishIsReceived(channel, AT_MOST_ONCE, "Hello world!");
 
@@ -214,7 +215,7 @@ public class PostOfficeUnsubscribeTest {
                 .payload(payload2)
                 .qos(MqttQoS.AT_MOST_ONCE)
                 .retained(false)
-                .topicName(NEWS_TOPIC).build());
+                .topicName(NEWS_TOPIC).build(), Instant.MAX);
 
         ConnectionTestUtils.verifyNoPublishIsReceived(anotherChannel);
     }
@@ -261,7 +262,7 @@ public class PostOfficeUnsubscribeTest {
                 .payload(anyPayload)
                 .qos(MqttQoS.AT_LEAST_ONCE)
                 .retained(false)
-                .topicName(topic).build());
+                .topicName(topic).build(), Instant.MAX);
 
         // disconnect the other channel
         anotherConnection.processDisconnect(null);
@@ -292,7 +293,7 @@ public class PostOfficeUnsubscribeTest {
                 .payload(payload.retainedDuplicate())
                 .qos(MqttQoS.AT_MOST_ONCE)
                 .retained(false)
-                .topicName(NEWS_TOPIC).build()).get(5, TimeUnit.SECONDS);
+                .topicName(NEWS_TOPIC).build(), Instant.MAX).get(5, TimeUnit.SECONDS);
 
         ConnectionTestUtils.verifyPublishIsReceived((EmbeddedChannel) connection.channel, AT_MOST_ONCE, "Hello world!");
 
@@ -312,7 +313,7 @@ public class PostOfficeUnsubscribeTest {
                 .payload(payload2.retainedDuplicate())
                 .qos(MqttQoS.AT_MOST_ONCE)
                 .retained(false)
-                .topicName(NEWS_TOPIC).build()).get(5, TimeUnit.SECONDS);
+                .topicName(NEWS_TOPIC).build(), Instant.MAX).get(5, TimeUnit.SECONDS);
 
         ConnectionTestUtils.verifyPublishIsReceived(subscriberChannel, AT_MOST_ONCE, "Hello world2!");
 
@@ -350,7 +351,7 @@ public class PostOfficeUnsubscribeTest {
                     .payload(bytePayload)
                     .qos(MqttQoS.AT_LEAST_ONCE)
                     .retained(false)
-                    .topicName(NEWS_TOPIC).build()).completableFuture().get(5, TimeUnit.SECONDS);
+                    .topicName(NEWS_TOPIC).build(), Instant.MAX).completableFuture().get(5, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             throw new RuntimeException(e);
         }
@@ -363,7 +364,7 @@ public class PostOfficeUnsubscribeTest {
             .qos(MqttQoS.EXACTLY_ONCE)
             .retained(true)
             .messageId(1)
-            .topicName(topic).build(), "username");
+            .topicName(topic).build(), "username", Instant.MAX);
     }
 
     /**

--- a/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionRegistryTest.java
@@ -230,7 +230,7 @@ public class SessionRegistryTest {
 
         final ByteBuf payload = Unpooled.wrappedBuffer("Hello World!".getBytes(StandardCharsets.UTF_8));
         SessionRegistry.PublishedMessage msg = new SessionRegistry.PublishedMessage(Topic.asTopic("/say"),
-            MqttQoS.AT_LEAST_ONCE, payload, false);
+            MqttQoS.AT_LEAST_ONCE, payload, false, Instant.MAX);
         try {
             // store a message in the MVStore
             final String mapName = "test_map";

--- a/broker/src/test/java/io/moquette/broker/SessionTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionTest.java
@@ -5,8 +5,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.codec.mqtt.MqttProperties;
-import io.netty.handler.codec.mqtt.MqttProperties.MqttProperty;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
 import io.netty.handler.codec.mqtt.MqttVersion;
@@ -17,6 +15,7 @@ import static io.moquette.BrokerConstants.FLIGHT_BEFORE_RESEND_MS;
 import io.moquette.broker.subscriptions.Subscription;
 
 import java.time.Clock;
+import java.time.Instant;
 import java.util.Arrays;
 import org.assertj.core.api.Assertions;
 
@@ -69,7 +68,7 @@ public class SessionTest {
 
     private void sendQoS1To(Session client, Topic destinationTopic, String message) {
         final ByteBuf payload = ByteBufUtil.writeUtf8(UnpooledByteBufAllocator.DEFAULT, message);
-        final SessionRegistry.PublishedMessage publishedMessage = new SessionRegistry.PublishedMessage(destinationTopic, MqttQoS.AT_LEAST_ONCE, payload, false);
+        final SessionRegistry.PublishedMessage publishedMessage = new SessionRegistry.PublishedMessage(destinationTopic, MqttQoS.AT_LEAST_ONCE, payload, false, Instant.MAX);
         client.sendPublishOnSessionAtQos(publishedMessage);
     }
 

--- a/broker/src/test/java/io/moquette/broker/SessionTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionTest.java
@@ -5,6 +5,8 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.mqtt.MqttProperties;
+import io.netty.handler.codec.mqtt.MqttProperties.MqttProperty;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
 import io.netty.handler.codec.mqtt.MqttVersion;
@@ -67,7 +69,8 @@ public class SessionTest {
 
     private void sendQoS1To(Session client, Topic destinationTopic, String message) {
         final ByteBuf payload = ByteBufUtil.writeUtf8(UnpooledByteBufAllocator.DEFAULT, message);
-        client.sendPublishOnSessionAtQos(destinationTopic, MqttQoS.AT_LEAST_ONCE, payload, false);
+        final SessionRegistry.PublishedMessage publishedMessage = new SessionRegistry.PublishedMessage(destinationTopic, MqttQoS.AT_LEAST_ONCE, payload, false);
+        client.sendPublishOnSessionAtQos(publishedMessage);
     }
 
     @Test

--- a/broker/src/test/java/io/moquette/integration/mqtt5/MessageExpirationTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/MessageExpirationTest.java
@@ -28,7 +28,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
-import static io.moquette.integration.mqtt5.ConnectTest.verifyNoPublish;
+import static io.netty.handler.codec.mqtt.MqttQoS.AT_MOST_ONCE;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MessageExpirationTest extends AbstractServerIntegrationTest {
@@ -98,5 +98,65 @@ public class MessageExpirationTest extends AbstractServerIntegrationTest {
             .getProperty(MqttProperties.MqttPropertyType.PUBLICATION_EXPIRY_INTERVAL.value());
         assertNotNull(messageExpiryProperty, "message expiry property must be present");
         assertTrue(messageExpiryProperty.value() < messageExpiryInterval, "Forwarded message expiry should be lowered");
+    }
+
+    @Test
+    public void givenPublishedMessageWithExpiryWhenMessageRemainInBrokerForMoreThanTheExipiryIsNotPublished() throws InterruptedException {
+        connectLowLevel();
+
+        // subscribe with an identifier
+        MqttMessage received = lowLevelClient.subscribeWithIdentifier("temperature/living",
+            MqttQoS.AT_LEAST_ONCE, 123);
+        verifyOfType(received, MqttMessageType.SUBACK);
+
+        //lowlevel client doesn't ACK any pub, so the in flight window fills up
+        Mqtt5BlockingClient publisher = createPublisherClient();
+        int inflightWindowSize = 10;
+        int messageExpiryInterval = 2; // seconds
+        // fill the in flight window so that messages starts to be enqueued
+        fillInFlightWindow(inflightWindowSize, publisher, messageExpiryInterval);
+
+        // send another message, which is enqueued and has an expiry of messageExpiryInterval seconds
+        publisher.publishWith()
+            .topic("temperature/living")
+            .payload(("Enqueued").getBytes(StandardCharsets.UTF_8))
+            .qos(MqttQos.AT_LEAST_ONCE) // Broker enqueues only QoS1 and QoS2
+            .messageExpiryInterval(messageExpiryInterval)
+            .send();
+
+        // let time flow so that the message in queue passes its expiry time
+        Thread.sleep(Duration.ofSeconds(messageExpiryInterval + 1).toMillis());
+
+        // now subscriber consumes messages, shouldn't receive any message in the form "Enqueued-"
+        consumesPublishesInflifhtWindow(inflightWindowSize);
+
+        MqttMessage mqttMessage = lowLevelClient.receiveNextMessage(Duration.ofMillis(100));
+        assertNull(mqttMessage, "No other messages MUST be received after consuming the in flight window");
+    }
+
+    private void consumesPublishesInflifhtWindow(int inflightWindowSize) throws InterruptedException {
+        for (int i = 0; i < inflightWindowSize; i++) {
+            MqttMessage mqttMessage = lowLevelClient.receiveNextMessage(Duration.ofMillis(200));
+            assertTrue(mqttMessage instanceof MqttPublishMessage);
+            MqttPublishMessage publish = (MqttPublishMessage) mqttMessage;
+            assertEquals(Integer.toString(i), publish.payload().toString(StandardCharsets.UTF_8));
+            int packetId = publish.variableHeader().packetId();
+
+            MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.PUBACK, false, AT_MOST_ONCE,
+                false, 0);
+            MqttPubAckMessage pubAck = new MqttPubAckMessage(fixedHeader, MqttMessageIdVariableHeader.from(packetId));
+            lowLevelClient.sendMessage(pubAck);
+        }
+    }
+
+    private static void fillInFlightWindow(int inflightWindowSize, Mqtt5BlockingClient publisher, int messageExpiryInterval) {
+        for (int i = 0; i < inflightWindowSize; i++) {
+            publisher.publishWith()
+                .topic("temperature/living")
+                .payload(Integer.toString(i).getBytes(StandardCharsets.UTF_8))
+                .qos(MqttQos.AT_LEAST_ONCE) // Broker enqueues only QoS1 and QoS2
+                .messageExpiryInterval(messageExpiryInterval)
+                .send();
+        }
     }
 }

--- a/broker/src/test/java/io/moquette/persistence/H2PersistentQueueTest.java
+++ b/broker/src/test/java/io/moquette/persistence/H2PersistentQueueTest.java
@@ -22,13 +22,11 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import org.h2.mvstore.MVStore;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -48,7 +46,7 @@ public class H2PersistentQueueTest extends H2BaseTest {
 
     private SessionRegistry.PublishedMessage createMessage(String name) {
         final ByteBuf payload = Unpooled.wrappedBuffer(name.getBytes(StandardCharsets.UTF_8));
-        return new SessionRegistry.PublishedMessage(Topic.asTopic(name), MqttQoS.AT_LEAST_ONCE, payload, false);
+        return new SessionRegistry.PublishedMessage(Topic.asTopic(name), MqttQoS.AT_LEAST_ONCE, payload, false, Instant.MAX);
     }
 
     @Test

--- a/broker/src/test/java/io/moquette/persistence/SegmentPersistentQueueTest.java
+++ b/broker/src/test/java/io/moquette/persistence/SegmentPersistentQueueTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.AfterAll;
@@ -205,7 +206,7 @@ public class SegmentPersistentQueueTest {
         // 4 totalSize + 1 msgType + 1 qos + 4 topicSize + 4 bodySize = 14
         int bodySize = totalMessageSize - 14 - topic.getBytes(UTF_8).length;
         final ByteBuf payload = Unpooled.wrappedBuffer(getBody(bodySize).getBytes(StandardCharsets.UTF_8));
-        return new PublishedMessage(Topic.asTopic(topic), MqttQoS.AT_LEAST_ONCE, payload, false);
+        return new PublishedMessage(Topic.asTopic(topic), MqttQoS.AT_LEAST_ONCE, payload, false, Instant.MAX);
     }
 
     @Test

--- a/broker/src/test/java/io/moquette/persistence/SegmentedPersistentQueueSerDesTest.java
+++ b/broker/src/test/java/io/moquette/persistence/SegmentedPersistentQueueSerDesTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Optional;
 
@@ -25,7 +26,7 @@ class SegmentedPersistentQueueSerDesTest {
         final Topic topic = Topic.asTopic("/metering/temperature");
         ByteBuf payload = Unpooled.wrappedBuffer("Some fancy things".getBytes(StandardCharsets.UTF_8));
         SessionRegistry.EnqueuedMessage messageToSerialize = new SessionRegistry.PublishedMessage(
-            topic, MqttQoS.AT_MOST_ONCE, payload, true);
+            topic, MqttQoS.AT_MOST_ONCE, payload, true, Instant.MAX);
 
         ByteBuffer serialized = sut.toBytes(messageToSerialize);
 
@@ -45,7 +46,7 @@ class SegmentedPersistentQueueSerDesTest {
         MqttProperties.IntegerProperty intProperty = new MqttProperties.IntegerProperty(
             MqttProperties.MqttPropertyType.SUBSCRIPTION_IDENTIFIER.value(), subscriptionId);
         SessionRegistry.EnqueuedMessage messageToSerialize = new SessionRegistry.PublishedMessage(
-            topic, MqttQoS.AT_MOST_ONCE, payload, true, intProperty);
+            topic, MqttQoS.AT_MOST_ONCE, payload, true, Instant.MAX, intProperty);
 
         ByteBuffer serialized = sut.toBytes(messageToSerialize);
 


### PR DESCRIPTION
## Release notes
Avoid to publish messages that has elapsed its expire property.

## What does this PR do?

- Reworked some Session methods arguments list to be wrapped inside the PublishedMessage
- Extracts the `message expiry` property from publish and move around down to the forwarding logic to matching subscriptions.
- Update the publish to subscription logic to drop messages that has elapsed their expiry.
- Adds integration test to prove the feature.

## Why is it important/What is the impact to the user?

Implements part of the message expiry requirement.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the Changelog if it's a feature or a fix that has to be reported


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #818
