### PR TITLE
Update message expiry remaining time and drop queued messages if expired

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -3,6 +3,7 @@ Version 0.18-SNAPSHOT:
    [feature] message expiry interval: (issue #818)
      - Implements the management of message expiry for retained part. (#819)
      - Avoid to publish messages that has elapsed its expire property. (#822)
+     - Update the message expiry property remaining seconds when a publish is forwarded. (#823)
    [feature] subscription option handling: (issue #808)
      - Move from qos to subscription option implementing the persistence of SubscriptionOption to/from storage. (#810)
      - Exposed the maximum granted QoS by the server with the config setting 'max_server_granted_qos'. (#811)

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -625,7 +625,7 @@ final class MQTTConnection {
             return PostOffice.RouteResult.failed(clientId);
         }
 
-        final Instant expiry = extractExpiryFromPropery(msg);
+        final Instant expiry = extractExpiryFromProperty(msg);
 
         // retain else msg is cleaned by the NewNettyMQTTHandler and is not available
         // in execution by SessionEventLoop
@@ -672,7 +672,7 @@ final class MQTTConnection {
         }
     }
 
-    private Instant extractExpiryFromPropery(MqttPublishMessage msg) {
+    private Instant extractExpiryFromProperty(MqttPublishMessage msg) {
         MqttProperties.MqttProperty expiryProp = msg.variableHeader()
             .properties()
             .getProperty(MqttProperties.MqttPropertyType.PUBLICATION_EXPIRY_INTERVAL.value());

--- a/broker/src/main/java/io/moquette/broker/MoquetteIdleTimeoutHandler.java
+++ b/broker/src/main/java/io/moquette/broker/MoquetteIdleTimeoutHandler.java
@@ -36,7 +36,7 @@ public class MoquetteIdleTimeoutHandler extends ChannelDuplexHandler {
         if (evt instanceof IdleStateEvent) {
             IdleState e = ((IdleStateEvent) evt).state();
             if (e == IdleState.READER_IDLE) {
-                LOG.info("Firing channel inactive event. MqttClientId = {}.", NettyUtils.clientID(ctx.channel()));
+                LOG.warn("Close channel because it's inactive, passed keep alive. MqttClientId = {}.", NettyUtils.clientID(ctx.channel()));
                 // fire a close that then fire channelInactive to trigger publish of Will
                 ctx.close().addListener(CLOSE_ON_FAILURE);
             }

--- a/broker/src/main/java/io/moquette/broker/Session.java
+++ b/broker/src/main/java/io/moquette/broker/Session.java
@@ -262,9 +262,11 @@ class Session {
             LOG.debug("Sending publish at QoS0 already expired, drop it");
             return;
         }
+
+        MqttProperties.MqttProperty[] mqttProperties = publishRequest.updatePublicationExpiryIfPresentOrAdd();
         MqttPublishMessage publishMsg = MQTTConnection.createPublishMessage(publishRequest.getTopic().toString(),
             publishRequest.getPublishingQos(), publishRequest.getPayload(), 0,
-            publishRequest.retained, false, publishRequest.mqttProperties);
+            publishRequest.retained, false, mqttProperties);
         mqttConnection.sendPublish(publishMsg);
     }
 
@@ -311,9 +313,11 @@ class Session {
             if (resendInflightOnTimeout) {
                 inflightTimeouts.add(new InFlightPacket(packetId, FLIGHT_BEFORE_RESEND_MS));
             }
+
+            MqttProperties.MqttProperty[] mqttProperties = publishRequest.updatePublicationExpiryIfPresentOrAdd();
             MqttPublishMessage publishMsg = MQTTConnection.createPublishMessage(
                 publishRequest.topic.toString(), publishRequest.getPublishingQos(),
-                publishRequest.payload, packetId, publishRequest.retained, false, publishRequest.mqttProperties);
+                publishRequest.payload, packetId, publishRequest.retained, false, mqttProperties);
             localMqttConnectionRef.sendPublish(publishMsg);
 
             drainQueueToConnection();

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -117,7 +117,7 @@ public class SessionRegistry {
             if (messageExpiry == Instant.MAX) {
                 return mqttProperties;
             }
-            long remainingSeconds = Duration.between(messageExpiry, Instant.now())
+            long remainingSeconds = Duration.between(Instant.now(), messageExpiry)
                 .getSeconds();
             final int indexOfExpiry = findPublicationExpiryProperty(mqttProperties);
             MqttProperties.IntegerProperty updatedProperty = new MqttProperties.IntegerProperty(MqttProperties.MqttPropertyType.PUBLICATION_EXPIRY_INTERVAL.value(), (int) remainingSeconds);
@@ -152,9 +152,29 @@ public class SessionRegistry {
             return property instanceof MqttProperties.IntegerProperty &&
                 property.propertyId() == MqttProperties.MqttPropertyType.PUBLICATION_EXPIRY_INTERVAL.value();
         }
+
+        public Instant getMessageExpiry() {
+            return messageExpiry;
+        }
+
+        @Override
+        public String toString() {
+            return "PublishedMessage{" +
+                "topic=" + topic +
+                ", publishingQos=" + publishingQos +
+                ", payload=" + payload +
+                ", retained=" + retained +
+                ", messageExpiry=" + messageExpiry +
+                ", mqttProperties=" + Arrays.toString(mqttProperties) +
+                '}';
+        }
     }
 
     public static final class PubRelMarker extends EnqueuedMessage {
+        @Override
+        public String toString() {
+            return "PubRelMarker{}";
+        }
     }
 
     public enum CreationModeEnum {

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -112,6 +112,46 @@ public class SessionRegistry {
         public boolean isExpired() {
             return messageExpiry != Instant.MAX && Instant.now().isAfter(messageExpiry);
         }
+
+        public MqttProperties.MqttProperty[] updatePublicationExpiryIfPresentOrAdd() {
+            if (messageExpiry == Instant.MAX) {
+                return mqttProperties;
+            }
+            long remainingSeconds = Duration.between(messageExpiry, Instant.now())
+                .getSeconds();
+            final int indexOfExpiry = findPublicationExpiryProperty(mqttProperties);
+            MqttProperties.IntegerProperty updatedProperty = new MqttProperties.IntegerProperty(MqttProperties.MqttPropertyType.PUBLICATION_EXPIRY_INTERVAL.value(), (int) remainingSeconds);
+
+            // update existing property
+            if (indexOfExpiry != -1) {
+                mqttProperties[indexOfExpiry] = updatedProperty;
+                return mqttProperties;
+            }
+
+            // insert a new property
+            MqttProperties.MqttProperty[] newProperties = Arrays.copyOf(mqttProperties, mqttProperties.length + 1);
+            newProperties[newProperties.length - 1] = updatedProperty;
+            return newProperties;
+        }
+
+        /**
+         * Linear search of PUBLICATION_EXPIRY_INTERVAL.
+         * @param properties the array of properties.
+         * @return the index of matched property or -1.
+         * */
+        private static int findPublicationExpiryProperty(MqttProperties.MqttProperty[] properties) {
+            for (int i = 0; i < properties.length; i++) {
+                if (isPublicationExpiryProperty(properties[i])) {
+                    return i;
+                }
+            }
+            return -1;
+        }
+
+        private static boolean isPublicationExpiryProperty(MqttProperties.MqttProperty property) {
+            return property instanceof MqttProperties.IntegerProperty &&
+                property.propertyId() == MqttProperties.MqttPropertyType.PUBLICATION_EXPIRY_INTERVAL.value();
+        }
     }
 
     public static final class PubRelMarker extends EnqueuedMessage {

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -117,8 +117,10 @@ public class SessionRegistry {
             if (messageExpiry == Instant.MAX) {
                 return mqttProperties;
             }
-            long remainingSeconds = Duration.between(Instant.now(), messageExpiry)
-                .getSeconds();
+
+            Duration duration = Duration.between(Instant.now(), messageExpiry);
+            // do some math rounding so that 2.9999 seconds remains 3 seconds
+            long remainingSeconds = Math.round(duration.toMillis() / 1_000.0);
             final int indexOfExpiry = findPublicationExpiryProperty(mqttProperties);
             MqttProperties.IntegerProperty updatedProperty = new MqttProperties.IntegerProperty(MqttProperties.MqttPropertyType.PUBLICATION_EXPIRY_INTERVAL.value(), (int) remainingSeconds);
 

--- a/broker/src/test/java/io/moquette/integration/mqtt5/AbstractServerIntegrationTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/AbstractServerIntegrationTest.java
@@ -139,4 +139,9 @@ public abstract class AbstractServerIntegrationTest {
         MqttConnAckMessage connAck = lowLevelClient.connectV5();
         assertConnectionAccepted(connAck, "Connection must be accepted");
     }
+
+    void connectLowLevel(int keepAliveSecs) {
+        MqttConnAckMessage connAck = lowLevelClient.connectV5(keepAliveSecs);
+        assertConnectionAccepted(connAck, "Connection must be accepted");
+    }
 }

--- a/broker/src/test/java/io/moquette/integration/mqtt5/MessageExpirationTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/MessageExpirationTest.java
@@ -20,13 +20,21 @@ package io.moquette.integration.mqtt5;
 
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5BlockingClient;
-import io.netty.handler.codec.mqtt.*;
+import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5PublishBuilder;
+import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5PublishResult;
+import io.netty.handler.codec.mqtt.MqttFixedHeader;
+import io.netty.handler.codec.mqtt.MqttMessage;
+import io.netty.handler.codec.mqtt.MqttMessageIdVariableHeader;
+import io.netty.handler.codec.mqtt.MqttMessageType;
+import io.netty.handler.codec.mqtt.MqttProperties;
+import io.netty.handler.codec.mqtt.MqttPubAckMessage;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttQoS;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
 import static io.netty.handler.codec.mqtt.MqttQoS.AT_MOST_ONCE;
@@ -103,7 +111,9 @@ public class MessageExpirationTest extends AbstractServerIntegrationTest {
 
     @Test
     public void givenPublishedMessageWithExpiryWhenMessageRemainInBrokerForMoreThanTheExipiryIsNotPublished() throws InterruptedException {
-        connectLowLevel();
+        int messageExpiryInterval = 2; // seconds
+        // avoid the keep alive period could disconnect
+        connectLowLevel(messageExpiryInterval * 2);
 
         // subscribe with an identifier
         MqttMessage received = lowLevelClient.subscribeWithIdentifier("temperature/living",
@@ -113,7 +123,6 @@ public class MessageExpirationTest extends AbstractServerIntegrationTest {
         //lowlevel client doesn't ACK any pub, so the in flight window fills up
         Mqtt5BlockingClient publisher = createPublisherClient();
         int inflightWindowSize = 10;
-        int messageExpiryInterval = 2; // seconds
         // fill the in flight window so that messages starts to be enqueued
         fillInFlightWindow(inflightWindowSize, publisher, messageExpiryInterval);
 
@@ -129,7 +138,7 @@ public class MessageExpirationTest extends AbstractServerIntegrationTest {
         Thread.sleep(Duration.ofSeconds(messageExpiryInterval + 1).toMillis());
 
         // now subscriber consumes messages, shouldn't receive any message in the form "Enqueued-"
-        consumesPublishesInflifhtWindow(inflightWindowSize);
+        consumesPublishesInflightWindow(inflightWindowSize);
 
         MqttMessage mqttMessage = lowLevelClient.receiveNextMessage(Duration.ofMillis(100));
         assertNull(mqttMessage, "No other messages MUST be received after consuming the in flight window");
@@ -137,7 +146,9 @@ public class MessageExpirationTest extends AbstractServerIntegrationTest {
 
     @Test
     public void givenPublishWithMessageExpiryPropertyWhenItsForwardedToSubscriberThenExpiryValueHasToBeDeducedByTheTimeSpentInBroker() throws InterruptedException {
-        connectLowLevel();
+        int messageExpiryInterval = 10; // seconds
+        // avoid the keep alive period could disconnect
+        connectLowLevel((int)(messageExpiryInterval * 1.5));
 
         // subscribe with an identifier
         MqttMessage received = lowLevelClient.subscribeWithIdentifier("temperature/living",
@@ -147,9 +158,8 @@ public class MessageExpirationTest extends AbstractServerIntegrationTest {
         //lowlevel client doesn't ACK any pub, so the in flight window fills up
         Mqtt5BlockingClient publisher = createPublisherClient();
         int inflightWindowSize = 10;
-        int messageExpiryInterval = 10; // seconds
         // fill the in flight window so that messages starts to be enqueued
-        fillInFlightWindow(inflightWindowSize, publisher, messageExpiryInterval);
+        fillInFlightWindow(inflightWindowSize, publisher, Integer.MIN_VALUE);
 
         // send another message, which is enqueued and has an expiry of messageExpiryInterval seconds
         publisher.publishWith()
@@ -160,30 +170,33 @@ public class MessageExpirationTest extends AbstractServerIntegrationTest {
             .send();
 
         // let time flow so that the message in queue passes its expiry time
-        Thread.sleep(Duration.ofSeconds(messageExpiryInterval / 2).toMillis());
+        long sleepMillis = Duration.ofSeconds(messageExpiryInterval / 2).toMillis();
+        Thread.sleep(sleepMillis);
 
         // now subscriber consumes messages, shouldn't receive any message in the form "Enqueued-"
-        consumesPublishesInflifhtWindow(inflightWindowSize);
+        consumesPublishesInflightWindow(inflightWindowSize);
+        MqttMessage mqttMessage = lowLevelClient.receiveNextMessage(Duration.ofMillis(1000));
 
-        MqttMessage mqttMessage = lowLevelClient.receiveNextMessage(Duration.ofMillis(100));
         assertNotNull(mqttMessage, "A publish out of the queue has to be received");
-        assertTrue(mqttMessage instanceof MqttPublishMessage);
+        assertEquals(MqttMessageType.PUBLISH, mqttMessage.fixedHeader().messageType(), "Expected a publish message");
         MqttPublishMessage publishMessage = (MqttPublishMessage) mqttMessage;
 
         // extract message expiry property
         MqttProperties.MqttProperty expiryProp = publishMessage.variableHeader()
             .properties()
             .getProperty(MqttProperties.MqttPropertyType.PUBLICATION_EXPIRY_INTERVAL.value());
-        assertNotNull(expiryProp, "Publication expiry property can'be null");
+        assertNotNull(expiryProp, "Publication expiry property can't be null");
         Integer expirySeconds = ((MqttProperties.IntegerProperty) expiryProp).value();
 
         assertTrue(expirySeconds < messageExpiryInterval, "Publish's expiry has to be updated");
     }
 
-    private void consumesPublishesInflifhtWindow(int inflightWindowSize) throws InterruptedException {
+    private void consumesPublishesInflightWindow(int inflightWindowSize) throws InterruptedException {
         for (int i = 0; i < inflightWindowSize; i++) {
-            MqttMessage mqttMessage = lowLevelClient.receiveNextMessage(Duration.ofMillis(200));
-            assertTrue(mqttMessage instanceof MqttPublishMessage);
+            MqttMessage mqttMessage = lowLevelClient.receiveNextMessage(Duration.ofMillis(20000));
+            assertNotNull(mqttMessage, "A message MUST be received");
+
+            assertEquals(MqttMessageType.PUBLISH, mqttMessage.fixedHeader().messageType(), "Message received should MqttPublishMessage");
             MqttPublishMessage publish = (MqttPublishMessage) mqttMessage;
             assertEquals(Integer.toString(i), publish.payload().toString(StandardCharsets.UTF_8));
             int packetId = publish.variableHeader().packetId();
@@ -197,12 +210,16 @@ public class MessageExpirationTest extends AbstractServerIntegrationTest {
 
     private static void fillInFlightWindow(int inflightWindowSize, Mqtt5BlockingClient publisher, int messageExpiryInterval) {
         for (int i = 0; i < inflightWindowSize; i++) {
-            publisher.publishWith()
+            Mqtt5PublishBuilder.Send.Complete<Mqtt5PublishResult> builder = publisher.publishWith()
                 .topic("temperature/living")
                 .payload(Integer.toString(i).getBytes(StandardCharsets.UTF_8))
-                .qos(MqttQos.AT_LEAST_ONCE) // Broker enqueues only QoS1 and QoS2
-                .messageExpiryInterval(messageExpiryInterval)
-                .send();
+                .qos(MqttQos.AT_LEAST_ONCE);
+            if (messageExpiryInterval != Integer.MIN_VALUE) {
+                builder // Broker enqueues only QoS1 and QoS2
+                    .messageExpiryInterval(messageExpiryInterval);
+            }
+
+           builder.send();
         }
     }
 }

--- a/broker/src/test/java/io/moquette/integration/mqtt5/SubscriptionOptionsTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/SubscriptionOptionsTest.java
@@ -21,7 +21,6 @@ package io.moquette.integration.mqtt5;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5BlockingClient;
 import com.hivemq.client.mqtt.mqtt5.message.subscribe.Mqtt5RetainHandling;
-import com.hivemq.client.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAckReasonCode;
 import org.eclipse.paho.mqttv5.client.IMqttMessageListener;
 import org.eclipse.paho.mqttv5.client.IMqttToken;
 import org.eclipse.paho.mqttv5.client.MqttClient;
@@ -64,6 +63,14 @@ public class SubscriptionOptionsTest extends AbstractSubscriptionIntegrationTest
             return new String(receivedMessage.getPayload(), StandardCharsets.UTF_8);
         }
 
+        public String receivedTopic() {
+            return receivedTopic;
+        }
+
+        public MqttMessage receivedMessage() {
+            return receivedMessage;
+        }
+
         public void assertReceivedMessageIn(int time, TimeUnit unit) {
             try {
                 assertTrue(latch.await(time, unit), "Publish is received");
@@ -95,7 +102,7 @@ public class SubscriptionOptionsTest extends AbstractSubscriptionIntegrationTest
         PublishCollector publishCollector = new PublishCollector();
         IMqttToken subscribeToken = client.subscribe(new MqttSubscription[]{subscription},
             new IMqttMessageListener[] {publishCollector});
-        verifySubscribedSuccessfully(subscribeToken);
+        TestUtils.verifySubscribedSuccessfully(subscribeToken);
 
         // publish a message on same topic the client subscribed
         client.publish("/metering/temp", new MqttMessage("18".getBytes(StandardCharsets.UTF_8), 1, false, null));
@@ -113,7 +120,7 @@ public class SubscriptionOptionsTest extends AbstractSubscriptionIntegrationTest
         PublishCollector publishCollector = new PublishCollector();
         IMqttToken subscribeToken = client.subscribe(new MqttSubscription[]{subscription},
             new IMqttMessageListener[] {publishCollector});
-        verifySubscribedSuccessfully(subscribeToken);
+        TestUtils.verifySubscribedSuccessfully(subscribeToken);
 
         // publish a message on same topic the client subscribed
         client.publish("/metering/temp", new MqttMessage("18".getBytes(StandardCharsets.UTF_8), 1, false, null));
@@ -123,12 +130,6 @@ public class SubscriptionOptionsTest extends AbstractSubscriptionIntegrationTest
         assertEquals("/metering/temp", publishCollector.receivedTopic);
         assertEquals("18", publishCollector.receivedPayload(), "Payload published on topic should match");
         assertEquals(MqttQos.AT_LEAST_ONCE.getCode(), publishCollector.receivedMessage.getQos());
-    }
-
-    private static void verifySubscribedSuccessfully(IMqttToken subscribeToken) {
-        assertEquals(1, subscribeToken.getReasonCodes().length);
-        assertEquals(Mqtt5SubAckReasonCode.GRANTED_QOS_1.getCode(), subscribeToken.getReasonCodes()[0],
-            "Client is subscribed to the topic");
     }
 
     @Test
@@ -160,7 +161,7 @@ public class SubscriptionOptionsTest extends AbstractSubscriptionIntegrationTest
         PublishCollector publishCollector = new PublishCollector();
         IMqttToken subscribeToken = subscriberWithRetain.subscribe(new MqttSubscription[]{subscription},
             new IMqttMessageListener[] {publishCollector});
-        verifySubscribedSuccessfully(subscribeToken);
+        TestUtils.verifySubscribedSuccessfully(subscribeToken);
 
         // Verify the message is also reflected back to the sender
         publishCollector.assertReceivedMessageIn(2, TimeUnit.SECONDS);
@@ -313,7 +314,7 @@ public class SubscriptionOptionsTest extends AbstractSubscriptionIntegrationTest
 
         IMqttToken subscribeToken = subscriber.subscribe(new MqttSubscription[]{subscription},
             new IMqttMessageListener[] {publishCollector});
-        verifySubscribedSuccessfully(subscribeToken);
+        TestUtils.verifySubscribedSuccessfully(subscribeToken);
     }
 
     private static void createClientWithRetainPolicy(PublishCollector publishCollector, int retainPolicy) throws MqttException {
@@ -324,7 +325,7 @@ public class SubscriptionOptionsTest extends AbstractSubscriptionIntegrationTest
 
         IMqttToken subscribeToken = subscriber.subscribe(new MqttSubscription[]{subscription},
             new IMqttMessageListener[] {publishCollector});
-        verifySubscribedSuccessfully(subscribeToken);
+        TestUtils.verifySubscribedSuccessfully(subscribeToken);
     }
 
     private static MqttClient createSubscriberClientWithRetainAsPublished(PublishCollector publishCollector, String topic) throws MqttException {
@@ -344,7 +345,7 @@ public class SubscriptionOptionsTest extends AbstractSubscriptionIntegrationTest
 
         IMqttToken subscribeToken = subscriber.subscribe(new MqttSubscription[]{subscription},
             new IMqttMessageListener[] {publishCollector});
-        verifySubscribedSuccessfully(subscribeToken);
+        TestUtils.verifySubscribedSuccessfully(subscribeToken);
 
         return subscriber;
     }

--- a/broker/src/test/java/io/moquette/integration/mqtt5/TestUtils.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/TestUtils.java
@@ -21,11 +21,14 @@ package io.moquette.integration.mqtt5;
 import com.hivemq.client.mqtt.MqttGlobalPublishFilter;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5BlockingClient;
 import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish;
+import com.hivemq.client.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAckReasonCode;
+import org.eclipse.paho.mqttv5.client.IMqttToken;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestUtils {
@@ -38,5 +41,11 @@ public class TestUtils {
             }
             verifier.accept(publishMessage.get());
         }
+    }
+
+    static void verifySubscribedSuccessfully(IMqttToken subscribeToken) {
+        assertEquals(1, subscribeToken.getReasonCodes().length);
+        assertEquals(Mqtt5SubAckReasonCode.GRANTED_QOS_1.getCode(), subscribeToken.getReasonCodes()[0],
+            "Client is subscribed to the topic");
     }
 }

--- a/broker/src/test/java/io/moquette/persistence/SegmentPersistentQueueTest.java
+++ b/broker/src/test/java/io/moquette/persistence/SegmentPersistentQueueTest.java
@@ -204,7 +204,14 @@ public class SegmentPersistentQueueTest {
 
     private static PublishedMessage createMessage(String topic, int totalMessageSize) {
         // 4 totalSize + 1 msgType + 1 qos + 4 topicSize + 4 bodySize = 14
-        int bodySize = totalMessageSize - 14 - topic.getBytes(UTF_8).length;
+        int publishedMessageSerializedHeaderSize =
+            4 + // totalSize
+            1 + // msgType
+            1 + // qos
+            4 + // topicSize
+            4 + // bodySize
+            + 4 + Instant.MAX.toString().getBytes(StandardCharsets.UTF_8).length; // message expiry
+        int bodySize = totalMessageSize - publishedMessageSerializedHeaderSize - topic.getBytes(UTF_8).length;
         final ByteBuf payload = Unpooled.wrappedBuffer(getBody(bodySize).getBytes(StandardCharsets.UTF_8));
         return new PublishedMessage(Topic.asTopic(topic), MqttQoS.AT_LEAST_ONCE, payload, false, Instant.MAX);
     }

--- a/broker/src/test/java/io/moquette/testclient/Client.java
+++ b/broker/src/test/java/io/moquette/testclient/Client.java
@@ -137,12 +137,17 @@ public class Client {
     }
 
     public MqttConnAckMessage connectV5() {
+        return connectV5(2);
+    }
+
+    @NotNull
+    public MqttConnAckMessage connectV5(int keepAliveSecs) {
         final MqttMessageBuilders.ConnectBuilder builder = MqttMessageBuilders.connect().protocolVersion(MqttVersion.MQTT_5);
         if (clientId != null) {
             builder.clientId(clientId);
         }
         MqttConnectMessage connectMessage = builder
-            .keepAlive(2) // secs
+            .keepAlive(keepAliveSecs) // secs
             .willFlag(false)
             .willQoS(MqttQoS.AT_MOST_ONCE)
             .build();


### PR DESCRIPTION
## Release notes
Update the message expiry property remaining seconds when a publish is forwarded.
Updates SerDes for segmented queues to store also the message expiry value.

## What does this PR do?

Updates the message expiry property, during forwarding of a publish, with the remaining seconds before expire.
This is done after extract a message from the Session's queue and before composing the publish message to forward.

## Why is it important/What is the impact to the user?

Completes the management of the message expiry property

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the Changelog if it's a feature or a fix that has to be reported


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #818 


