### PR TITLE
Updated will publishing to contains also the message expire property

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -4,6 +4,7 @@ Version 0.18-SNAPSHOT:
      - Implements the management of message expiry for retained part. (#819)
      - Avoid to publish messages that has elapsed its expire property. (#822)
      - Update the message expiry property remaining seconds when a publish is forwarded. (#823)
+     - Updated will publishing to contains also the message expire property. (#824)
    [feature] subscription option handling: (issue #808)
      - Move from qos to subscription option implementing the persistence of SubscriptionOption to/from storage. (#810)
      - Exposed the maximum granted QoS by the server with the config setting 'max_server_granted_qos'. (#811)

--- a/broker/src/main/java/io/moquette/broker/ISessionsRepository.java
+++ b/broker/src/main/java/io/moquette/broker/ISessionsRepository.java
@@ -256,10 +256,10 @@ public interface ISessionsRepository {
          }
 
          /**
-          * Used only when update with an expire instant.
+          * Copy constructor used only when update with an expire instant.
           * */
          public Will(Will orig, Instant expireAt) {
-            this(orig.topic, orig.payload, orig.qos, orig.retained, orig.delayInterval);
+            this(orig.topic, orig.payload, orig.qos, orig.retained, orig.delayInterval, orig.properties);
             this.expireAt = expireAt;
          }
 
@@ -273,6 +273,16 @@ public interface ISessionsRepository {
              this.retained = orig.retained;
              this.delayInterval = orig.delayInterval;
              this.expireAt = orig.expireAt;
+             this.properties = properties;
+         }
+
+         private Will(String topic, byte[] payload, MqttQoS qos, boolean retained, int delayInterval,
+                      WillOptions properties) {
+             this.topic = topic;
+             this.payload = payload;
+             this.qos = qos;
+             this.retained = retained;
+             this.delayInterval = delayInterval;
              this.properties = properties;
          }
 

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -311,7 +311,17 @@ class PostOffice {
     }
 
     private void publishWill(ISessionsRepository.Will will) {
-        publish2Subscribers(WILL_PUBLISHER, Unpooled.copiedBuffer(will.payload), new Topic(will.topic), will.qos, will.retained, Instant.MAX);
+        final Instant messageExpiryInstant = willMessageExpiry(will);
+        publish2Subscribers(WILL_PUBLISHER, Unpooled.copiedBuffer(will.payload), new Topic(will.topic),
+            will.qos, will.retained, messageExpiryInstant);
+    }
+
+    private static Instant willMessageExpiry(ISessionsRepository.Will will) {
+        Optional<Duration> messageExpiryOpt = will.properties.messageExpiry();
+        if (messageExpiryOpt.isPresent()) {
+            return Instant.now().plus(messageExpiryOpt.get());
+        }
+        return Instant.MAX;
     }
 
     /**

--- a/broker/src/test/java/io/moquette/integration/mqtt5/MessageExpirationTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/MessageExpirationTest.java
@@ -188,7 +188,7 @@ public class MessageExpirationTest extends AbstractServerIntegrationTest {
 
         // subscribe with an identifier
         MqttMessage received = lowLevelClient.subscribeWithIdentifier("temperature/living",
-            MqttQoS.AT_LEAST_ONCE, 123);
+            MqttQoS.AT_LEAST_ONCE, 123, 500, TimeUnit.MILLISECONDS);
         verifyOfType(received, MqttMessageType.SUBACK);
 
         //lowlevel client doesn't ACK any pub, so the in flight window fills up

--- a/broker/src/test/java/io/moquette/integration/mqtt5/MessageExpirationTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/MessageExpirationTest.java
@@ -53,7 +53,7 @@ public class MessageExpirationTest extends AbstractServerIntegrationTest {
     }
 
     @Test
-    public void givenPublishWithRetainedAndMessageExpiryWhenTimePassedThenRetainedIsNotForwardedOnSubscription() throws InterruptedException {
+    public void givenPublishWithRetainedAndMessageExpiryWhenTimePassedThenRetainedIsNotForwardedOnSubscription() throws InterruptedException, MqttException {
         Mqtt5BlockingClient publisher = createPublisherClient();
         int messageExpiryInterval = 3; //seconds
         publisher.publishWith()
@@ -113,6 +113,7 @@ public class MessageExpirationTest extends AbstractServerIntegrationTest {
             .getProperty(MqttProperties.MqttPropertyType.PUBLICATION_EXPIRY_INTERVAL.value());
         assertNotNull(messageExpiryProperty, "message expiry property must be present");
         assertTrue(messageExpiryProperty.value() < messageExpiryInterval, "Forwarded message expiry should be lowered");
+        assertTrue(publish.release(), "Last reference of publish should be released");
     }
 
     @Test
@@ -184,7 +185,7 @@ public class MessageExpirationTest extends AbstractServerIntegrationTest {
     public void givenPublishWithMessageExpiryPropertyWhenItsForwardedToSubscriberThenExpiryValueHasToBeDeducedByTheTimeSpentInBroker() throws InterruptedException {
         int messageExpiryInterval = 10; // seconds
         // avoid the keep alive period could disconnect
-        connectLowLevel((int)(messageExpiryInterval * 1.5));
+        connectLowLevel((int) (messageExpiryInterval * 1.5));
 
         // subscribe with an identifier
         MqttMessage received = lowLevelClient.subscribeWithIdentifier("temperature/living",
@@ -225,6 +226,7 @@ public class MessageExpirationTest extends AbstractServerIntegrationTest {
         Integer expirySeconds = ((MqttProperties.IntegerProperty) expiryProp).value();
 
         assertTrue(expirySeconds < messageExpiryInterval, "Publish's expiry has to be updated");
+        assertTrue(publishMessage.release(), "Last reference of publish should be released");
     }
 
     private void consumesPublishesInflightWindow(int inflightWindowSize) throws InterruptedException {
@@ -236,6 +238,7 @@ public class MessageExpirationTest extends AbstractServerIntegrationTest {
             MqttPublishMessage publish = (MqttPublishMessage) mqttMessage;
             assertEquals(Integer.toString(i), publish.payload().toString(StandardCharsets.UTF_8));
             int packetId = publish.variableHeader().packetId();
+            assertTrue(publish.release(), "Reference of publish should be released");
 
             MqttFixedHeader fixedHeader = new MqttFixedHeader(MqttMessageType.PUBACK, false, AT_MOST_ONCE,
                 false, 0);
@@ -255,7 +258,7 @@ public class MessageExpirationTest extends AbstractServerIntegrationTest {
                     .messageExpiryInterval(messageExpiryInterval);
             }
 
-           builder.send();
+            builder.send();
         }
     }
 }

--- a/broker/src/test/java/io/moquette/integration/mqtt5/SubscriptionWithIdentifierTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/SubscriptionWithIdentifierTest.java
@@ -14,8 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class SubscriptionWithIdentifierTest extends AbstractSubscriptionIntegrationTest {
 
@@ -45,7 +44,9 @@ public class SubscriptionWithIdentifierTest extends AbstractSubscriptionIntegrat
             .until(lowLevelClient::hasReceivedMessages);
         MqttMessage mqttMsg = lowLevelClient.receiveNextMessage(Duration.ofSeconds(1));
         verifyOfType(mqttMsg, MqttMessageType.PUBLISH);
-        verifySubscriptionIdentifier(123, (MqttPublishMessage) mqttMsg);
+        MqttPublishMessage mqttPublish = (MqttPublishMessage) mqttMsg;
+        verifySubscriptionIdentifier(123, mqttPublish);
+        assertTrue(mqttPublish.release(), "Reference of publish should be released");
     }
 
     private static void verifySubscriptionIdentifier(int expectedSubscriptionIdentifier, MqttPublishMessage publish) {
@@ -82,6 +83,8 @@ public class SubscriptionWithIdentifierTest extends AbstractSubscriptionIntegrat
             .until(lowLevelClient::hasReceivedMessages);
         MqttMessage mqttMsg = lowLevelClient.receiveNextMessage(Duration.ofSeconds(1));
         verifyOfType(mqttMsg, MqttMessageType.PUBLISH);
-        verifySubscriptionIdentifier(123, (MqttPublishMessage) mqttMsg);
+        MqttPublishMessage mqttPublish = (MqttPublishMessage) mqttMsg;
+        verifySubscriptionIdentifier(123, mqttPublish);
+        assertTrue(mqttPublish.release(), "Reference of publish should be released");
     }
 }

--- a/broker/src/test/java/io/moquette/integration/mqtt5/TestUtils.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/TestUtils.java
@@ -32,11 +32,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestUtils {
-    static void verifyPublishedMessage(Mqtt5BlockingClient client, Consumer<Mqtt5Publish> verifier, int timeoutSeconds) throws Exception {
+    static void verifyPublishedMessage(Mqtt5BlockingClient client, int timeoutSeconds, Consumer<Mqtt5Publish> verifier) throws InterruptedException {
         try (Mqtt5BlockingClient.Mqtt5Publishes publishes = client.publishes(MqttGlobalPublishFilter.ALL)) {
             Optional<Mqtt5Publish> publishMessage = publishes.receive(timeoutSeconds, TimeUnit.SECONDS);
             if (!publishMessage.isPresent()) {
-                fail("Expected to receive a publish message");
+                fail("Expected to receive a publish in " + timeoutSeconds + " seconds");
                 return;
             }
             verifier.accept(publishMessage.get());

--- a/broker/src/test/java/io/moquette/testclient/Client.java
+++ b/broker/src/test/java/io/moquette/testclient/Client.java
@@ -18,6 +18,7 @@ package io.moquette.testclient;
 
 import io.moquette.BrokerConstants;
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.ByteBuf;
 import io.netty.channel.*;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
@@ -78,9 +79,9 @@ public class Client {
                 @Override
                 public void initChannel(SocketChannel ch) throws Exception {
                     ChannelPipeline pipeline = ch.pipeline();
-                    pipeline.addLast("decoder", new MqttDecoder());
-                    pipeline.addLast("encoder", MqttEncoder.INSTANCE);
-                    pipeline.addLast("handler", handler);
+                    pipeline.addLast("rawcli_decoder", new MqttDecoder());
+                    pipeline.addLast("rawcli_encoder", MqttEncoder.INSTANCE);
+                    pipeline.addLast("rawcli_handler", handler);
                 }
             });
 


### PR DESCRIPTION
## Release notes
Updated will publishing to contains also the message expire property.


## What does this PR do?

Change the publishing of will messages (`PostOffice.publishWill` method) to include also the message expiry property.

## Why is it important/What is the impact to the user?
Completes the development to support message expiry, implementing the will publishing part.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the Changelog if it's a feature or a fix that has to be reported

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## How to test this PR locally

<!-- Recommended
Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Relates #818

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->
