### PR TITLE
Fixed #831: changed several cases where a shared readerIndex was changed

### DIFF
--- a/broker/src/main/java/io/moquette/broker/DebugUtils.java
+++ b/broker/src/main/java/io/moquette/broker/DebugUtils.java
@@ -23,10 +23,7 @@ import java.nio.charset.StandardCharsets;
 public final class DebugUtils {
 
     public static String payload2Str(ByteBuf content) {
-        final int readerPin = content.readableBytes();
-        final String result = content.toString(StandardCharsets.UTF_8);
-        content.readerIndex(readerPin);
-        return result;
+        return content.toString(StandardCharsets.UTF_8);
     }
 
     private DebugUtils() {

--- a/broker/src/main/java/io/moquette/broker/Utils.java
+++ b/broker/src/main/java/io/moquette/broker/Utils.java
@@ -13,7 +13,6 @@
  *
  * You may elect to redistribute this code under either of these licenses.
  */
-
 package io.moquette.broker;
 
 import io.netty.buffer.ByteBuf;
@@ -40,14 +39,6 @@ public final class Utils {
 
     public static int messageId(MqttMessage msg) {
         return ((MqttMessageIdVariableHeader) msg.variableHeader()).messageId();
-    }
-
-    public static byte[] readBytesAndRewind(ByteBuf payload) {
-        byte[] payloadContent = new byte[payload.readableBytes()];
-        int mark = payload.readerIndex();
-        payload.readBytes(payloadContent);
-        payload.readerIndex(mark);
-        return payloadContent;
     }
 
     public static MqttVersion versionFromConnect(MqttConnectMessage msg) {

--- a/broker/src/main/java/io/moquette/persistence/SegmentedPersistentQueueSerDes.java
+++ b/broker/src/main/java/io/moquette/persistence/SegmentedPersistentQueueSerDes.java
@@ -57,7 +57,7 @@ class SegmentedPersistentQueueSerDes {
     private void writePayload(ByteBuffer target, ByteBuf source) {
         final int payloadSize = source.readableBytes();
         byte[] rawBytes = new byte[payloadSize];
-        source.readBytes(rawBytes).release();
+        source.getBytes(source.readerIndex(), rawBytes).release();
         target.putInt(payloadSize);
         target.put(rawBytes);
     }


### PR DESCRIPTION
DebugUtils.payload2Str set the readerIndex to the readableBytes, witch was simply wrong. 

Utils.readBytesAndRewind was unused and thus removed. Though it changed the readerIndex, it also reset it, but this use would still have not been thread-safe.

SegmentedPersistentQueueSerDes use of readBytes (that changes the readerIndex) was changed to getBytes which does not change the readerIndex.

Closes #831
