### PR TITLE
Fixed SegmentedQueues not being cleaned up on session purge

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.19-SNAPSHOT
+   [fix] Fixed SegmentedQueues not being cleaned up on session purge. (#833)
 
 Version 0.18:
    [fix] Update Netty to 4.1.116 and H2 2.1.214

--- a/broker/src/main/java/io/moquette/broker/unsafequeues/Queue.java
+++ b/broker/src/main/java/io/moquette/broker/unsafequeues/Queue.java
@@ -157,6 +157,15 @@ public class Queue {
     }
 
     /**
+     * Close the Queue and release all resources.
+     */
+    public void close() {
+        queuePool.purgeQueue(name);
+        headSegment = null;
+        tailSegment = null;
+    }
+
+    /**
      * Read next message or return null if the queue has no data.
      * */
     public Optional<ByteBuffer> dequeue() throws QueueException {

--- a/broker/src/main/java/io/moquette/broker/unsafequeues/QueuePool.java
+++ b/broker/src/main/java/io/moquette/broker/unsafequeues/QueuePool.java
@@ -389,9 +389,10 @@ public class QueuePool {
         final LinkedList<SegmentRef> segmentRefs = queueSegments.remove(queueName);
         SegmentRef segmentRef = segmentRefs.pollLast();
         segmentsAllocationLock.lock();
+        LOG.debug("Purging segments for queue {}", queueName);
         try {
             while (segmentRef != null) {
-                LOG.debug("Consumed tail segment {} from queue {}", segmentRef, queueName);
+                LOG.debug("Purging segment {} from queue {}", segmentRef, queueName);
                 recycledSegments.add(segmentRef);
                 segmentRef = segmentRefs.pollLast();
             }

--- a/broker/src/main/java/io/moquette/persistence/SegmentPersistentQueue.java
+++ b/broker/src/main/java/io/moquette/persistence/SegmentPersistentQueue.java
@@ -63,5 +63,6 @@ public class SegmentPersistentQueue extends AbstractSessionMessageQueue<SessionR
     @Override
     public void closeAndPurge() {
         closed = true;
+        segmentedQueue.close();
     }
 }


### PR DESCRIPTION
Segmented queues were closed, but not cleared on session close. This resulted in segments not being returned to the pool, and thus disk-space not being released. The queues were also not removed from the QueuePool, resulting in a memory leak.

Relates #734
