### PR TITLE
Fixed empty shared subscriptions list remaining forever

### DIFF
--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrieSubscriptionDirectory.java
@@ -192,13 +192,13 @@ public class CTrieSubscriptionDirectory implements ISubscriptionsDirectory {
 
     @Override
     public void removeSharedSubscriptionsForClient(String clientId) {
-        List<SharedSubscription> sessionSharedSubscriptions = clientSharedSubscriptions
-            .computeIfAbsent(clientId, s -> Collections.emptyList());
-
-        // remove the client from all shared subscriptions
-        for (SharedSubscription subscription : sessionSharedSubscriptions) {
-            UnsubscribeRequest request = UnsubscribeRequest.buildShared(subscription.getShareName(), subscription.topicFilter(), clientId);
-            ctrie.removeFromTree(request);
+        List<SharedSubscription> sessionSharedSubscriptions = clientSharedSubscriptions.remove(clientId);
+        if (sessionSharedSubscriptions != null) {
+            // remove the client from all shared subscriptions
+            for (SharedSubscription subscription : sessionSharedSubscriptions) {
+                UnsubscribeRequest request = UnsubscribeRequest.buildShared(subscription.getShareName(), subscription.topicFilter(), clientId);
+                ctrie.removeFromTree(request);
+            }
         }
 
         subscriptionsRepository.removeAllSharedSubscriptions(clientId);

--- a/broker/src/main/java/io/moquette/persistence/H2SubscriptionsRepository.java
+++ b/broker/src/main/java/io/moquette/persistence/H2SubscriptionsRepository.java
@@ -81,7 +81,7 @@ public class H2SubscriptionsRepository implements ISubscriptionsRepository {
     public void removeAllSharedSubscriptions(String clientId) {
         final String sharedSubsMapName = sharedSubscriptions.get(clientId);
         if (sharedSubsMapName == null) {
-            LOG.info("Removing all shared subscription of a non existing client: {}", clientId);
+            LOG.debug("Removing all shared subscription of a non existing client: {}", clientId);
             return;
         }
         wipeAllSharedSubscripptions(clientId, sharedSubsMapName);


### PR DESCRIPTION
Even for clients that never made shared subscriptions, upon session clean, an empty shared subscriptions list was created and never removed.

Relates #734 
