### PR TITLE
Optimised page file opening

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.18-SNAPSHOT:
+   [fix] Optimised page file opening for disk-based queues. (#837)
    [feature] Manage payload format indicator property, when set verify payload format. (#826)
    [refactoring] Refactory of PostOffice to pass publish message in hits entirety avoiding decomposition into single parameters. (#827)
    [feature] Add Netty native transport support on MacOS. Bundle all the native transport module by default (#806)


### PR DESCRIPTION
Instead of mapping the entire page file every time a segment is re-used, we map the page file once, and re-use the mapped buffer for each segment.
The cache uses WeakReferences to ensure that a page file that is no longer used does not stay mapped.
