### PR TITLE
Fixes 841: Incorrect reference used in compareAndSet in CTrie.cleanTomb.

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.18-SNAPSHOT:
+   [fix] Incorrect reference used in compareAndSet in CTrie.cleanTomb. (#841)
    [feature] Implement response-information property for request-response flow. (#840)
    [fix] Optimised page file opening for disk-based queues. (#837)
    [feature] Manage payload format indicator property, when set verify payload format. (#826)

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CNode.java
@@ -99,9 +99,9 @@ class CNode implements Comparable<CNode> {
         }
     }
 
-    public void remove(INode node) {
+    public INode remove(INode node) {
         int idx = findIndexForToken(node.mainNode().token);
-        this.children.remove(idx);
+        return this.children.remove(idx);
     }
 
     private List<Subscription> sharedSubscriptions() {

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
@@ -360,10 +360,7 @@ public class CTrie {
             }
         }
         if (cnode instanceof TNode) {
-            // this inode is a tomb, has no clients and should be cleaned up
-            // Because we implemented cleanTomb below, this should be rare, but possible
-            // Consider calling cleanTomb here too
-            return Action.OK;
+            return cleanTomb(inode, iParent);
         }
         if (cnode.containsOnly(clientId) && topic.isEmpty() && cnode.allChildren().isEmpty()) {
             // last client to leave this node, AND there are no downstream children, remove via TNode tomb
@@ -393,9 +390,10 @@ public class CTrie {
      * @return REPEAT if this method wasn't successful or OK.
      */
     private Action cleanTomb(INode inode, INode iParent) {
-        CNode updatedCnode = iParent.mainNode().copy();
+        CNode origCnode = iParent.mainNode();
+        CNode updatedCnode = origCnode.copy();
         updatedCnode.remove(inode);
-        return iParent.compareAndSet(iParent.mainNode(), updatedCnode) ? Action.OK : Action.REPEAT;
+        return iParent.compareAndSet(origCnode, updatedCnode) ? Action.OK : Action.REPEAT;
     }
 
     public int size() {

--- a/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
+++ b/broker/src/main/java/io/moquette/broker/subscriptions/CTrie.java
@@ -392,8 +392,15 @@ public class CTrie {
     private Action cleanTomb(INode inode, INode iParent) {
         CNode origCnode = iParent.mainNode();
         CNode updatedCnode = origCnode.copy();
-        updatedCnode.remove(inode);
-        return iParent.compareAndSet(origCnode, updatedCnode) ? Action.OK : Action.REPEAT;
+        INode removed = updatedCnode.remove(inode);
+        if (removed == inode) {
+            return iParent.compareAndSet(origCnode, updatedCnode) ? Action.OK : Action.REPEAT;
+        } else {
+            // The node removed (from the copy!) was not the node we expected to remove.
+            // Probably because another thread replaced the TNode with a live node, so
+            // we don't need to clean it and can return success.
+            return Action.OK;
+        }
     }
 
     public int size() {


### PR DESCRIPTION
cleanTomb used compareAndSet to update a reference, but incorrectly re-fetched the 'original' instead of using the version that was used to make the copy. The result was that in case of a conflict, the changes of one thread would be overwritten by another thread.

If cleanTomb failes when called from the remove method, the node is already replaced by a TNode, and the subsequent call will
re-try to clean the TNode. The node removed by cleanTomb may already have been replaced with a live node by another thread, so
cleanTomb checks if the removed node actually was the intended node before committing the results.

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the Changelog if it's a feature or a fix that has to be reported

- bug
- Closes #841