### PR TITLE
Implement topic alias management

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.18-SNAPSHOT:
+   [feature] Topic alias: implemented handling of topic alias received by publishers. (#873)
    [feature] Flow-control: Handled client's receive maximum property to configure the inflight window through the client. (#858)
    [feature] Generate correct MANIFEST.MF with bnd-maven-plugin. (#848)
    [feature] Flow-control: implemented publish's quota management on the server side. (#852)

--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -124,8 +124,6 @@ public final class BrokerConstants {
     public static final String BUGSNAG_ENABLE_PROPERTY_NAME = "use_bugsnag";
     public static final String BUGSNAG_TOKEN_PROPERTY_NAME = "bugsnag.token";
 
-    public static final String STORAGE_CLASS_NAME = "storage_class";
-
     @Deprecated
     public static final String PERSISTENT_CLIENT_EXPIRATION_PROPERTY_NAME = IConfig.PERSISTENT_CLIENT_EXPIRATION_PROPERTY_NAME;
 
@@ -133,6 +131,8 @@ public final class BrokerConstants {
     public static final int INFLIGHT_WINDOW_SIZE = 10;
     public static final int INFINITE_SESSION_EXPIRY = 0xFFFFFFFF;
     public static final int RECEIVE_MAXIMUM = 65 * 1024;
+
+    public static final int DISABLED_TOPIC_ALIAS = 0;
 
     private BrokerConstants() {
     }

--- a/broker/src/main/java/io/moquette/broker/BrokerConfiguration.java
+++ b/broker/src/main/java/io/moquette/broker/BrokerConfiguration.java
@@ -27,6 +27,7 @@ class BrokerConfiguration {
     private final boolean allowZeroByteClientId;
     private final boolean reauthorizeSubscriptionsOnConnect;
     private final int bufferFlushMillis;
+    private final int topicAliasMaximum;
     // integer max value means that the property is unset
     private int receiveMaximum;
 
@@ -67,6 +68,8 @@ class BrokerConfiguration {
         }
 
         receiveMaximum = props.intProp(IConfig.RECEIVE_MAXIMUM, BrokerConstants.RECEIVE_MAXIMUM);
+
+        topicAliasMaximum = props.intProp(IConfig.TOPIC_ALIAS_MAXIMUM_PROPERTY_NAME, BrokerConstants.DISABLED_TOPIC_ALIAS);
     }
 
     // test method
@@ -86,12 +89,21 @@ class BrokerConfiguration {
     // test method
     public BrokerConfiguration(boolean allowAnonymous, boolean peerCertificateAsUsername, boolean allowZeroByteClientId,
                                boolean reauthorizeSubscriptionsOnConnect, int bufferFlushMillis, int receiveMaximum) {
+        this(allowAnonymous, peerCertificateAsUsername, allowZeroByteClientId, reauthorizeSubscriptionsOnConnect,
+            bufferFlushMillis, receiveMaximum, BrokerConstants.DISABLED_TOPIC_ALIAS);
+    }
+
+    // test method
+    public BrokerConfiguration(boolean allowAnonymous, boolean peerCertificateAsUsername, boolean allowZeroByteClientId,
+                               boolean reauthorizeSubscriptionsOnConnect, int bufferFlushMillis, int receiveMaximum,
+                               int topicAliasMaximum) {
         this.allowAnonymous = allowAnonymous;
         this.peerCertificateAsUsername = peerCertificateAsUsername;
         this.allowZeroByteClientId = allowZeroByteClientId;
         this.reauthorizeSubscriptionsOnConnect = reauthorizeSubscriptionsOnConnect;
         this.bufferFlushMillis = bufferFlushMillis;
         this.receiveMaximum = receiveMaximum;
+        this.topicAliasMaximum = topicAliasMaximum;
     }
 
     public boolean isAllowAnonymous() {
@@ -116,5 +128,9 @@ class BrokerConfiguration {
 
     public int receiveMaximum() {
         return receiveMaximum;
+    }
+
+    public int topicAliasMaximum() {
+        return topicAliasMaximum;
     }
 }

--- a/broker/src/main/java/io/moquette/broker/TopicAliasMapping.java
+++ b/broker/src/main/java/io/moquette/broker/TopicAliasMapping.java
@@ -1,18 +1,18 @@
 /*
  *
- *  * Copyright (c) 2012-2024 The original author or authors
- *  * ------------------------------------------------------
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Public License v1.0
- *  * and Apache License v2.0 which accompanies this distribution.
- *  *
- *  * The Eclipse Public License is available at
- *  * http://www.eclipse.org/legal/epl-v10.html
- *  *
- *  * The Apache License v2.0 is available at
- *  * http://www.opensource.org/licenses/apache2.0.php
- *  *
- *  * You may elect to redistribute this code under either of these licenses.
+ * Copyright (c) 2012-2024 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
  *
  */
 

--- a/broker/src/main/java/io/moquette/broker/TopicAliasMapping.java
+++ b/broker/src/main/java/io/moquette/broker/TopicAliasMapping.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *  * Copyright (c) 2012-2024 The original author or authors
+ *  * ------------------------------------------------------
+ *  * All rights reserved. This program and the accompanying materials
+ *  * are made available under the terms of the Eclipse Public License v1.0
+ *  * and Apache License v2.0 which accompanies this distribution.
+ *  *
+ *  * The Eclipse Public License is available at
+ *  * http://www.eclipse.org/legal/epl-v10.html
+ *  *
+ *  * The Apache License v2.0 is available at
+ *  * http://www.opensource.org/licenses/apache2.0.php
+ *  *
+ *  * You may elect to redistribute this code under either of these licenses.
+ *
+ */
+
+package io.moquette.broker;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Implements a mapping cache so that the binding key -> value is also reversed,
+ * it maintains the invariant to be a 1:1 mapping.
+ * */
+class TopicAliasMapping {
+
+    private final Map<String, Integer> direct = new HashMap<>();
+    private final Map<Integer, String> reversed = new HashMap<>();
+
+    void update(String topicName, int topicAlias) {
+        Integer previousAlias = direct.put(topicName, topicAlias);
+        if (previousAlias != null) {
+            reversed.remove(previousAlias);
+        }
+        reversed.put(topicAlias, topicName);
+    }
+
+    Optional<String> topicFromAlias(int topicAlias) {
+        return Optional.ofNullable(reversed.get(topicAlias));
+    }
+
+    int size() {
+        return reversed.size();
+    }
+}

--- a/broker/src/main/java/io/moquette/broker/config/FluentConfig.java
+++ b/broker/src/main/java/io/moquette/broker/config/FluentConfig.java
@@ -9,31 +9,7 @@ import java.util.Locale;
 import java.util.Properties;
 import java.util.function.Consumer;
 
-import static io.moquette.broker.config.IConfig.ACL_FILE_PROPERTY_NAME;
-import static io.moquette.broker.config.IConfig.ALLOW_ANONYMOUS_PROPERTY_NAME;
-import static io.moquette.broker.config.IConfig.AUTHENTICATOR_CLASS_NAME;
-import static io.moquette.broker.config.IConfig.AUTHORIZATOR_CLASS_NAME;
-import static io.moquette.broker.config.IConfig.BUFFER_FLUSH_MS_PROPERTY_NAME;
-import static io.moquette.broker.config.IConfig.DATA_PATH_PROPERTY_NAME;
-import static io.moquette.broker.config.IConfig.DEFAULT_NETTY_MAX_BYTES_IN_MESSAGE;
-import static io.moquette.broker.config.IConfig.ENABLE_TELEMETRY_NAME;
-import static io.moquette.broker.config.IConfig.PEER_CERTIFICATE_AS_USERNAME;
-import static io.moquette.broker.config.IConfig.PORT_PROPERTY_NAME;
-import static io.moquette.broker.config.IConfig.JKS_PATH_PROPERTY_NAME;
-import static io.moquette.broker.config.IConfig.KEY_MANAGER_PASSWORD_PROPERTY_NAME;
-import static io.moquette.broker.config.IConfig.KEY_STORE_PASSWORD_PROPERTY_NAME;
-import static io.moquette.broker.config.IConfig.KEY_STORE_TYPE;
-import static io.moquette.broker.config.IConfig.NETTY_MAX_BYTES_PROPERTY_NAME;
-import static io.moquette.broker.config.IConfig.PASSWORD_FILE_PROPERTY_NAME;
-import static io.moquette.broker.config.IConfig.PERSISTENCE_ENABLED_PROPERTY_NAME;
-import static io.moquette.broker.config.IConfig.PERSISTENT_CLIENT_EXPIRATION_PROPERTY_NAME;
-import static io.moquette.broker.config.IConfig.PERSISTENT_QUEUE_TYPE_PROPERTY_NAME;
-import static io.moquette.broker.config.IConfig.RECEIVE_MAXIMUM;
-import static io.moquette.broker.config.IConfig.HOST_PROPERTY_NAME;
-import static io.moquette.broker.config.IConfig.SESSION_QUEUE_SIZE;
-import static io.moquette.broker.config.IConfig.SSL_PORT_PROPERTY_NAME;
-import static io.moquette.broker.config.IConfig.SSL_PROVIDER;
-import static io.moquette.broker.config.IConfig.WEB_SOCKET_PORT_PROPERTY_NAME;
+import static io.moquette.broker.config.IConfig.*;
 
 /**
  *  DSL to create Moquette config.
@@ -206,6 +182,11 @@ public class FluentConfig {
 
     public FluentConfig receiveMaximum(int receiveMaximum) {
         configAccumulator.put(RECEIVE_MAXIMUM, Integer.valueOf(receiveMaximum).toString());
+        return this;
+    }
+
+    public FluentConfig topicAliasMaximum(int topicAliasMaximum) {
+        configAccumulator.put(TOPIC_ALIAS_MAXIMUM_PROPERTY_NAME, Integer.valueOf(topicAliasMaximum).toString());
         return this;
     }
 

--- a/broker/src/main/java/io/moquette/broker/config/FluentConfig.java
+++ b/broker/src/main/java/io/moquette/broker/config/FluentConfig.java
@@ -9,7 +9,32 @@ import java.util.Locale;
 import java.util.Properties;
 import java.util.function.Consumer;
 
-import static io.moquette.broker.config.IConfig.*;
+import static io.moquette.broker.config.IConfig.ACL_FILE_PROPERTY_NAME;
+import static io.moquette.broker.config.IConfig.ALLOW_ANONYMOUS_PROPERTY_NAME;
+import static io.moquette.broker.config.IConfig.AUTHENTICATOR_CLASS_NAME;
+import static io.moquette.broker.config.IConfig.AUTHORIZATOR_CLASS_NAME;
+import static io.moquette.broker.config.IConfig.BUFFER_FLUSH_MS_PROPERTY_NAME;
+import static io.moquette.broker.config.IConfig.DATA_PATH_PROPERTY_NAME;
+import static io.moquette.broker.config.IConfig.DEFAULT_NETTY_MAX_BYTES_IN_MESSAGE;
+import static io.moquette.broker.config.IConfig.ENABLE_TELEMETRY_NAME;
+import static io.moquette.broker.config.IConfig.HOST_PROPERTY_NAME;
+import static io.moquette.broker.config.IConfig.JKS_PATH_PROPERTY_NAME;
+import static io.moquette.broker.config.IConfig.KEY_MANAGER_PASSWORD_PROPERTY_NAME;
+import static io.moquette.broker.config.IConfig.KEY_STORE_PASSWORD_PROPERTY_NAME;
+import static io.moquette.broker.config.IConfig.KEY_STORE_TYPE;
+import static io.moquette.broker.config.IConfig.NETTY_MAX_BYTES_PROPERTY_NAME;
+import static io.moquette.broker.config.IConfig.PASSWORD_FILE_PROPERTY_NAME;
+import static io.moquette.broker.config.IConfig.PEER_CERTIFICATE_AS_USERNAME;
+import static io.moquette.broker.config.IConfig.PERSISTENCE_ENABLED_PROPERTY_NAME;
+import static io.moquette.broker.config.IConfig.PERSISTENT_CLIENT_EXPIRATION_PROPERTY_NAME;
+import static io.moquette.broker.config.IConfig.PERSISTENT_QUEUE_TYPE_PROPERTY_NAME;
+import static io.moquette.broker.config.IConfig.PORT_PROPERTY_NAME;
+import static io.moquette.broker.config.IConfig.RECEIVE_MAXIMUM;
+import static io.moquette.broker.config.IConfig.SESSION_QUEUE_SIZE;
+import static io.moquette.broker.config.IConfig.SSL_PORT_PROPERTY_NAME;
+import static io.moquette.broker.config.IConfig.SSL_PROVIDER;
+import static io.moquette.broker.config.IConfig.TOPIC_ALIAS_MAXIMUM_PROPERTY_NAME;
+import static io.moquette.broker.config.IConfig.WEB_SOCKET_PORT_PROPERTY_NAME;
 
 /**
  *  DSL to create Moquette config.

--- a/broker/src/main/java/io/moquette/broker/config/IConfig.java
+++ b/broker/src/main/java/io/moquette/broker/config/IConfig.java
@@ -67,6 +67,7 @@ public abstract class IConfig {
     public static final String NETTY_MAX_BYTES_PROPERTY_NAME = "netty.mqtt.message_size";
     public static final String MAX_SERVER_GRANTED_QOS_PROPERTY_NAME = "max_server_granted_qos";
     public static final int DEFAULT_NETTY_MAX_BYTES_IN_MESSAGE = 8092;
+    public static final String TOPIC_ALIAS_MAXIMUM_PROPERTY_NAME = "topic_alias_maximum";
 
     public abstract void setProperty(String name, String value);
 

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
@@ -25,24 +25,23 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
-import io.netty.handler.codec.mqtt.MqttMessageBuilders;
-import io.netty.handler.codec.mqtt.MqttPublishMessage;
-import io.netty.handler.codec.mqtt.MqttQoS;
-import io.netty.handler.codec.mqtt.MqttVersion;
+import io.netty.handler.codec.mqtt.*;
 //import org.jetbrains.annotations.NotNull;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.concurrent.*;
 
 import static io.moquette.BrokerConstants.NO_BUFFER_FLUSH;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonMap;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MQTTConnectionPublishTest {
 
@@ -53,23 +52,27 @@ public class MQTTConnectionPublishTest {
     private MQTTConnection sut;
     private EmbeddedChannel channel;
     private SessionRegistry sessionRegistry;
-    private MqttMessageBuilders.ConnectBuilder connMsg;
     private MemoryQueueRepository queueRepository;
     private ScheduledExecutorService scheduler;
+    private ByteBuf payload;
+    private BlockingQueue<MqttPublishMessage> forwardedPublishes;
 
     @BeforeEach
     public void setUp() {
-        connMsg = MqttMessageBuilders.connect().protocolVersion(MqttVersion.MQTT_3_1).cleanSession(true);
+        forwardedPublishes = new LinkedBlockingQueue<>();
 
         BrokerConfiguration config = new BrokerConfiguration(true, true, false, NO_BUFFER_FLUSH);
 
         scheduler = Executors.newScheduledThreadPool(1);
 
         createMQTTConnection(config);
+
+        payload = Unpooled.copiedBuffer("Hello MQTT world!".getBytes(UTF_8));
     }
 
     @AfterEach
     public void tearDown() {
+        payload.release();
         scheduler.shutdown();
     }
 
@@ -94,7 +97,31 @@ public class MQTTConnectionPublishTest {
         ISessionsRepository fakeSessionRepo = memorySessionsRepository();
         sessionRegistry = new SessionRegistry(subscriptions, fakeSessionRepo, queueRepository, permitAll, scheduler, loopsGroup);
         final PostOffice postOffice = new PostOffice(subscriptions,
-            new MemoryRetainedRepository(), sessionRegistry, fakeSessionRepo, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup);
+            new MemoryRetainedRepository(), sessionRegistry, fakeSessionRepo, ConnectionTestUtils.NO_OBSERVERS_INTERCEPTOR, permitAll, loopsGroup) {
+
+            // mock the publish forwarder method
+            @Override
+            CompletableFuture<Void> receivedPublishQos0(MQTTConnection connection, String username, String clientID,
+                                                        MqttPublishMessage msg,
+                                                        Instant messageExpiry) {
+                forwardedPublishes.add(msg);
+                return null;
+            }
+
+            @Override
+            RoutingResults receivedPublishQos1(MQTTConnection connection, String username, int messageID,
+                                               MqttPublishMessage msg, Instant messageExpiry) {
+                forwardedPublishes.add(msg);
+                return null;
+            }
+
+            @Override
+            RoutingResults receivedPublishQos2(MQTTConnection connection, MqttPublishMessage msg, String username,
+                                               Instant messageExpiry) {
+                forwardedPublishes.add(msg);
+                return null;
+            }
+        };
         return new MQTTConnection(channel, config, mockAuthenticator, sessionRegistry, postOffice);
     }
 
@@ -106,7 +133,6 @@ public class MQTTConnectionPublishTest {
     @Test
     public void dropConnectionOnPublishWithInvalidTopicFormat() throws ExecutionException, InterruptedException {
         // Connect message with clean session set to true and client id is null.
-        final ByteBuf payload = Unpooled.copiedBuffer("Hello MQTT world!".getBytes(UTF_8));
         MqttPublishMessage publish = MqttMessageBuilders.publish()
             .topicName("")
             .retained(false)
@@ -117,7 +143,148 @@ public class MQTTConnectionPublishTest {
 
         // Verify
         assertFalse(channel.isOpen(), "Connection should be closed by the broker");
-        payload.release();
     }
 
+    @Test
+    public void givenPublishMessageWithInvalidTopicAliasThenConnectionDisconnects() throws ExecutionException, InterruptedException {
+        connectMqtt5AndVerifyAck(sut);
+
+        MqttPublishMessage publish = createPublishWithTopicNameAndTopicAlias("kitchen/blinds", 0);
+
+        // Exercise
+        PostOffice.RouteResult pubResult = sut.processPublish(publish);
+
+        // Verify
+        assertNotNull(pubResult);
+        assertFalse(pubResult.isSuccess());
+        assertFalse(channel.isOpen(), "Connection should be closed by the broker");
+        // read last message sent
+        MqttMessage disconnectMsg = channel.readOutbound();
+        assertEquals(MqttMessageType.DISCONNECT, disconnectMsg.fixedHeader().messageType());
+        assertEquals(MqttReasonCodes.Disconnect.TOPIC_ALIAS_INVALID.byteValue(), ((MqttReasonCodeAndPropertiesVariableHeader) disconnectMsg.variableHeader()).reasonCode());
+    }
+
+    @Test
+    public void givenPublishMessageWithUnmappedTopicAliasThenPublishMessageIsForwardedWithoutAliasAndJustTopicName() throws ExecutionException, InterruptedException {
+        connectMqtt5AndVerifyAck(sut);
+
+        String topicName = "kitchen/blinds";
+        MqttPublishMessage publish = createPublishWithTopicNameAndTopicAlias(topicName, 10);
+
+        // Exercise
+        PostOffice.RouteResult pubResult = sut.processPublish(publish);
+
+        // Verify
+        assertNotNull(pubResult);
+        assertTrue(pubResult.isSuccess());
+        assertTrue(channel.isOpen(), "Connection should be open");
+
+        // Read the forwarded publish message
+        MqttPublishMessage reshapedPublish = forwardedPublishes.poll(1, TimeUnit.SECONDS);
+        assertNotNull(reshapedPublish, "Wait time expired on reading forwarded publish message");
+        assertEquals(topicName, reshapedPublish.variableHeader().topicName());
+        verifyNotContainsProperty(reshapedPublish.variableHeader(), MqttProperties.MqttPropertyType.TOPIC_ALIAS);
+    }
+
+    @Test
+    public void givenPublishMessageWithAlreadyMappedTopicAliasThenPublishMessageIsForwardedWithoutAliasAndJustTopicName() throws ExecutionException, InterruptedException {
+        connectMqtt5AndVerifyAck(sut);
+
+        String topicName = "kitchen/blinds";
+        MqttPublishMessage publish = createPublishWithTopicNameAndTopicAlias(topicName, 10);
+
+        // setup the alias mapping with a first publish message
+        PostOffice.RouteResult pubResult = sut.processPublish(publish);
+        assertNotNull(pubResult);
+        assertTrue(pubResult.isSuccess());
+        assertTrue(channel.isOpen(), "Connection should be open");
+        MqttPublishMessage reshapedPublish = forwardedPublishes.poll(1, TimeUnit.SECONDS);
+        assertNotNull(reshapedPublish, "Wait time expired on reading forwarded publish message");
+
+        // Exercise, use the mapped alias
+        MqttPublishMessage publishWithJustAlias = createPublishWithTopicNameAndTopicAlias(10);
+        pubResult = sut.processPublish(publishWithJustAlias);
+
+        // Verify
+        assertNotNull(pubResult);
+        assertTrue(pubResult.isSuccess());
+        assertTrue(channel.isOpen(), "Connection should be open");
+
+        // Read the forwarded publish message
+        reshapedPublish = forwardedPublishes.poll(1, TimeUnit.SECONDS);
+        assertNotNull(reshapedPublish, "Wait time expired on reading forwarded publish message");
+        assertEquals(topicName, reshapedPublish.variableHeader().topicName());
+        verifyNotContainsProperty(reshapedPublish.variableHeader(), MqttProperties.MqttPropertyType.TOPIC_ALIAS);
+    }
+
+    @Test
+    public void givenPublishMessageWithUnmappedTopicAliasAndEmptyTopicNameThenConnectionDisconnects() throws ExecutionException, InterruptedException {
+        connectMqtt5AndVerifyAck(sut);
+
+        MqttPublishMessage publish = createPublishWithTopicNameAndTopicAlias("", 10);
+
+        // Exercise
+        PostOffice.RouteResult pubResult = sut.processPublish(publish);
+
+        // Verify
+        assertNotNull(pubResult);
+        assertFalse(pubResult.isSuccess());
+        assertFalse(channel.isOpen(), "Connection should be closed by the broker");
+        // read last message sent
+        MqttMessage disconnectMsg = channel.readOutbound();
+        assertEquals(MqttMessageType.DISCONNECT, disconnectMsg.fixedHeader().messageType());
+        assertEquals(MqttReasonCodes.Disconnect.PROTOCOL_ERROR.byteValue(), ((MqttReasonCodeAndPropertiesVariableHeader) disconnectMsg.variableHeader()).reasonCode());
+    }
+
+    private static void verifyNotContainsProperty(MqttPublishVariableHeader header, MqttProperties.MqttPropertyType typeToVerify) {
+        Optional<? extends MqttProperties.MqttProperty> match = header.properties().listAll().stream()
+            .filter(mp -> mp.propertyId() == typeToVerify.value())
+            .findFirst();
+        assertFalse(match.isPresent(), "Found a property of type " + typeToVerify);
+    }
+
+    private MqttPublishMessage createPublishWithTopicNameAndTopicAlias(String topicName, int topicAlias) {
+        final MqttProperties propertiesWithTopicAlias = new MqttProperties();
+        propertiesWithTopicAlias.add(
+            new MqttProperties.IntegerProperty(
+                MqttProperties.MqttPropertyType.TOPIC_ALIAS.value(), topicAlias));
+
+        return MqttMessageBuilders.publish()
+            .topicName(topicName)
+            .properties(propertiesWithTopicAlias)
+            .qos(MqttQoS.AT_MOST_ONCE)
+            .payload(payload)
+            .build();
+    }
+
+    private MqttPublishMessage createPublishWithTopicNameAndTopicAlias(int topicAlias) {
+        final MqttProperties propertiesWithTopicAlias = new MqttProperties();
+        propertiesWithTopicAlias.add(
+            new MqttProperties.IntegerProperty(
+                MqttProperties.MqttPropertyType.TOPIC_ALIAS.value(), topicAlias));
+
+        return MqttMessageBuilders.publish()
+            .properties(propertiesWithTopicAlias)
+            .qos(MqttQoS.AT_MOST_ONCE)
+            .payload(payload)
+            .build();
+    }
+
+    private void connectMqtt5AndVerifyAck(MQTTConnection mqttConnection) {
+        MqttConnectMessage connect = MqttMessageBuilders.connect()
+            .protocolVersion(MqttVersion.MQTT_5)
+            .clientId(null)
+            .cleanSession(true)
+            .build();
+        PostOffice.RouteResult connectResult = mqttConnection.processConnect(connect);
+        assertNotNull(connectResult);
+        assertTrue(connectResult.isSuccess());
+        // given that CONN is processed by session event loop and from that is sent also the CONNACK, wait for
+        // connection to be active.
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(1))
+            .until(mqttConnection::isConnected);
+        MqttConnAckMessage connAckMsg = channel.readOutbound();
+        assertEquals(MqttMessageType.CONNACK, connAckMsg.fixedHeader().messageType());
+    }
 }

--- a/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
+++ b/broker/src/test/java/io/moquette/broker/MQTTConnectionPublishTest.java
@@ -248,10 +248,6 @@ public class MQTTConnectionPublishTest {
 
     @Test
     public void givenTopicAliasDisabledWhenPublishContainingTopicAliasIsReceivedThenConnectionIsDropped() {
-        // update code and test to implement the behaviour:
-        // If broker side the maximum topic alias is 0 or not send, means no topic alias should be received.
-        // If in such condition a broker receives a topic alias, it MUST drop the connection.
-
         // create a configuration with topic alias disabled
         BrokerConfiguration config = new BrokerConfiguration(true, false, true,
             false, NO_BUFFER_FLUSH, BrokerConstants.INFLIGHT_WINDOW_SIZE,

--- a/broker/src/test/java/io/moquette/broker/RetainBufferTest.java
+++ b/broker/src/test/java/io/moquette/broker/RetainBufferTest.java
@@ -1,0 +1,49 @@
+/*
+ *
+ *  * Copyright (c) 2012-2024 The original author or authors
+ *  * ------------------------------------------------------
+ *  * All rights reserved. This program and the accompanying materials
+ *  * are made available under the terms of the Eclipse Public License v1.0
+ *  * and Apache License v2.0 which accompanies this distribution.
+ *  *
+ *  * The Eclipse Public License is available at
+ *  * http://www.eclipse.org/legal/epl-v10.html
+ *  *
+ *  * The Apache License v2.0 is available at
+ *  * http://www.opensource.org/licenses/apache2.0.php
+ *  *
+ *  * You may elect to redistribute this code under either of these licenses.
+ *
+ */
+
+package io.moquette.broker;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RetainBufferTest {
+
+
+    @Test
+    public void testRetainedDuplicate() {
+        ByteBuf origin = Unpooled.buffer(10);
+        assertEquals(1, origin.refCnt());
+
+        ByteBuf retainedDup = origin.retainedDuplicate();
+        assertEquals(2, origin.refCnt());
+        assertEquals(2, retainedDup.refCnt());
+    }
+
+    @Test
+    public void testDuplicate() {
+        ByteBuf origin = Unpooled.buffer(10);
+        assertEquals(1, origin.refCnt());
+
+        ByteBuf duplicate = origin.duplicate();
+        assertEquals(1, origin.refCnt());
+        assertEquals(1, duplicate.refCnt());
+    }
+}

--- a/broker/src/test/java/io/moquette/broker/TopicAliasMappingTest.java
+++ b/broker/src/test/java/io/moquette/broker/TopicAliasMappingTest.java
@@ -1,0 +1,77 @@
+/*
+ *
+ *  * Copyright (c) 2012-2024 The original author or authors
+ *  * ------------------------------------------------------
+ *  * All rights reserved. This program and the accompanying materials
+ *  * are made available under the terms of the Eclipse Public License v1.0
+ *  * and Apache License v2.0 which accompanies this distribution.
+ *  *
+ *  * The Eclipse Public License is available at
+ *  * http://www.eclipse.org/legal/epl-v10.html
+ *  *
+ *  * The Apache License v2.0 is available at
+ *  * http://www.opensource.org/licenses/apache2.0.php
+ *  *
+ *  * You may elect to redistribute this code under either of these licenses.
+ *
+ */
+
+package io.moquette.broker;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TopicAliasMappingTest {
+
+    private TopicAliasMapping sut;
+
+    @BeforeEach
+    void setUp() {
+        sut = new TopicAliasMapping();
+    }
+
+    private static void verifyTopicName(String expected, Optional<String> topicName) {
+        assertTrue(topicName.isPresent());
+        assertEquals(expected, topicName.get());
+    }
+
+    @Test
+    public void givenAnEmptyMappingWhenNewBindingIsRequestedThenShouldBeRetrievable() {
+        sut.update("sensors/temperature", 12);
+
+        Optional<String> topicName = sut.topicFromAlias(12);
+        verifyTopicName("sensors/temperature", topicName);
+        assertEquals(1, sut.size());
+    }
+
+    @Test
+    public void givenAnExistingBindingWhenNewBindingWithSameTopicNameIsRequestedThenAliasIsUpdated() {
+        // first binding
+        sut.update("sensors/temperature", 12);
+
+        // second update with different alias
+        sut.update("sensors/temperature", 22);
+        assertEquals(1, sut.size());
+
+        Optional<String> topicName = sut.topicFromAlias(22);
+        verifyTopicName("sensors/temperature", topicName);
+    }
+
+    @Test
+    public void givenAnExistingBindingWhenNewBindingWithDifferentTopicNameAndSameTopicAliasIsRequestedThenAliasIsUpdated() {
+        // first binding
+        sut.update("sensors/temperature", 12);
+
+        // second update with different name
+        sut.update("finance/quotes", 12);
+        assertEquals(1, sut.size());
+
+        Optional<String> topicName = sut.topicFromAlias(12);
+        verifyTopicName("finance/quotes", topicName);
+    }
+}

--- a/broker/src/test/java/io/moquette/broker/TopicAliasMappingTest.java
+++ b/broker/src/test/java/io/moquette/broker/TopicAliasMappingTest.java
@@ -1,18 +1,18 @@
 /*
  *
- *  * Copyright (c) 2012-2024 The original author or authors
- *  * ------------------------------------------------------
- *  * All rights reserved. This program and the accompanying materials
- *  * are made available under the terms of the Eclipse Public License v1.0
- *  * and Apache License v2.0 which accompanies this distribution.
- *  *
- *  * The Eclipse Public License is available at
- *  * http://www.eclipse.org/legal/epl-v10.html
- *  *
- *  * The Apache License v2.0 is available at
- *  * http://www.opensource.org/licenses/apache2.0.php
- *  *
- *  * You may elect to redistribute this code under either of these licenses.
+ * Copyright (c) 2012-2024 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ * 
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ * 
+ * You may elect to redistribute this code under either of these licenses.
  *
  */
 

--- a/distribution/src/main/resources/moquette.conf
+++ b/distribution/src/main/resources/moquette.conf
@@ -223,3 +223,14 @@ password_file config/password_file.conf
 # default: 2 (exactly_once)
 #*********************************************************************
 # max_server_granted_qos 2
+
+#*********************************************************************
+# Maximum value acceptable value by the broker as topic alias
+#
+# topic_alias_maximum:
+#       This option is used to enable and limit the number of topic alias entries on the local cache.
+#       By default is 0, which means that topic alias functionality is disabled. Any value in range 0..65535 is accepted,
+#       but given that's a cache size per connection, is better to limit in low tens.
+# default: 0 (disabled)
+#*********************************************************************
+# topic_alias_maximum 16


### PR DESCRIPTION
## Release notes
Implemented handling of topic alias received by publishers. Doesn't implement the alias remapping in forwarded publishes.

## What does this PR do?

Updates CONNACK to set `topic alias maximum` property if user explicitly configures `topic_alias_maximum` configuration setting.
Adds a topic alias to topic name cache to MQTTConnection, named `TopicAliasMapping`.
Updates PUBLISH processing to handled the incoming topic alias, checking the various error condition (respect to the specification), resolve the alias to topic name and forward processing of publish message with topic name and without topic alias.
Added unit tests to MQTTConnection to cover the feature.

## Why is it important/What is the impact to the user?

Implements the topic alias feature defined in the specification of MQTT 5. It handles only for incoming publishes, it doesn't apply any technique to replace topic names with aliases on the forward to subscribers phase.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the Changelog if it's a feature or a fix that has to be reported

## How to test this PR locally

## Related issues
- Closes #859
