### PR TITLE
[Infra] Updated GH Cache action to be >v1 & v2 due to deprecation

### DIFF
--- a/.github/workflows/maven_build.yml
+++ b/.github/workflows/maven_build.yml
@@ -26,7 +26,7 @@ jobs:
               uses: actions/checkout@v2
 
             - name: Cache maven repository
-              uses: actions/cache@v2
+              uses: actions/cache@v4
               with:
                   path: |
                       ~/.m2/repository


### PR DESCRIPTION
Update GH Cache action to be >v1 & v2 due to deprecation starting from 2025/02/01