### PR TITLE
MQTTv3.1.1 supports a zero-byte clientId during authentication

### DIFF
--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -210,7 +210,7 @@ final class MQTTConnection {
         final boolean cleanSession = msg.variableHeader().isCleanSession();
         final boolean serverGeneratedClientId;
         if (clientId == null || clientId.isEmpty()) {
-            if (isNotProtocolVersion(msg, MqttVersion.MQTT_5)) {
+            if (isNotProtocolVersion(msg, MqttVersion.MQTT_5) && isNotProtocolVersion(msg, MqttVersion.MQTT_3_1_1)) {
                 if (!brokerConfig.isAllowZeroByteClientId()) {
                     LOG.info("Broker doesn't permit MQTT empty client ID. Username: {}", username);
                     abortConnection(CONNECTION_REFUSED_IDENTIFIER_REJECTED);


### PR DESCRIPTION
Bug:
According to the MQTT v3.1.1 protocol specification, MQTT clients can send connect messages without specifying the client ID. This is not a feature exclusive to MQTTV5, **it should also exist in MQTTv3.1.1**.

![1743154194521](https://github.com/user-attachments/assets/28f3e829-71ca-498f-94b1-c80dffac4a77)


I think brokers should generate random clientId instead of failing authentication.
![1743154850427](https://github.com/user-attachments/assets/a67c0006-054d-4c47-a0d8-5ece551b31af)
