### PR TITLE
Changed the remove method to work of a session instead of a clientID

### DIFF
--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -242,9 +242,8 @@ public class SessionRegistry {
     private void removeExpiredSession(ISessionsRepository.SessionData expiredSession) {
         final String expiredAt = expiredSession.expireAt().map(Instant::toString).orElse("UNDEFINED");
         LOG.debug("Removing session {}, expired on {}", expiredSession.clientId(), expiredAt);
-        remove(expiredSession.clientId());
+        remove(pool.get(expiredSession.clientId()));
         sessionsRepository.delete(expiredSession);
-
         subscriptionsDirectory.removeSharedSubscriptionsForClient(expiredSession.clientId());
     }
 
@@ -510,20 +509,20 @@ public class SessionRegistry {
             throw new SessionCorruptedException("Session has already changed state: " + session);
         }
 
-        unsubscribe(session);
-        remove(session.getClientID());
-
+        remove(session);
+        sessionsRepository.delete(session.getSessionData());
         subscriptionsDirectory.removeSharedSubscriptionsForClient(session.getClientID());
     }
 
-    void remove(String clientID) {
-        final Session old = pool.remove(clientID);
-        if (old != null) {
+    void remove(Session session) {
+        String clientID = session.getClientID();
+        if (pool.remove(clientID, session)) {
             metricsProvider.removeOpenSession();
+            unsubscribe(session);
             // remove from expired tracker if present
             sessionExpirationService.untrack(clientID);
             loopsGroup.routeCommand(clientID, "Clean up removed session", () -> {
-                old.cleanUp();
+                session.cleanUp();
                 return null;
             });
         }

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -241,10 +241,18 @@ public class SessionRegistry {
 
     private void removeExpiredSession(ISessionsRepository.SessionData expiredSession) {
         final String expiredAt = expiredSession.expireAt().map(Instant::toString).orElse("UNDEFINED");
-        LOG.debug("Removing session {}, expired on {}", expiredSession.clientId(), expiredAt);
-        remove(pool.get(expiredSession.clientId()));
-        sessionsRepository.delete(expiredSession);
-        subscriptionsDirectory.removeSharedSubscriptionsForClient(expiredSession.clientId());
+        final String clientId = expiredSession.clientId();
+        loopsGroup.routeCommand(clientId, "PurgeSession", () -> {
+            LOG.debug("Removing session {}, expired on {}", clientId, expiredAt);
+            final Session session = pool.get(clientId);
+            boolean success = session.assignState(SessionStatus.DISCONNECTED, SessionStatus.DESTROYED);
+            if (!success) {
+                remove(session);
+                sessionsRepository.delete(expiredSession);
+                subscriptionsDirectory.removeSharedSubscriptionsForClient(clientId);
+            }
+            return null;
+        });
     }
 
     private void trackForRemovalOnExpiration(ISessionsRepository.SessionData session) {


### PR DESCRIPTION
The client may have started a new session before the old one is purged, therefore the purge must check if the session being removed should actually be removed and is not a new session.

By basing the remove method on the session instead of the client id, it can ensure only the correct session is removed from the pool.
