### PR TITLE
MQTT 3.1.1 support for empty clientID must be droppe if the broker config explititly states to avoid.

### DIFF
--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -210,7 +210,7 @@ final class MQTTConnection {
         final boolean cleanSession = msg.variableHeader().isCleanSession();
         final boolean serverGeneratedClientId;
         if (clientId == null || clientId.isEmpty()) {
-            if (isNotProtocolVersion(msg, MqttVersion.MQTT_5) && isNotProtocolVersion(msg, MqttVersion.MQTT_3_1_1)) {
+            if (isNotProtocolVersion(msg, MqttVersion.MQTT_5)) {
                 if (!brokerConfig.isAllowZeroByteClientId()) {
                     LOG.info("Broker doesn't permit MQTT empty client ID. Username: {}", username);
                     abortConnection(CONNECTION_REFUSED_IDENTIFIER_REJECTED);


### PR DESCRIPTION
Revert #900 because when `allowZeroByteClientId` is false also for MQTT3.1.1 empty client ID is not accepted.

Failed test:
- https://github.com/moquette-io/moquette/blob/adb5ec6b91cc74a6987f98ec1a3b2f64d37af47f/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java#L351
- https://github.com/moquette-io/moquette/blob/adb5ec6b91cc74a6987f98ec1a3b2f64d37af47f/broker/src/test/java/io/moquette/broker/MQTTConnectionConnectTest.java#L370