### PR TITLE
Extended test for access rights on shared subscriptions

### DIFF
--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -391,22 +391,22 @@ class PostOffice {
         int messageID = messageId(msg);
         final Session session = sessionRegistry.retrieve(clientID);
 
-        List<MqttTopicSubscription> ackTopics;
+        List<MqttTopicSubscription> ackingSubsriptions;
         if (mqttConnection.isProtocolVersion5()) {
-            ackTopics = authorizator.verifyAlsoSharedTopicsReadAccess(clientID, username, msg);
+            ackingSubsriptions = authorizator.verifyAlsoSharedTopicsReadAccess(clientID, username, msg);
         } else {
-            ackTopics = authorizator.verifyTopicsReadAccess(clientID, username, msg);
+            ackingSubsriptions = authorizator.verifyTopicsReadAccess(clientID, username, msg);
         }
-        ackTopics = updateWithMaximumSupportedQoS(ackTopics);
-        MqttSubAckMessage ackMessage = doAckMessageFromValidateFilters(ackTopics, messageID);
+        ackingSubsriptions = updateWithMaximumSupportedQoS(ackingSubsriptions);
+        MqttSubAckMessage ackMessage = doAckMessageFromValidateFilters(ackingSubsriptions, messageID);
 
         final List<SharedSubscriptionData> sharedSubscriptions;
         final Optional<SubscriptionIdentifier> subscriptionIdOpt;
 
         if (mqttConnection.isProtocolVersion5()) {
-            sharedSubscriptions = ackTopics.stream()
-                .filter(sub -> sub.qualityOfService() != FAILURE)
-                .filter(sub -> SharedSubscriptionUtils.isSharedSubscription(sub.topicName()))
+            sharedSubscriptions = ackingSubsriptions.stream()
+                .filter(PostOffice::isNoFailure)
+                .filter(SharedSubscriptionUtils::isSharedSubscription)
                 .map(SharedSubscriptionData::fromMqttSubscription)
                 .collect(Collectors.toList());
 
@@ -432,7 +432,7 @@ class PostOffice {
         }
 
         // store topics of non-shared subscriptions in session
-        List<Subscription> newSubscriptions = ackTopics.stream()
+        List<Subscription> newSubscriptions = ackingSubsriptions.stream()
             .filter(sub -> sub.qualityOfService() != FAILURE)
             .filter(sub -> !SharedSubscriptionUtils.isSharedSubscription(sub.topicName()))
             .map(sub -> {
@@ -785,6 +785,10 @@ class PostOffice {
 
     private static boolean hasProperty(MqttProperties props, MqttPropertyType prop) {
         return props.getProperty(prop.value()) != null;
+    }
+
+    private static boolean isNoFailure(MqttTopicSubscription sub) {
+        return sub.qualityOfService() != FAILURE;
     }
 
     private static int getIntProperty(MqttProperties props, MqttPropertyType prop) {

--- a/broker/src/main/java/io/moquette/broker/SharedSubscriptionUtils.java
+++ b/broker/src/main/java/io/moquette/broker/SharedSubscriptionUtils.java
@@ -15,6 +15,7 @@
  */
 package io.moquette.broker;
 
+import io.netty.handler.codec.mqtt.MqttTopicSubscription;
 import java.util.Objects;
 
 /**
@@ -40,6 +41,14 @@ class SharedSubscriptionUtils {
         int afterShare = "$share/".length();
         int endOfShareName = fullSharedTopicFilter.indexOf('/', afterShare);
         return fullSharedTopicFilter.substring(endOfShareName + 1);
+    }
+
+    /**
+     * @return true if the topic filter in a subscription is shared format
+     * */
+    protected static boolean isSharedSubscription(MqttTopicSubscription subscription) {
+        Objects.requireNonNull(subscription, "subscription can't be null");
+        return isSharedSubscription(subscription.topicFilter());
     }
 
     /**

--- a/broker/src/test/java/io/moquette/integration/mqtt5/SharedSubscriptionTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/SharedSubscriptionTest.java
@@ -66,7 +66,7 @@ public class SharedSubscriptionTest extends AbstractSubscriptionIntegrationTest 
     }
 
     @Test
-    public void givenATopicNotReadableWhenAClientSubscribeSharedThenReceiveSubackWithNegativeResponse() throws IOException, InterruptedException {
+    public void givenNonReadableTopicWhenClientSubscribeToTheSharedThenReceiveSubackWithNegativeResponseAndNoMessageIsDispatched() throws IOException, InterruptedException {
         // stop already started broker instance
         stopServer();
 
@@ -87,13 +87,13 @@ public class SharedSubscriptionTest extends AbstractSubscriptionIntegrationTest 
             "Granted qos list must be the same cardinality of the subscribe request");
         assertEquals(MqttQoS.FAILURE.value(), grantedQoSes.iterator().next(),
             "Not readable topic should reflect also in shared subscription");
-        
-        // Test if the client does not reveive data on denied Topic.
+
+        // Test if the client does not receive data on denied Topic.
         Mqtt5BlockingClient publisherClient = createPublisherClient();
         publish(publisherClient, "measures/temp", MqttQos.AT_MOST_ONCE);
 
         MqttMessage received = lowLevelClient.receiveNextMessage(Duration.ofSeconds(1));
-        assertNull(received, "Client should not have reveived a message on rejected shared topic");
+        assertNull(received, "Client should not have received a message on rejected shared topic");
 
     }
 


### PR DESCRIPTION
Looking over the subscription-adding code I noticed that for shared subscriptions the client received a rejection message, when they are not allowed to read the topic, but the subscription is still added to the topic tree regardless!
This test extension seems to confirm my suspicion.
This is probably a security vulnerability... @andsel you may want to enable [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository) on the repository.