### PR TITLE
[BUG] Incorrect ACL Comment Parsing for Topics with Wildcard '#'

### DIFF
--- a/broker/src/main/java/io/moquette/broker/security/ACLFileParser.java
+++ b/broker/src/main/java/io/moquette/broker/security/ACLFileParser.java
@@ -96,7 +96,7 @@ public final class ACLFileParser {
         Pattern commentLine = Pattern.compile("^#.*"); // As spec, comment lines should start with '#'
         Pattern invalidCommentLine = Pattern.compile("^\\s*#.*");
         // This pattern has a dependency on filtering `commentLine`.
-        Pattern endLineComment = Pattern.compile("^([\\w\\s\\/\\+]+#?)(\\s*#.*)$");
+        Pattern endLineComment = Pattern.compile("^(\\S+\\s+(\\S+\\s+)?[^\\s#]+(?:/[+#])?)(?:\\s+#.*)?$");
         Matcher endLineCommentMatcher;
 
         try {

--- a/broker/src/test/java/io/moquette/broker/security/ACLFileParserTest.java
+++ b/broker/src/test/java/io/moquette/broker/security/ACLFileParserTest.java
@@ -73,6 +73,16 @@ public class ACLFileParserTest {
     }
 
     @Test
+    public void testParseEndWithPoundTopicWithoutEndLineComment() throws ParseException {
+        Reader conf = new StringReader("topic /weather/italy/#");
+        AuthorizationsCollector authorizations = ACLFileParser.parse(conf);
+
+        // Verify
+        assertTrue(authorizations.canRead(new Topic("/weather/italy/#"), "", ""));
+        assertTrue(authorizations.canWrite(new Topic("/weather/italy/#"), "", ""));
+    }
+
+    @Test
     public void testParseValidPoundTopicWithEndLineComment() throws ParseException {
         Reader conf = new StringReader("topic /weather/italy/anemometer/# #simple comment");
         AuthorizationsCollector authorizations = ACLFileParser.parse(conf);


### PR DESCRIPTION
## Release notes
Fixed an issue where the ACL parser incorrectly interpreted the MQTT topic wildcard '#' as the start of a line comment. This caused topic strings in ACL configuration files to be truncated, preventing proper authorization for topics containing the wildcard.

## What does this PR do?

This PR fixes a bug in the ACL file parser where the MQTT single-level topic wildcard character '#'was being incorrectly recognized as the start of a line comment. This caused the parser to stop reading the current line at the '#'character, truncating any topic string that contained it.
<img width="2708" height="1070" alt="image" src="https://github.com/user-attachments/assets/5350f37f-df81-4bb1-9f4f-528013b6cc6b" />


## Why is it important/What is the impact to the user?

* ACL rules for topics ending with wildcard '#'are incorrectly parsed
* Users may be denied access to topics they should have permissions for
* MQTT subscription patterns like 'test/v1/#'don't work as expected
* System functionality that relies on wildcard subscriptions may break

## Checklist

- [√] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have made corresponding changes to the documentation~~
~~- [ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [√] I have added tests that prove my fix is effective or that my feature works
- [√] I have updated the Changelog if it's a feature or a fix that has to be reported

## Author's Checklist

- [ ] Check if the topic requirements/constraints are met.

## How to test this PR locally

1. Add a rule in the local acl.conf file.
2. Ensure that the topic in this rule ends with #.
3. Ensure that there are no​ comments on this line (i.e., the line does not start with #).
* Example:​ topic read test/v1/#
4. Start or restart the service.
5. Verify that the client can successfully subscribe to the topic test/v1/#.

## Related issues

- Closes [#927](https://github.com/moquette-io/moquette/issues/927)
