### PR TITLE
Fixed metrics session mis-counting

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.19-SNAPSHOT
+   [fix] Fixed SessionCount metric miscounting when non-clean session are replaced with clean sessions. (#940)
    [Cleanup] Cleaned up subscription handling. (#931)
    [feature] Added metrics framework and Prometheus implementation.
      - Enable by setting `metrics_provider_class` to `MetricsProviderPrometheus`.

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -39,7 +39,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 import static io.moquette.broker.Session.INFINITE_EXPIRY;
-import io.moquette.metrics.MetricsManager;
 import io.moquette.metrics.MetricsProvider;
 
 public class SessionRegistry {
@@ -316,6 +315,7 @@ public class SessionRegistry {
             // publish new session
             final Session newSession = createNewSession(msg, clientId);
             Session previous = pool.put(clientId, newSession);
+            metricsProvider.addOpenSession();
             if (previous != null) {
                 LOG.error("We're re-opening a session for clientId {} and we purged the old session, but there is still a session in the pool! this is a bug!", clientId);
             }

--- a/broker/src/test/java/io/moquette/metrics/MetricsTest.java
+++ b/broker/src/test/java/io/moquette/metrics/MetricsTest.java
@@ -25,15 +25,17 @@ import io.netty.handler.codec.mqtt.MqttQoS;
 import java.io.IOException;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Properties;
-import java.util.logging.Level;
 import org.awaitility.Awaitility;
 import org.awaitility.Durations;
 import org.eclipse.paho.client.mqttv3.IMqttClient;
 import org.eclipse.paho.client.mqttv3.MqttClient;
 import org.eclipse.paho.client.mqttv3.MqttClientPersistence;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
+import org.hamcrest.core.Is;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -107,15 +109,17 @@ public class MetricsTest {
         server.stopServer();
     }
 
+    private MetricsProviderMock validateMetricsProvider() {
+        // Setup, check if the mock metrics provider is used and is clean.
+        MetricsProvider metricsProvider = server.getMetricsProvider();
+        assertTrue(metricsProvider instanceof MetricsProviderMock, "MetricsProvider should be of type MetricsProviderMock, found " + metricsProvider.getClass());
+        MetricsProviderMock mp = (MetricsProviderMock) metricsProvider;
+        return mp;
+    }
+
     @Test
     public void testMetrics() throws MqttException {
-        MetricsProvider metricsProvider = server.getMetricsProvider();
-        MetricsProviderMock mp = null;
-        if (metricsProvider instanceof MetricsProviderMock) {
-            mp = (MetricsProviderMock) metricsProvider;
-        } else {
-            Assertions.fail("MetricsProvider should be of type MetricsProviderMock, found " + metricsProvider.getClass());
-        }
+        MetricsProviderMock mp = validateMetricsProvider();
 
         assertEquals(0, mp.getSessionCount());
         assertEquals(0, mp.getPublishCount());
@@ -144,12 +148,10 @@ public class MetricsTest {
         clientListener.disconnect();
         clientPublisher.disconnect();
 
-        try {
-            // Sleep shortly to give the metrics time to update.
-            Thread.sleep(100);
-        } catch (InterruptedException ex) {
-            // It's fine
-        }
+        Awaitility.await("Wait for the metrics to update.")
+            .pollInterval(Duration.ofMillis(10))
+            .atMost(Duration.ofMillis(100))
+            .until(() -> mp.getSessionCount(), Is.is(0));
 
         assertEquals(0, mp.getSessionCount());
         assertEquals(1, mp.getPublishCount());
@@ -161,6 +163,63 @@ public class MetricsTest {
         assertTrue(mp.getSessionQueueFillMax() > 0);
         assertEquals(0, mp.getSessionQueueOverrunSum());
         mp.clearSessionQueueFillMax();
+
+    }
+
+    /**
+     * Tests if replacing a non-clean session with a clean one correctly updates
+     * the session count metric.
+     *
+     * @throws MqttException if there is a connection problem.
+     */
+    @Test
+    public void givenClosedNonCleanSessionWhenReconnectAsCleanThenSessionCountMetricsDoesntMissIt() throws MqttException {
+        // Setup, check if the mock metrics provider is used and is clean.
+        MetricsProviderMock mp = validateMetricsProvider();
+        assertEquals(0, mp.getSessionCount());
+
+        // Connect two clients, one with clean session, one with non-clean session.
+        final MqttConnectOptions listenerOptions = new MqttConnectOptions();
+        listenerOptions.setCleanSession(false);
+        clientListener.connect(listenerOptions);
+        clientPublisher.connect();
+
+        // There should now be two open sessions.
+        Awaitility.await("Wait for the metrics to update.")
+            .pollInterval(Duration.ofMillis(10))
+            .atMost(Duration.ofMillis(100))
+            .until(() -> mp.getSessionCount(), Is.is(2));
+
+        // Disconnect the clients, this should leave the non-clean session open.
+        clientListener.disconnect();
+        clientPublisher.disconnect();
+
+        // There should now be one open session, the non-clean listener session.
+        Awaitility.await("Wait for the metrics to update.")
+            .pollInterval(Duration.ofMillis(10))
+            .atMost(Duration.ofMillis(100))
+            .until(() -> mp.getSessionCount(), Is.is(1));
+
+        // Re-open both sessions, but now both set to clean.
+        listenerOptions.setCleanSession(true);
+        clientListener.connect(listenerOptions);
+        clientPublisher.connect();
+
+        // There should now again be two open sessions, old non-clean session should be replaced with a clean one.
+        Awaitility.await("Wait for the metrics to update.")
+            .pollInterval(Duration.ofMillis(10))
+            .atMost(Duration.ofMillis(100))
+            .until(() -> mp.getSessionCount(), Is.is(2));
+
+        // disconnect both sessions, this should leave 0 sessions open.
+        clientListener.disconnect();
+        clientPublisher.disconnect();
+
+        // There should now be no open sessions.
+        Awaitility.await("Wait for the metrics to update.")
+            .pollInterval(Duration.ofMillis(10))
+            .atMost(Duration.ofMillis(100))
+            .until(() -> mp.getSessionCount(), Is.is(0));
 
     }
 

--- a/metrics_prometheus/src/test/java/io/moquette/metrics/prometheus/MetricsProviderPrometheusTest.java
+++ b/metrics_prometheus/src/test/java/io/moquette/metrics/prometheus/MetricsProviderPrometheusTest.java
@@ -42,6 +42,9 @@ import org.eclipse.paho.client.mqttv3.persist.MqttDefaultFilePersistence;
 import org.junit.jupiter.api.AfterEach;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import io.moquette.metrics.MetricsProvider;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -67,6 +70,7 @@ public class MetricsProviderPrometheusTest {
     private String dbPath;
 
     protected void startServer(String dbPath) throws IOException {
+        PrometheusRegistry.defaultRegistry.clear();
         server = new Server();
         final Properties configProps = prepareTestProperties(dbPath);
         config = new MemoryConfig(configProps);
@@ -170,7 +174,81 @@ public class MetricsProviderPrometheusTest {
         assertEquals("0.0", data.get(METRIC_MOQUETTE_SESSION_QUEUE_FILL + "{queue_id=\"queue-0\"}"));
         assertEquals("0.0", data.get(METRIC_MOQUETTE_SESSION_QUEUE_OVERRUNS_TOTAL + "{queue_name=\"queue-0\"}"));
         assertTrue(Double.parseDouble(data.get(METRIC_MOQUETTE_SESSION_QUEUE_FILL_MAX)) == 0.0);
+    }
 
+    @Test
+    public void givenClosedNonCleanSessionWhenReconnectAsCleanThenSessionCountMetricsDoesntMissIt() throws MqttException {
+        // Setup, check if the prometheus metrics provider is used and is clean.
+        MetricsProvider metricsProvider = server.getMetricsProvider();
+        assertTrue(metricsProvider instanceof MetricsProviderPrometheus, "MetricsProvider should be of type MetricsProviderPrometheus, found " + metricsProvider.getClass());
+        String metricsUrl = "http://localhost:9400/metrics";
+        HttpHelper.HttpResponse response = HttpHelper.doGet(metricsUrl);
+        assertEquals(200, response.code, () -> "Error fetching metrics: " + metricsUrl);
+        LOGGER.debug("Data: \n{}", response.response);
+        Map<String, String> data = parseMetrics(response.response);
+        assertEquals("0.0", data.get(METRIC_MOQUETTE_OPEN_SESSIONS));
+        assertEquals("0.0", data.get(METRIC_MOQUETTE_PUBLISHES_TOTAL));
+
+        // Connect two clients, one with clean session, one with non-clean session.
+        final MqttConnectOptions listenerOptions = new MqttConnectOptions();
+        listenerOptions.setCleanSession(false);
+        clientListener.connect(listenerOptions);
+        clientListener.subscribe("test/topic");
+        clientPublisher.connect();
+
+        // Publish a message for timing. If the message is through, the system is ready for the next step.
+        clientPublisher.publish("test/topic", "Hello world MQTT!!".getBytes(UTF_8), 2, false);
+        Awaitility.await().until(messagesCollector::isMessageReceived);
+
+        // There should now be two open sessions, one for the listener and one for the publisher.
+        response = HttpHelper.doGet(metricsUrl);
+        assertEquals(200, response.code, () -> "Error fetching metrics: " + metricsUrl);
+        LOGGER.debug("Data: \n{}", response.response);
+        data = parseMetrics(response.response);
+        assertEquals("2.0", data.get(METRIC_MOQUETTE_OPEN_SESSIONS));
+        assertEquals("1.0", data.get(METRIC_MOQUETTE_PUBLISHES_TOTAL));
+
+        // Disconnect the clients, this should leave the non-clean session open.
+        clientListener.disconnect();
+        clientPublisher.disconnect();
+
+        // There should now be one open session, the non-clean listener session.
+        response = HttpHelper.doGet(metricsUrl);
+        assertEquals(200, response.code, () -> "Error fetching metrics: " + metricsUrl);
+        LOGGER.debug("Data: \n{}", response.response);
+        data = parseMetrics(response.response);
+        assertEquals("1.0", data.get(METRIC_MOQUETTE_OPEN_SESSIONS));
+        assertEquals("1.0", data.get(METRIC_MOQUETTE_PUBLISHES_TOTAL));
+
+        // Re-open both sessions, but now both set to clean.
+        listenerOptions.setCleanSession(true);
+        clientListener.connect(listenerOptions);
+        clientListener.subscribe("test/topic");
+        clientPublisher.connect();
+
+        // Publish a message for timing. If the message is through, the system is ready for the next step.
+        clientPublisher.publish("test/topic", "Hello world MQTT!!".getBytes(UTF_8), 2, false);
+        Awaitility.await().until(messagesCollector::isMessageReceived);
+
+        // There should now again be two open sessions, old non-clean session should be replaced with a clean one.
+        response = HttpHelper.doGet(metricsUrl);
+        assertEquals(200, response.code, () -> "Error fetching metrics: " + metricsUrl);
+        LOGGER.debug("Data: \n{}", response.response);
+        data = parseMetrics(response.response);
+        assertEquals("2.0", data.get(METRIC_MOQUETTE_OPEN_SESSIONS));
+        assertEquals("2.0", data.get(METRIC_MOQUETTE_PUBLISHES_TOTAL));
+
+        // disconnect both sessions, this should leave 0 sessions open.
+        clientListener.disconnect();
+        clientPublisher.disconnect();
+
+        // There should now be no open sessions.
+        response = HttpHelper.doGet(metricsUrl);
+        assertEquals(200, response.code, () -> "Error fetching metrics: " + metricsUrl);
+        LOGGER.debug("Data: \n{}", response.response);
+        data = parseMetrics(response.response);
+        assertEquals("0.0", data.get(METRIC_MOQUETTE_OPEN_SESSIONS));
+        assertEquals("2.0", data.get(METRIC_MOQUETTE_PUBLISHES_TOTAL));
     }
 
     private Map<String, String> parseMetrics(String response) {


### PR DESCRIPTION
## What does this PR do?
Fix a session-accounting-mistake in the session-reopen code, causing the Metrics to miscount sessions. I was seeing negative session counts :)

Since the metrics code is not released yet, no need to update the changelog.


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have made corresponding change to the default configuration files (and/or docker env variables)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the Changelog if it's a feature or a fix that has to be reported

