### PR TITLE
Expose client remote address in connect intercept

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [![](https://jitpack.io/v/moquette-io/moquette.svg)](https://jitpack.io/#moquette-io/moquette)
 
-## Moquette MQTT broker
-[Documentation reference guide](http://moquette-io.github.io/moquette/) Guide on how to use and configure Moquette
+## Timecho Moquette based on Moquette MQTT
+[Documentation reference guide](http://moquette-io.github.io/moquette/) – original Moquette documentation, applicable to this fork as well.
 
-Moquette is a lightweight broker compliant with MQTT 5 and MQTT 3, easily encapsulated in other applications.
+Timecho Moquette is a lightweight broker, based on the upstream [moquette-io/moquette](https://github.com/moquette-io/moquette) project, compliant with MQTT 5 and MQTT 3, and easily embedded into other applications.
 The broker supports QoS 0, QoS 1 and QoS 2. The MQTT5 specification is almost fully supported. 
 The features implemented by the broker are:
 * session and message expiry

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <relativePath>../pom.xml</relativePath>
         <artifactId>moquette-parent</artifactId>
-        <groupId>io.moquette</groupId>
+        <groupId>com.timecho.moquette</groupId>
         <version>0.19-SNAPSHOT</version>
     </parent>
 
     <artifactId>moquette-broker</artifactId>
     <packaging>jar</packaging>
-    <name>Moquette - broker</name>
+    <name>Timecho Moquette - broker</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <relativePath>../pom.xml</relativePath>
         <artifactId>moquette-parent</artifactId>
-        <groupId>io.moquette</groupId>
+        <groupId>com.timecho</groupId>
         <version>0.19-SNAPSHOT</version>
     </parent>
 

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -396,7 +396,7 @@ final class MQTTConnection {
                             setupInflightResender(channel);
                         }
 
-                        postOffice.dispatchConnection(msg, remoteAddress());
+                        postOffice.dispatchConnection(msg, channel);
                         LOG.trace("dispatch connection: {}", msg);
                     }
                 } else {

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -396,7 +396,7 @@ final class MQTTConnection {
                             setupInflightResender(channel);
                         }
 
-                        postOffice.dispatchConnection(msg);
+                        postOffice.dispatchConnection(msg, remoteAddress());
                         LOG.trace("dispatch connection: {}", msg);
                     }
                 } else {

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -42,6 +42,7 @@ import io.netty.handler.codec.mqtt.MqttTopicSubscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
@@ -1124,8 +1125,8 @@ class PostOffice {
      * notify MqttConnectMessage after connection established (already pass login).
      * @param msg
      */
-    void dispatchConnection(MqttConnectMessage msg) {
-        interceptor.notifyClientConnected(msg);
+    void dispatchConnection(MqttConnectMessage msg, InetSocketAddress remoteAddress) {
+        interceptor.notifyClientConnected(msg, remoteAddress);
     }
 
     void dispatchDisconnection(String clientId,String userName) {

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -25,6 +25,7 @@ import io.moquette.broker.subscriptions.Topic;
 import io.moquette.interception.BrokerInterceptor;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttFixedHeader;
 import io.netty.handler.codec.mqtt.MqttMessageBuilders;
@@ -42,7 +43,6 @@ import io.netty.handler.codec.mqtt.MqttTopicSubscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
@@ -1125,8 +1125,8 @@ class PostOffice {
      * notify MqttConnectMessage after connection established (already pass login).
      * @param msg
      */
-    void dispatchConnection(MqttConnectMessage msg, InetSocketAddress remoteAddress) {
-        interceptor.notifyClientConnected(msg, remoteAddress);
+    void dispatchConnection(MqttConnectMessage msg, Channel channel) {
+        interceptor.notifyClientConnected(msg, channel);
     }
 
     void dispatchDisconnection(String clientId,String userName) {

--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -539,7 +539,7 @@ public class Server {
                 observers.add(handler);
             }
         }
-        interceptor = new BrokerInterceptor(props, observers);
+        interceptor = new BrokerInterceptor(props, observers, metricsProvider);
     }
 
     @SuppressWarnings("unchecked")

--- a/broker/src/main/java/io/moquette/interception/BrokerInterceptor.java
+++ b/broker/src/main/java/io/moquette/interception/BrokerInterceptor.java
@@ -21,6 +21,8 @@ import io.moquette.broker.Utils;
 import io.moquette.interception.messages.*;
 import io.moquette.broker.config.IConfig;
 import io.moquette.broker.subscriptions.Subscription;
+import io.moquette.metrics.MetricsProvider;
+import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.util.ReferenceCountUtil;
@@ -43,10 +45,12 @@ public final class BrokerInterceptor implements Interceptor {
     private static final Logger LOG = LoggerFactory.getLogger(BrokerInterceptor.class);
     private final Map<Class<?>, List<InterceptHandler>> handlers;
     private final ExecutorService executor;
+    private final MetricsProvider metricsProvider;
 
-    private BrokerInterceptor(int poolSize, List<InterceptHandler> handlers) {
+    private BrokerInterceptor(int poolSize, List<InterceptHandler> handlers, MetricsProvider metricsProvider) {
         LOG.info("Initializing broker interceptor. InterceptorIds={}", getInterceptorIds(handlers));
         this.handlers = new HashMap<>();
+        this.metricsProvider = metricsProvider;
         for (Class<?> messageType : InterceptHandler.ALL_MESSAGE_TYPES) {
             this.handlers.put(messageType, new CopyOnWriteArrayList<InterceptHandler>());
         }
@@ -62,7 +66,7 @@ public final class BrokerInterceptor implements Interceptor {
      * @param handlers InterceptHandlers listeners.
      */
     public BrokerInterceptor(List<InterceptHandler> handlers) {
-        this(1, handlers);
+        this(1, handlers, null);
     }
 
     /**
@@ -72,7 +76,19 @@ public final class BrokerInterceptor implements Interceptor {
      *
      */
     public BrokerInterceptor(IConfig props, List<InterceptHandler> handlers) {
-        this(Integer.parseInt(props.getProperty(BrokerConstants.BROKER_INTERCEPTOR_THREAD_POOL_SIZE, "1")), handlers);
+        this(Integer.parseInt(props.getProperty(BrokerConstants.BROKER_INTERCEPTOR_THREAD_POOL_SIZE, "1")),
+            handlers, null);
+    }
+
+    /**
+     * Configures a broker interceptor, with a thread pool of one thread ane a metricsProvider.
+     *
+     * @param handlers InterceptHandlers listeners.
+     * @param metricsProvider MetricsProvider metricsProvider.
+     */
+    public BrokerInterceptor(IConfig props, List<InterceptHandler> handlers, MetricsProvider metricsProvider) {
+        this(Integer.parseInt(props.getProperty(BrokerConstants.BROKER_INTERCEPTOR_THREAD_POOL_SIZE, "1")),
+            handlers, metricsProvider);
     }
 
     /**
@@ -124,6 +140,15 @@ public final class BrokerInterceptor implements Interceptor {
     public void notifyTopicPublished(final MqttPublishMessage msg, final String clientID, final String username) {
         Utils.retain(msg, "notify interceptors");
 
+        ByteBuf payload = msg.payload();
+        int payloadSize = payload.readableBytes();
+
+        if (metricsProvider != null) {
+            metricsProvider.interceptorPublishTaskSubmitted();
+            metricsProvider.recordInterceptorMessageSize(payloadSize);
+            metricsProvider.interceptorTaskSubmittedWithSize(payloadSize);
+        }
+
         executor.execute(() -> {
                 try {
                     int messageId = msg.variableHeader().messageId();
@@ -137,6 +162,10 @@ public final class BrokerInterceptor implements Interceptor {
                     }
                 } finally {
                     Utils.release(msg, "notify interceptors");
+                    if (metricsProvider != null) {
+                        metricsProvider.interceptorPublishTaskCompleted();
+                        metricsProvider.interceptorTaskCompletedWithSize(payloadSize);
+                    }
                 }
         });
     }

--- a/broker/src/main/java/io/moquette/interception/BrokerInterceptor.java
+++ b/broker/src/main/java/io/moquette/interception/BrokerInterceptor.java
@@ -28,6 +28,7 @@ import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.util.ReferenceCountUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -111,10 +112,15 @@ public final class BrokerInterceptor implements Interceptor {
 
     @Override
     public void notifyClientConnected(final MqttConnectMessage msg) {
+        notifyClientConnected(msg, null);
+    }
+
+    @Override
+    public void notifyClientConnected(final MqttConnectMessage msg, final InetSocketAddress remoteAddress) {
         for (final InterceptHandler handler : this.handlers.get(InterceptConnectMessage.class)) {
             LOG.debug("Sending MQTT CONNECT message to interceptor. CId={}, interceptorId={}",
                     msg.payload().clientIdentifier(), handler.getID());
-            executor.execute(() -> handler.onConnect(new InterceptConnectMessage(msg)));
+            executor.execute(() -> handler.onConnect(new InterceptConnectMessage(msg, remoteAddress)));
         }
     }
 

--- a/broker/src/main/java/io/moquette/interception/BrokerInterceptor.java
+++ b/broker/src/main/java/io/moquette/interception/BrokerInterceptor.java
@@ -23,12 +23,12 @@ import io.moquette.broker.config.IConfig;
 import io.moquette.broker.subscriptions.Subscription;
 import io.moquette.metrics.MetricsProvider;
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.util.ReferenceCountUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -112,15 +112,15 @@ public final class BrokerInterceptor implements Interceptor {
 
     @Override
     public void notifyClientConnected(final MqttConnectMessage msg) {
-        notifyClientConnected(msg, null);
+        notifyClientConnected(msg, (Channel) null);
     }
 
     @Override
-    public void notifyClientConnected(final MqttConnectMessage msg, final InetSocketAddress remoteAddress) {
+    public void notifyClientConnected(final MqttConnectMessage msg, final Channel channel) {
         for (final InterceptHandler handler : this.handlers.get(InterceptConnectMessage.class)) {
             LOG.debug("Sending MQTT CONNECT message to interceptor. CId={}, interceptorId={}",
                     msg.payload().clientIdentifier(), handler.getID());
-            executor.execute(() -> handler.onConnect(new InterceptConnectMessage(msg, remoteAddress)));
+            executor.execute(() -> handler.onConnect(new InterceptConnectMessage(msg, channel)));
         }
     }
 

--- a/broker/src/main/java/io/moquette/interception/Interceptor.java
+++ b/broker/src/main/java/io/moquette/interception/Interceptor.java
@@ -22,6 +22,8 @@ import io.moquette.interception.messages.InterceptExceptionMessage;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 
+import java.net.InetSocketAddress;
+
 /**
  * This interface is to be used internally by the broker components.
  * <p>
@@ -35,6 +37,10 @@ import io.netty.handler.codec.mqtt.MqttPublishMessage;
 public interface Interceptor {
 
     void notifyClientConnected(MqttConnectMessage msg);
+
+    default void notifyClientConnected(MqttConnectMessage msg, InetSocketAddress remoteAddress) {
+        notifyClientConnected(msg);
+    }
 
     void notifyClientDisconnected(String clientID, String username);
 

--- a/broker/src/main/java/io/moquette/interception/Interceptor.java
+++ b/broker/src/main/java/io/moquette/interception/Interceptor.java
@@ -19,10 +19,9 @@ package io.moquette.interception;
 import io.moquette.interception.messages.InterceptAcknowledgedMessage;
 import io.moquette.broker.subscriptions.Subscription;
 import io.moquette.interception.messages.InterceptExceptionMessage;
+import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
-
-import java.net.InetSocketAddress;
 
 /**
  * This interface is to be used internally by the broker components.
@@ -38,7 +37,7 @@ public interface Interceptor {
 
     void notifyClientConnected(MqttConnectMessage msg);
 
-    default void notifyClientConnected(MqttConnectMessage msg, InetSocketAddress remoteAddress) {
+    default void notifyClientConnected(MqttConnectMessage msg, Channel channel) {
         notifyClientConnected(msg);
     }
 

--- a/broker/src/main/java/io/moquette/interception/messages/InterceptConnectMessage.java
+++ b/broker/src/main/java/io/moquette/interception/messages/InterceptConnectMessage.java
@@ -18,17 +18,38 @@ package io.moquette.interception.messages;
 
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 
+import java.net.InetSocketAddress;
+import java.util.Optional;
+
 public class InterceptConnectMessage extends InterceptAbstractMessage {
 
     private final MqttConnectMessage msg;
+    private final InetSocketAddress remoteAddress;
 
     public InterceptConnectMessage(MqttConnectMessage msg) {
+        this(msg, null);
+    }
+
+    public InterceptConnectMessage(MqttConnectMessage msg, InetSocketAddress remoteAddress) {
         super(msg);
         this.msg = msg;
+        this.remoteAddress = remoteAddress;
     }
 
     public String getClientID() {
         return msg.payload().clientIdentifier();
+    }
+
+    public Optional<InetSocketAddress> getRemoteAddress() {
+        return Optional.ofNullable(remoteAddress);
+    }
+
+    public String getClientAddress() {
+        return remoteAddress == null ? null : remoteAddress.getHostString();
+    }
+
+    public int getClientPort() {
+        return remoteAddress == null ? -1 : remoteAddress.getPort();
     }
 
     public boolean isCleanSession() {

--- a/broker/src/main/java/io/moquette/interception/messages/InterceptConnectMessage.java
+++ b/broker/src/main/java/io/moquette/interception/messages/InterceptConnectMessage.java
@@ -16,6 +16,7 @@
 
 package io.moquette.interception.messages;
 
+import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 
 import java.net.InetSocketAddress;
@@ -24,32 +25,43 @@ import java.util.Optional;
 public class InterceptConnectMessage extends InterceptAbstractMessage {
 
     private final MqttConnectMessage msg;
-    private final InetSocketAddress remoteAddress;
+    private final Channel channel;
 
     public InterceptConnectMessage(MqttConnectMessage msg) {
         this(msg, null);
     }
 
-    public InterceptConnectMessage(MqttConnectMessage msg, InetSocketAddress remoteAddress) {
+    public InterceptConnectMessage(MqttConnectMessage msg, Channel channel) {
         super(msg);
         this.msg = msg;
-        this.remoteAddress = remoteAddress;
+        this.channel = channel;
     }
 
     public String getClientID() {
         return msg.payload().clientIdentifier();
     }
 
+    public Optional<Channel> getChannel() {
+        return Optional.ofNullable(channel);
+    }
+
     public Optional<InetSocketAddress> getRemoteAddress() {
-        return Optional.ofNullable(remoteAddress);
+        if (channel != null && channel.remoteAddress() instanceof InetSocketAddress) {
+            return Optional.of((InetSocketAddress) channel.remoteAddress());
+        }
+        return Optional.empty();
     }
 
     public String getClientAddress() {
-        return remoteAddress == null ? null : remoteAddress.getHostString();
+        return getRemoteAddress()
+            .map(InetSocketAddress::getHostString)
+            .orElse(null);
     }
 
     public int getClientPort() {
-        return remoteAddress == null ? -1 : remoteAddress.getPort();
+        return getRemoteAddress()
+            .map(InetSocketAddress::getPort)
+            .orElse(-1);
     }
 
     public boolean isCleanSession() {

--- a/broker/src/main/java/io/moquette/metrics/MetricsProvider.java
+++ b/broker/src/main/java/io/moquette/metrics/MetricsProvider.java
@@ -74,4 +74,37 @@ public interface MetricsProvider {
      * @param qos The QoS of the message.
      */
     public void addMessage(int queue, int qos);
+
+    /**
+     * Register that an interceptor publish task was submitted to the thread pool.
+     * This tracks the production rate of interceptor tasks.
+     */
+    public void interceptorPublishTaskSubmitted();
+
+    /**
+     * Register that an interceptor publish task was completed.
+     * This tracks the consumption rate of interceptor tasks.
+     */
+    public void interceptorPublishTaskCompleted();
+
+    /**
+     * Record the size of a message payload in bytes.
+     * This is used to track message size distribution (P50, P99, etc.)
+     * @param sizeBytes The size of the message payload in bytes
+     */
+    public void recordInterceptorMessageSize(long sizeBytes);
+
+    /**
+     * Record that an interceptor task was submitted with its payload size.
+     * This is used to track the backlog memory usage of payloads in the queue.
+     * @param payloadSizeBytes The size of the message payload in bytes
+     */
+    public void interceptorTaskSubmittedWithSize(long payloadSizeBytes);
+
+    /**
+     * Record that an interceptor task was completed with its payload size.
+     * This is used to track the backlog memory usage of payloads in the queue.
+     * @param payloadSizeBytes The size of the message payload in bytes
+     */
+    public void interceptorTaskCompletedWithSize(long payloadSizeBytes);
 }

--- a/broker/src/main/java/io/moquette/metrics/MetricsProviderNull.java
+++ b/broker/src/main/java/io/moquette/metrics/MetricsProviderNull.java
@@ -67,4 +67,30 @@ public class MetricsProviderNull extends AbstractMetricsProvider {
         // ignored
     }
 
+    @Override
+    public void interceptorPublishTaskSubmitted() {
+        // No-op for null provider
+    }
+
+    @Override
+    public void interceptorPublishTaskCompleted() {
+        // No-op for null provider
+    }
+
+    @Override
+    public void recordInterceptorMessageSize(long sizeBytes) {
+        // No-op
+    }
+
+
+    @Override
+    public void interceptorTaskSubmittedWithSize(long payloadSizeBytes) {
+        // No-op
+    }
+
+    @Override
+    public void interceptorTaskCompletedWithSize(long payloadSizeBytes) {
+        // No-op
+    }
+
 }

--- a/broker/src/test/java/io/moquette/interception/BrokerInterceptorTest.java
+++ b/broker/src/test/java/io/moquette/interception/BrokerInterceptorTest.java
@@ -28,11 +28,16 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.net.InetSocketAddress;
 import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -121,6 +126,42 @@ public class BrokerInterceptorTest {
         interceptor.notifyClientConnected(MqttMessageBuilders.connect().build());
         interval();
         assertEquals(40, n.get());
+    }
+
+    @Test
+    public void testNotifyClientConnectedIncludesRemoteAddress() throws Exception {
+        final CountDownLatch notified = new CountDownLatch(1);
+        final AtomicReference<InterceptConnectMessage> intercepted = new AtomicReference<>();
+        final BrokerInterceptor localInterceptor = new BrokerInterceptor(
+            Collections.<InterceptHandler>singletonList(new AbstractInterceptHandler() {
+                @Override
+                public String getID() {
+                    return "RemoteAddressObserver";
+                }
+
+                @Override
+                public void onConnect(InterceptConnectMessage msg) {
+                    intercepted.set(msg);
+                    notified.countDown();
+                }
+
+                @Override
+                public void onSessionLoopError(Throwable error) {
+                    throw new RuntimeException(error);
+                }
+            }));
+
+        try {
+            final InetSocketAddress remoteAddress = new InetSocketAddress("127.0.0.1", 12345);
+            localInterceptor.notifyClientConnected(MqttMessageBuilders.connect().build(), remoteAddress);
+
+            assertTrue(notified.await(1, TimeUnit.SECONDS));
+            assertEquals(remoteAddress, intercepted.get().getRemoteAddress().get());
+            assertEquals("127.0.0.1", intercepted.get().getClientAddress());
+            assertEquals(12345, intercepted.get().getClientPort());
+        } finally {
+            localInterceptor.stop();
+        }
     }
 
     @Test

--- a/broker/src/test/java/io/moquette/interception/BrokerInterceptorTest.java
+++ b/broker/src/test/java/io/moquette/interception/BrokerInterceptorTest.java
@@ -21,6 +21,7 @@ import io.moquette.broker.subscriptions.Subscription;
 import io.moquette.broker.subscriptions.Topic;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttMessageBuilders;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
@@ -37,10 +38,12 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class BrokerInterceptorTest {
 
@@ -153,9 +156,12 @@ public class BrokerInterceptorTest {
 
         try {
             final InetSocketAddress remoteAddress = new InetSocketAddress("127.0.0.1", 12345);
-            localInterceptor.notifyClientConnected(MqttMessageBuilders.connect().build(), remoteAddress);
+            final Channel channel = mock(Channel.class);
+            when(channel.remoteAddress()).thenReturn(remoteAddress);
+            localInterceptor.notifyClientConnected(MqttMessageBuilders.connect().build(), channel);
 
             assertTrue(notified.await(1, TimeUnit.SECONDS));
+            assertSame(channel, intercepted.get().getChannel().get());
             assertEquals(remoteAddress, intercepted.get().getRemoteAddress().get());
             assertEquals("127.0.0.1", intercepted.get().getClientAddress());
             assertEquals(12345, intercepted.get().getClientPort());

--- a/broker/src/test/java/io/moquette/metrics/MetricsProviderMock.java
+++ b/broker/src/test/java/io/moquette/metrics/MetricsProviderMock.java
@@ -94,6 +94,31 @@ public class MetricsProviderMock extends AbstractMetricsProvider {
         getMessageCount()[queue][qos]++;
     }
 
+    @Override
+    public void interceptorPublishTaskSubmitted() {
+
+    }
+
+    @Override
+    public void interceptorPublishTaskCompleted() {
+
+    }
+
+    @Override
+    public void recordInterceptorMessageSize(long sizeBytes) {
+
+    }
+
+    @Override
+    public void interceptorTaskSubmittedWithSize(long payloadSizeBytes) {
+
+    }
+
+    @Override
+    public void interceptorTaskCompletedWithSize(long payloadSizeBytes) {
+
+    }
+
     /**
      * @return the queueCount
      */

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <relativePath>../pom.xml</relativePath>
         <artifactId>moquette-parent</artifactId>
-        <groupId>io.moquette</groupId>
+        <groupId>com.timecho.moquette</groupId>
         <version>0.19-SNAPSHOT</version>
     </parent>
 
     <artifactId>distribution</artifactId>
     <packaging>pom</packaging>
-    <name>Moquette - distribution</name>
+    <name>Timecho Moquette - distribution</name>
 
     <!-- Includes all modules -->
     <dependencies>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <relativePath>../pom.xml</relativePath>
         <artifactId>moquette-parent</artifactId>
-        <groupId>io.moquette</groupId>
+        <groupId>com.timecho</groupId>
         <version>0.19-SNAPSHOT</version>
     </parent>
 

--- a/embedding_moquette/pom.xml
+++ b/embedding_moquette/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <relativePath>../pom.xml</relativePath>
         <artifactId>moquette-parent</artifactId>
-        <groupId>io.moquette</groupId>
+        <groupId>com.timecho.moquette</groupId>
         <version>0.19-SNAPSHOT</version>
     </parent>
 
     <artifactId>embedded_test</artifactId>
     <packaging>jar</packaging>
-    <name>Moquette - Embedded test</name>
+    <name>Timecho Moquette - Embedded test</name>
 
     <dependencies>
         <dependency>

--- a/embedding_moquette/pom.xml
+++ b/embedding_moquette/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <relativePath>../pom.xml</relativePath>
         <artifactId>moquette-parent</artifactId>
-        <groupId>io.moquette</groupId>
+        <groupId>com.timecho</groupId>
         <version>0.19-SNAPSHOT</version>
     </parent>
 

--- a/metrics_prometheus/pom.xml
+++ b/metrics_prometheus/pom.xml
@@ -4,13 +4,13 @@
     <parent>
         <relativePath>../pom.xml</relativePath>
         <artifactId>moquette-parent</artifactId>
-        <groupId>io.moquette</groupId>
+        <groupId>com.timecho.moquette</groupId>
         <version>0.19-SNAPSHOT</version>
     </parent>
 
     <artifactId>moquette-metrics-prometheus</artifactId>
     <packaging>jar</packaging>
-    <name>Moquette - Metrics - Prometheus</name>
+    <name>Timecho Moquette - Metrics - Prometheus</name>
 
 
     <properties>
@@ -27,7 +27,7 @@
             <version>${slf4j.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.moquette</groupId>
+            <groupId>com.timecho.moquette</groupId>
             <artifactId>moquette-broker</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/metrics_prometheus/pom.xml
+++ b/metrics_prometheus/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <relativePath>../pom.xml</relativePath>
         <artifactId>moquette-parent</artifactId>
-        <groupId>io.moquette</groupId>
+        <groupId>com.timecho</groupId>
         <version>0.19-SNAPSHOT</version>
     </parent>
 
@@ -27,7 +27,7 @@
             <version>${slf4j.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.moquette</groupId>
+            <groupId>com.timecho</groupId>
             <artifactId>moquette-broker</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/metrics_prometheus/src/main/java/io/moquette/metrics/prometheus/MetricsProviderPrometheus.java
+++ b/metrics_prometheus/src/main/java/io/moquette/metrics/prometheus/MetricsProviderPrometheus.java
@@ -21,10 +21,13 @@ import io.prometheus.metrics.core.datapoints.CounterDataPoint;
 import io.prometheus.metrics.core.metrics.Counter;
 import io.prometheus.metrics.core.metrics.Gauge;
 import io.prometheus.metrics.core.metrics.GaugeWithCallback;
+import io.prometheus.metrics.core.metrics.Histogram;
 import io.prometheus.metrics.exporter.httpserver.HTTPServer;
 import io.prometheus.metrics.instrumentation.jvm.JvmMetrics;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +57,13 @@ public class MetricsProviderPrometheus implements MetricsProvider {
     private CounterDataPoint[][] messageCounters;
     private Counter publishCounter;
 
+    private Counter interceptorPublishTaskSubmittedCounter;
+    private Counter interceptorPublishTaskCompletedCounter;
+
+    private Histogram interceptorMessageSizeHistogram;
+
+    private final AtomicLong interceptorBacklogMemoryBytes = new AtomicLong(0);
+
     @Override
     public void init(IConfig config) {
         LOG.info("Initialising Prometheus metrics provider.");
@@ -63,22 +73,47 @@ public class MetricsProviderPrometheus implements MetricsProvider {
             JvmMetrics.builder().register();
             if (metricsPort > 0) {
                 metricsServer = HTTPServer.builder()
-                        .port(metricsPort)
-                        .buildAndStart();
+                    .port(metricsPort)
+                    .buildAndStart();
                 LOG.info("Prometheus metrics endpoint started on port {}", metricsPort);
             }
         } catch (IOException ex) {
             LOG.error("Failed to start metrics server.", ex);
         }
         openSessionsGauge = Gauge.builder()
-                .name(METRIC_MOQUETTE_OPEN_SESSIONS)
-                .help("The number of open sessions in the broker.")
-                .register();
+            .name(METRIC_MOQUETTE_OPEN_SESSIONS)
+            .help("The number of open sessions in the broker.")
+            .register();
 
         publishCounter = Counter.builder()
-                .name(METRIC_MOQUETTE_PUBLISHES_TOTAL)
-                .help("Number of publishes made on the broker")
-                .register();
+            .name(METRIC_MOQUETTE_PUBLISHES_TOTAL)
+            .help("Number of publishes made on the broker")
+            .register();
+
+        interceptorPublishTaskSubmittedCounter = Counter.builder()
+            .name("moquette_interceptor_publish_tasks_submitted_total")
+            .help("Total number of interceptor publish tasks submitted to the thread pool")
+            .register();
+
+        interceptorPublishTaskCompletedCounter = Counter.builder()
+            .name("moquette_interceptor_publish_tasks_completed_total")
+            .help("Total number of interceptor publish tasks completed by the thread pool")
+            .register();
+
+        interceptorMessageSizeHistogram = Histogram.builder()
+            .name("moquette_interceptor_message_size_bytes")
+            .help("Size distribution of messages processed by interceptors (in bytes)")
+            .classicUpperBounds(100.0, 500.0, 1000.0, 5000.0, 10000.0, 50000.0, 100000.0, 500000.0, 1000000.0) // 自定义分桶
+            .register();
+
+        GaugeWithCallback.builder()
+            .name("moquette_interceptor_backlog_memory_bytes")
+            .help("Current memory size of message payloads waiting in the interceptor thread pool queue (in bytes)")
+            .callback(cb -> {
+                long backlogMemory = interceptorBacklogMemoryBytes.get();
+                cb.call(backlogMemory);
+            })
+            .register();
     }
 
     @Override
@@ -96,27 +131,27 @@ public class MetricsProviderPrometheus implements MetricsProvider {
     public void initSessionQueues(int queueCount, int queueSize) {
         this.sessionQueueSize = queueSize;
         GaugeWithCallback.builder()
-                .name(METRIC_MOQUETTE_SESSION_QUEUE_FILL)
-                .help("Fill level of the Session Queue (0 - 1)")
-                .labelNames("queue_id")
-                .callback(cb -> {
-                    for (int idx = 0; idx < sessionQueueFill.length; idx++) {
-                        cb.call(1.0 * sessionQueueFill[idx].get() / sessionQueueSize, labelForQueue(idx));
-                    }
-                })
-                .register();
+            .name(METRIC_MOQUETTE_SESSION_QUEUE_FILL)
+            .help("Fill level of the Session Queue (0 - 1)")
+            .labelNames("queue_id")
+            .callback(cb -> {
+                for (int idx = 0; idx < sessionQueueFill.length; idx++) {
+                    cb.call(1.0 * sessionQueueFill[idx].get() / sessionQueueSize, labelForQueue(idx));
+                }
+            })
+            .register();
 
         Counter sessionQueueOverrunCounter = Counter.builder()
-                .name(METRIC_MOQUETTE_SESSION_QUEUE_OVERRUNS_TOTAL)
-                .help("Number of items dropped because the queue was full")
-                .labelNames("queue_name")
-                .register();
+            .name(METRIC_MOQUETTE_SESSION_QUEUE_OVERRUNS_TOTAL)
+            .help("Number of items dropped because the queue was full")
+            .labelNames("queue_name")
+            .register();
 
         Counter messageCounter = Counter.builder()
-                .name(METRIC_MOQUETTE_SESSION_MESSAGES_TOTAL)
-                .help("Number of messages send by this session queue")
-                .labelNames("queue_name", "QoS")
-                .register();
+            .name(METRIC_MOQUETTE_SESSION_MESSAGES_TOTAL)
+            .help("Number of messages send by this session queue")
+            .labelNames("queue_name", "QoS")
+            .register();
 
         sessionQueueFill = new AtomicInteger[queueCount];
         sessionQueueOverrunCounters = new CounterDataPoint[queueCount];
@@ -134,17 +169,17 @@ public class MetricsProviderPrometheus implements MetricsProvider {
         }
 
         GaugeWithCallback.builder()
-                .name(METRIC_MOQUETTE_SESSION_QUEUE_FILL_MAX)
-                .help("Maximum fill level of the Session Queue since the last scrape call (0 - 1)")
-                .labelNames("queue_id")
-                .callback(cb -> {
-                    for (int idx = 0; idx < sessionQueueFillMax.length; idx++) {
-                        final String label = "queue-" + idx;
-                        cb.call(1.0 * sessionQueueFillMax[idx] / sessionQueueSize, label);
-                        sessionQueueFillMax[idx] = 0;
-                    }
-                })
-                .register();
+            .name(METRIC_MOQUETTE_SESSION_QUEUE_FILL_MAX)
+            .help("Maximum fill level of the Session Queue since the last scrape call (0 - 1)")
+            .labelNames("queue_id")
+            .callback(cb -> {
+                for (int idx = 0; idx < sessionQueueFillMax.length; idx++) {
+                    final String label = "queue-" + idx;
+                    cb.call(1.0 * sessionQueueFillMax[idx] / sessionQueueSize, label);
+                    sessionQueueFillMax[idx] = 0;
+                }
+            })
+            .register();
     }
 
     @Override
@@ -197,4 +232,28 @@ public class MetricsProviderPrometheus implements MetricsProvider {
         messageCounters[queue][qos].inc();
     }
 
+    @Override
+    public void interceptorPublishTaskSubmitted() {
+        interceptorPublishTaskSubmittedCounter.inc();
+    }
+
+    @Override
+    public void interceptorPublishTaskCompleted() {
+        interceptorPublishTaskCompletedCounter.inc();
+    }
+
+    @Override
+    public void recordInterceptorMessageSize(long sizeBytes) {
+        interceptorMessageSizeHistogram.observe(sizeBytes);
+    }
+
+    @Override
+    public void interceptorTaskSubmittedWithSize(long payloadSizeBytes) {
+        interceptorBacklogMemoryBytes.addAndGet(payloadSizeBytes);
+    }
+
+    @Override
+    public void interceptorTaskCompletedWithSize(long payloadSizeBytes) {
+        interceptorBacklogMemoryBytes.addAndGet(-payloadSizeBytes);
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -12,15 +12,15 @@
         <maven.compiler.target>8</maven.compiler.target>
     </properties>
 
-    <groupId>io.moquette</groupId>
+    <groupId>com.timecho.moquette</groupId>
     <artifactId>moquette-parent</artifactId>
 
     <packaging>pom</packaging>
     <version>0.19-SNAPSHOT</version>
-    <name>Moquette MQTT</name>
-    <description>Moquette lightweight MQTT Broker</description>
+    <name>Timecho Moquette based on Moquette MQTT</name>
+    <description>Timecho's maintained fork of the Moquette lightweight MQTT broker</description>
     <inceptionYear>2011</inceptionYear>
-    <url>http://moquette.io</url>
+    <url>https://github.com/TimechoLab/moquette</url>
 
     <licenses>
         <license>
@@ -47,9 +47,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git@github.com:moquette-io/moquette.git</connection>
-        <developerConnection>scm:git:git@github.com:moquette-io/moquette.git</developerConnection>
-        <url>git@github.com:moquette-io/moquette.git</url>
+        <connection>scm:git:https://github.com/TimechoLab/moquette.git</connection>
+        <developerConnection>scm:git:git@github.com:TimechoLab/moquette.git</developerConnection>
+        <url>https://github.com/TimechoLab/moquette</url>
     </scm>
 
     <modules>
@@ -261,12 +261,12 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>timecho.snapshot.http</id>
+            <url>https://nexus.infra.timecho.com:8443/repository/maven-snapshots/</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+            <id>timecho.release.http</id>
+            <url>https://nexus.infra.timecho.com:8443/repository/maven-releases/</url>
         </repository>
     </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,13 +12,13 @@
         <maven.compiler.target>8</maven.compiler.target>
     </properties>
 
-    <groupId>io.moquette</groupId>
+    <groupId>com.timecho</groupId>
     <artifactId>moquette-parent</artifactId>
 
     <packaging>pom</packaging>
     <version>0.19-SNAPSHOT</version>
-    <name>Moquette MQTT</name>
-    <description>Moquette lightweight MQTT Broker</description>
+    <name>Timecho MQTT</name>
+    <description>Timecho lightweight MQTT Broker based on Moquette</description>
     <inceptionYear>2011</inceptionYear>
     <url>http://moquette.io</url>
 
@@ -47,9 +47,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git@github.com:moquette-io/moquette.git</connection>
-        <developerConnection>scm:git:git@github.com:moquette-io/moquette.git</developerConnection>
-        <url>git@github.com:moquette-io/moquette.git</url>
+        <connection>scm:git:git@github.com:TimechoLab/moquette.git</connection>
+        <developerConnection>scm:git:git@github.com:TimechoLab/moquette.git</developerConnection>
+        <url>git@github.com:TimechoLab/moquette.git</url>
     </scm>
 
     <modules>
@@ -234,39 +234,18 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.7.0</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
         </profile>
     </profiles>
-
-    <repositories>
-        <repository>
-            <id>Maven repo</id>
-            <url>https://repo1.maven.org/maven2/</url>
-        </repository>
-
-        <repository>
-            <id>Paho Releases</id>
-            <url>https://repo.eclipse.org/content/repositories/paho-releases/</url>
-        </repository>
-
-        <repository>
-            <id>sonatype-snapshots</id>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </repository>
-    </repositories>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
-    </distributionManagement>
 </project>


### PR DESCRIPTION
## Summary

Expose the connecting client Netty `Channel` through `InterceptConnectMessage`; remote socket address helpers continue to be available and now derive from the channel when no explicit address is provided.

## Changes

- Thread the Netty channel from `MQTTConnection` through `PostOffice` and `BrokerInterceptor`.
- Add `getChannel()`, `getRemoteAddress()`, `getClientAddress()`, and `getClientPort()` to `InterceptConnectMessage`.
- Keep existing connect-message constructors and one/two-argument interceptor notification paths compatible.
- Add coverage proving connect intercept messages include the channel and can derive the remote address from it.

## Validation

- `./mvnw -pl broker -Dtest=BrokerInterceptorTest test`
- Earlier full run: `./mvnw -pl broker test -DskipITs` reached `Tests run: 341, Failures: 0, Errors: 0, Skipped: 6` before the local forked process hit `unable to create native thread`, so the full run did not complete in this environment.