### PR TITLE
Expose client remote address in connect intercept

### DIFF
--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -396,7 +396,7 @@ final class MQTTConnection {
                             setupInflightResender(channel);
                         }
 
-                        postOffice.dispatchConnection(msg);
+                        postOffice.dispatchConnection(msg, channel);
                         LOG.trace("dispatch connection: {}", msg);
                     }
                 } else {

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -400,7 +400,7 @@ final class MQTTConnection {
                             setupInflightResender(channel);
                         }
 
-                        postOffice.dispatchConnection(msg, channel);
+                        postOffice.dispatchConnection(msg, remoteAddress());
                         LOG.trace("dispatch connection: {}", msg);
                     }
                 } else {

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -25,6 +25,7 @@ import io.moquette.broker.subscriptions.Topic;
 import io.moquette.interception.BrokerInterceptor;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttFixedHeader;
 import io.netty.handler.codec.mqtt.MqttMessageBuilders;
@@ -1104,8 +1105,8 @@ class PostOffice {
      * notify MqttConnectMessage after connection established (already pass login).
      * @param msg
      */
-    void dispatchConnection(MqttConnectMessage msg) {
-        interceptor.notifyClientConnected(msg);
+    void dispatchConnection(MqttConnectMessage msg, Channel channel) {
+        interceptor.notifyClientConnected(msg, channel);
     }
 
     void dispatchDisconnection(String clientId,String userName) {

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -25,7 +25,6 @@ import io.moquette.broker.subscriptions.Topic;
 import io.moquette.interception.BrokerInterceptor;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttFixedHeader;
 import io.netty.handler.codec.mqtt.MqttMessageBuilders;
@@ -43,6 +42,7 @@ import io.netty.handler.codec.mqtt.MqttTopicSubscription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
@@ -1131,8 +1131,8 @@ class PostOffice {
      * notify MqttConnectMessage after connection established (already pass login).
      * @param msg
      */
-    void dispatchConnection(MqttConnectMessage msg, Channel channel) {
-        interceptor.notifyClientConnected(msg, channel);
+    void dispatchConnection(MqttConnectMessage msg, InetSocketAddress remoteAddress) {
+        interceptor.notifyClientConnected(msg, remoteAddress);
     }
 
     void dispatchDisconnection(String clientId,String userName) {

--- a/broker/src/main/java/io/moquette/interception/BrokerInterceptor.java
+++ b/broker/src/main/java/io/moquette/interception/BrokerInterceptor.java
@@ -21,6 +21,7 @@ import io.moquette.broker.Utils;
 import io.moquette.interception.messages.*;
 import io.moquette.broker.config.IConfig;
 import io.moquette.broker.subscriptions.Subscription;
+import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import io.netty.util.ReferenceCountUtil;
@@ -95,10 +96,15 @@ public final class BrokerInterceptor implements Interceptor {
 
     @Override
     public void notifyClientConnected(final MqttConnectMessage msg) {
+        notifyClientConnected(msg, (Channel) null);
+    }
+
+    @Override
+    public void notifyClientConnected(final MqttConnectMessage msg, final Channel channel) {
         for (final InterceptHandler handler : this.handlers.get(InterceptConnectMessage.class)) {
             LOG.debug("Sending MQTT CONNECT message to interceptor. CId={}, interceptorId={}",
                     msg.payload().clientIdentifier(), handler.getID());
-            executor.execute(() -> handler.onConnect(new InterceptConnectMessage(msg)));
+            executor.execute(() -> handler.onConnect(new InterceptConnectMessage(msg, channel)));
         }
     }
 

--- a/broker/src/main/java/io/moquette/interception/BrokerInterceptor.java
+++ b/broker/src/main/java/io/moquette/interception/BrokerInterceptor.java
@@ -21,11 +21,12 @@ import io.moquette.broker.Utils;
 import io.moquette.interception.messages.*;
 import io.moquette.broker.config.IConfig;
 import io.moquette.broker.subscriptions.Subscription;
-import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -95,15 +96,15 @@ public final class BrokerInterceptor implements Interceptor {
 
     @Override
     public void notifyClientConnected(final MqttConnectMessage msg) {
-        notifyClientConnected(msg, (Channel) null);
+        notifyClientConnected(msg, (InetSocketAddress) null);
     }
 
     @Override
-    public void notifyClientConnected(final MqttConnectMessage msg, final Channel channel) {
+    public void notifyClientConnected(final MqttConnectMessage msg, final InetSocketAddress remoteAddress) {
         for (final InterceptHandler handler : this.handlers.get(InterceptConnectMessage.class)) {
             LOG.debug("Sending MQTT CONNECT message to interceptor. CId={}, interceptorId={}",
                     msg.payload().clientIdentifier(), handler.getID());
-            executor.execute(() -> handler.onConnect(new InterceptConnectMessage(msg, channel)));
+            executor.execute(() -> handler.onConnect(new InterceptConnectMessage(msg, remoteAddress)));
         }
     }
 

--- a/broker/src/main/java/io/moquette/interception/Interceptor.java
+++ b/broker/src/main/java/io/moquette/interception/Interceptor.java
@@ -19,6 +19,7 @@ package io.moquette.interception;
 import io.moquette.interception.messages.InterceptAcknowledgedMessage;
 import io.moquette.broker.subscriptions.Subscription;
 import io.moquette.interception.messages.InterceptExceptionMessage;
+import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 
@@ -35,6 +36,10 @@ import io.netty.handler.codec.mqtt.MqttPublishMessage;
 public interface Interceptor {
 
     void notifyClientConnected(MqttConnectMessage msg);
+
+    default void notifyClientConnected(MqttConnectMessage msg, Channel channel) {
+        notifyClientConnected(msg);
+    }
 
     void notifyClientDisconnected(String clientID, String username);
 

--- a/broker/src/main/java/io/moquette/interception/Interceptor.java
+++ b/broker/src/main/java/io/moquette/interception/Interceptor.java
@@ -19,9 +19,10 @@ package io.moquette.interception;
 import io.moquette.interception.messages.InterceptAcknowledgedMessage;
 import io.moquette.broker.subscriptions.Subscription;
 import io.moquette.interception.messages.InterceptExceptionMessage;
-import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
+
+import java.net.InetSocketAddress;
 
 /**
  * This interface is to be used internally by the broker components.
@@ -37,7 +38,7 @@ public interface Interceptor {
 
     void notifyClientConnected(MqttConnectMessage msg);
 
-    default void notifyClientConnected(MqttConnectMessage msg, Channel channel) {
+    default void notifyClientConnected(MqttConnectMessage msg, InetSocketAddress remoteAddress) {
         notifyClientConnected(msg);
     }
 

--- a/broker/src/main/java/io/moquette/interception/messages/InterceptConnectMessage.java
+++ b/broker/src/main/java/io/moquette/interception/messages/InterceptConnectMessage.java
@@ -16,19 +16,52 @@
 
 package io.moquette.interception.messages;
 
+import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
+
+import java.net.InetSocketAddress;
+import java.util.Optional;
 
 public class InterceptConnectMessage extends InterceptAbstractMessage {
 
     private final MqttConnectMessage msg;
+    private final Channel channel;
 
     public InterceptConnectMessage(MqttConnectMessage msg) {
+        this(msg, null);
+    }
+
+    public InterceptConnectMessage(MqttConnectMessage msg, Channel channel) {
         super(msg);
         this.msg = msg;
+        this.channel = channel;
     }
 
     public String getClientID() {
         return msg.payload().clientIdentifier();
+    }
+
+    public Optional<Channel> getChannel() {
+        return Optional.ofNullable(channel);
+    }
+
+    public Optional<InetSocketAddress> getRemoteAddress() {
+        if (channel != null && channel.remoteAddress() instanceof InetSocketAddress) {
+            return Optional.of((InetSocketAddress) channel.remoteAddress());
+        }
+        return Optional.empty();
+    }
+
+    public String getClientAddress() {
+        return getRemoteAddress()
+            .map(InetSocketAddress::getHostString)
+            .orElse(null);
+    }
+
+    public int getClientPort() {
+        return getRemoteAddress()
+            .map(InetSocketAddress::getPort)
+            .orElse(-1);
     }
 
     public boolean isCleanSession() {

--- a/broker/src/main/java/io/moquette/interception/messages/InterceptConnectMessage.java
+++ b/broker/src/main/java/io/moquette/interception/messages/InterceptConnectMessage.java
@@ -16,7 +16,6 @@
 
 package io.moquette.interception.messages;
 
-import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttConnectMessage;
 
 import java.net.InetSocketAddress;
@@ -25,31 +24,24 @@ import java.util.Optional;
 public class InterceptConnectMessage extends InterceptAbstractMessage {
 
     private final MqttConnectMessage msg;
-    private final Channel channel;
+    private final InetSocketAddress remoteAddress;
 
     public InterceptConnectMessage(MqttConnectMessage msg) {
         this(msg, null);
     }
 
-    public InterceptConnectMessage(MqttConnectMessage msg, Channel channel) {
+    public InterceptConnectMessage(MqttConnectMessage msg, InetSocketAddress remoteAddress) {
         super(msg);
         this.msg = msg;
-        this.channel = channel;
+        this.remoteAddress = remoteAddress;
     }
 
     public String getClientID() {
         return msg.payload().clientIdentifier();
     }
 
-    public Optional<Channel> getChannel() {
-        return Optional.ofNullable(channel);
-    }
-
     public Optional<InetSocketAddress> getRemoteAddress() {
-        if (channel != null && channel.remoteAddress() instanceof InetSocketAddress) {
-            return Optional.of((InetSocketAddress) channel.remoteAddress());
-        }
-        return Optional.empty();
+        return Optional.ofNullable(remoteAddress);
     }
 
     public String getClientAddress() {

--- a/broker/src/main/java/io/moquette/interception/messages/InterceptConnectMessage.java
+++ b/broker/src/main/java/io/moquette/interception/messages/InterceptConnectMessage.java
@@ -45,15 +45,11 @@ public class InterceptConnectMessage extends InterceptAbstractMessage {
     }
 
     public String getClientAddress() {
-        return getRemoteAddress()
-            .map(InetSocketAddress::getHostString)
-            .orElse(null);
+        return remoteAddress != null ? remoteAddress.getHostString() : null;
     }
 
     public int getClientPort() {
-        return getRemoteAddress()
-            .map(InetSocketAddress::getPort)
-            .orElse(-1);
+        return remoteAddress != null ? remoteAddress.getPort() : -1;
     }
 
     public boolean isCleanSession() {

--- a/broker/src/test/java/io/moquette/interception/BrokerInterceptorTest.java
+++ b/broker/src/test/java/io/moquette/interception/BrokerInterceptorTest.java
@@ -21,6 +21,7 @@ import io.moquette.broker.subscriptions.Subscription;
 import io.moquette.broker.subscriptions.Topic;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttMessageBuilders;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
@@ -28,14 +29,21 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.net.InetSocketAddress;
 import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class BrokerInterceptorTest {
 
@@ -121,6 +129,45 @@ public class BrokerInterceptorTest {
         interceptor.notifyClientConnected(MqttMessageBuilders.connect().build());
         interval();
         assertEquals(40, n.get());
+    }
+
+    @Test
+    public void testNotifyClientConnectedIncludesRemoteAddress() throws Exception {
+        final CountDownLatch notified = new CountDownLatch(1);
+        final AtomicReference<InterceptConnectMessage> intercepted = new AtomicReference<>();
+        final BrokerInterceptor localInterceptor = new BrokerInterceptor(
+            Collections.<InterceptHandler>singletonList(new AbstractInterceptHandler() {
+                @Override
+                public String getID() {
+                    return "RemoteAddressObserver";
+                }
+
+                @Override
+                public void onConnect(InterceptConnectMessage msg) {
+                    intercepted.set(msg);
+                    notified.countDown();
+                }
+
+                @Override
+                public void onSessionLoopError(Throwable error) {
+                    throw new RuntimeException(error);
+                }
+            }));
+
+        try {
+            final InetSocketAddress remoteAddress = new InetSocketAddress("127.0.0.1", 12345);
+            final Channel channel = mock(Channel.class);
+            when(channel.remoteAddress()).thenReturn(remoteAddress);
+            localInterceptor.notifyClientConnected(MqttMessageBuilders.connect().build(), channel);
+
+            assertTrue(notified.await(1, TimeUnit.SECONDS));
+            assertSame(channel, intercepted.get().getChannel().get());
+            assertEquals(remoteAddress, intercepted.get().getRemoteAddress().get());
+            assertEquals("127.0.0.1", intercepted.get().getClientAddress());
+            assertEquals(12345, intercepted.get().getClientPort());
+        } finally {
+            localInterceptor.stop();
+        }
     }
 
     @Test

--- a/broker/src/test/java/io/moquette/interception/BrokerInterceptorTest.java
+++ b/broker/src/test/java/io/moquette/interception/BrokerInterceptorTest.java
@@ -24,20 +24,18 @@ import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.mqtt.MqttMessageBuilders;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
-import java.util.Collections;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -103,7 +101,7 @@ public class BrokerInterceptorTest {
     }
 
     private static final BrokerInterceptor interceptor = new BrokerInterceptor(
-        Collections.<InterceptHandler>singletonList(new MockObserver()));
+        List.of(new MockObserver()));
 
     @BeforeAll
     public static void beforeAllTests() {
@@ -129,11 +127,10 @@ public class BrokerInterceptorTest {
     }
 
     @Test
-    public void testNotifyClientConnectedIncludesRemoteAddress() throws Exception {
-        final CountDownLatch notified = new CountDownLatch(1);
+    public void testNotifyClientConnectedIncludesRemoteAddress() {
         final AtomicReference<InterceptConnectMessage> intercepted = new AtomicReference<>();
         final BrokerInterceptor localInterceptor = new BrokerInterceptor(
-            Collections.<InterceptHandler>singletonList(new AbstractInterceptHandler() {
+            List.of(new AbstractInterceptHandler() {
                 @Override
                 public String getID() {
                     return "RemoteAddressObserver";
@@ -142,7 +139,6 @@ public class BrokerInterceptorTest {
                 @Override
                 public void onConnect(InterceptConnectMessage msg) {
                     intercepted.set(msg);
-                    notified.countDown();
                 }
 
                 @Override
@@ -155,7 +151,7 @@ public class BrokerInterceptorTest {
             final InetSocketAddress remoteAddress = new InetSocketAddress("127.0.0.1", 12345);
             localInterceptor.notifyClientConnected(MqttMessageBuilders.connect().build(), remoteAddress);
 
-            assertTrue(notified.await(1, TimeUnit.SECONDS));
+            Awaitility.await().until(() -> intercepted.get() != null);
             assertEquals(remoteAddress, intercepted.get().getRemoteAddress().get());
             assertEquals("127.0.0.1", intercepted.get().getClientAddress());
             assertEquals(12345, intercepted.get().getClientPort());

--- a/broker/src/test/java/io/moquette/interception/BrokerInterceptorTest.java
+++ b/broker/src/test/java/io/moquette/interception/BrokerInterceptorTest.java
@@ -21,7 +21,6 @@ import io.moquette.broker.subscriptions.Subscription;
 import io.moquette.broker.subscriptions.Topic;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.Channel;
 import io.netty.handler.codec.mqtt.MqttMessageBuilders;
 import io.netty.handler.codec.mqtt.MqttQoS;
 import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
@@ -38,12 +37,10 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.refEq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class BrokerInterceptorTest {
 
@@ -156,12 +153,9 @@ public class BrokerInterceptorTest {
 
         try {
             final InetSocketAddress remoteAddress = new InetSocketAddress("127.0.0.1", 12345);
-            final Channel channel = mock(Channel.class);
-            when(channel.remoteAddress()).thenReturn(remoteAddress);
-            localInterceptor.notifyClientConnected(MqttMessageBuilders.connect().build(), channel);
+            localInterceptor.notifyClientConnected(MqttMessageBuilders.connect().build(), remoteAddress);
 
             assertTrue(notified.await(1, TimeUnit.SECONDS));
-            assertSame(channel, intercepted.get().getChannel().get());
             assertEquals(remoteAddress, intercepted.get().getRemoteAddress().get());
             assertEquals("127.0.0.1", intercepted.get().getClientAddress());
             assertEquals(12345, intercepted.get().getClientPort());


### PR DESCRIPTION
## Summary

- Include the client remote socket address in `InterceptConnectMessage` for CONNECT interceptors.
- Expose remote address, client address, and client port accessors.
- Keep the existing one-argument connect interception API compatible without retaining the live Netty `Channel`.

## Test
- `./mvnw -pl broker -Dtest=BrokerInterceptorTest test`

Fixes #867