### PR TITLE
Preparatory work to split authentication in the CONNECT processing

### DIFF
--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -47,6 +47,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.net.ssl.SSLPeerUnverifiedException;
 
 import static io.netty.channel.ChannelFutureListener.CLOSE_ON_FAILURE;
@@ -76,7 +77,7 @@ final class MQTTConnection {
     private Quota receivedQuota;
     private Quota sendQuota;
     private TopicAliasMapping aliasMappings;
-    private MqttConnectMessage connectMessage;
+    private AtomicReference<MqttConnectMessage> connectMessage = new AtomicReference<>();
 
     static final class ErrorCodeException extends Exception {
 
@@ -235,7 +236,7 @@ final class MQTTConnection {
         }
 
         sendQuota = retrieveSendQuota(msg);
-        connectMessage = msg;
+        connectMessage.set(msg);
 
         if (!login(msg, clientId)) {
             if (isProtocolVersion(MqttVersion.MQTT_5)) {
@@ -260,7 +261,7 @@ final class MQTTConnection {
         final String sessionId = clientId;
         return postOffice.routeCommand(clientId, "CONN", () -> {
             checkMatchSessionLoop(sessionId);
-            executeConnect(MQTTConnection.this.connectMessage, sessionId, serverGeneratedClientId);
+            executeConnect(MQTTConnection.this.connectMessage.get(), sessionId, serverGeneratedClientId);
             MQTTConnection.this.connectMessage = null;
             return null;
         });

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -76,6 +76,7 @@ final class MQTTConnection {
     private Quota receivedQuota;
     private Quota sendQuota;
     private TopicAliasMapping aliasMappings;
+    private MqttConnectMessage connectMessage;
 
     static final class ErrorCodeException extends Exception {
 
@@ -197,6 +198,7 @@ final class MQTTConnection {
         MqttConnectPayload payload = msg.payload();
         String clientId = payload.clientIdentifier();
         final String username = payload.userName();
+        protocolVersion = msg.variableHeader().version();
         LOG.trace("Processing CONNECT message. CId: {} username: {}", clientId, username);
 
         if (isNotProtocolVersion(msg, MqttVersion.MQTT_3_1) &&
@@ -207,10 +209,10 @@ final class MQTTConnection {
             abortConnection(CONNECTION_REFUSED_UNACCEPTABLE_PROTOCOL_VERSION);
             return PostOffice.RouteResult.failed(clientId);
         }
-        final boolean cleanSession = msg.variableHeader().isCleanSession();
+        boolean cleanSession = msg.variableHeader().isCleanSession();
         final boolean serverGeneratedClientId;
         if (clientId == null || clientId.isEmpty()) {
-            if (isNotProtocolVersion(msg, MqttVersion.MQTT_5)) {
+            if (!isProtocolVersion(MqttVersion.MQTT_5)) {
                 if (!brokerConfig.isAllowZeroByteClientId()) {
                     LOG.info("Broker doesn't permit MQTT empty client ID. Username: {}", username);
                     abortConnection(CONNECTION_REFUSED_IDENTIFIER_REJECTED);
@@ -232,8 +234,11 @@ final class MQTTConnection {
             serverGeneratedClientId = false;
         }
 
+        sendQuota = retrieveSendQuota(msg);
+        connectMessage = msg;
+
         if (!login(msg, clientId)) {
-            if (isProtocolVersion(msg, MqttVersion.MQTT_5)) {
+            if (isProtocolVersion(MqttVersion.MQTT_5)) {
                 final ConnAckPropertiesBuilder builder = prepareConnAckPropertiesBuilder(false, clientId);
                 builder.reasonString("User credentials provided are not recognized as valid");
                 abortConnectionV5(CONNECTION_REFUSED_BAD_USERNAME_OR_PASSWORD, builder);
@@ -246,19 +251,17 @@ final class MQTTConnection {
         }
 
         // initialize topic alias mapping
-        if (isProtocolVersion(msg, MqttVersion.MQTT_5)) {
+        if (isProtocolVersion(MqttVersion.MQTT_5)) {
             aliasMappings = new TopicAliasMapping();
         }
 
         receivedQuota = createQuota(brokerConfig.receiveMaximum());
 
-        sendQuota = retrieveSendQuota(msg);
-
         final String sessionId = clientId;
-        protocolVersion = msg.variableHeader().version();
         return postOffice.routeCommand(clientId, "CONN", () -> {
             checkMatchSessionLoop(sessionId);
-            executeConnect(msg, sessionId, serverGeneratedClientId);
+            executeConnect(MQTTConnection.this.connectMessage, sessionId, serverGeneratedClientId);
+            MQTTConnection.this.connectMessage = null;
             return null;
         });
     }
@@ -498,6 +501,10 @@ final class MQTTConnection {
 
     private static boolean isProtocolVersion(MqttConnectMessage msg, MqttVersion version) {
         return msg.variableHeader().version() == version.protocolLevel();
+    }
+
+    private boolean isProtocolVersion(MqttVersion version) {
+        return protocolVersion == version.protocolLevel();
     }
 
     private void abortConnection(MqttConnectReturnCode returnCode) {


### PR DESCRIPTION
## Release notes
[rn:skip]

## What does this PR do?


Store some parts of MqttConnectMessage or the message in its entirety as preparatory work splitting the authetication part between CONNECT and AUTH.

## Why is it important/What is the impact to the user?
N/A

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have updated the Changelog if it's a feature or a fix that has to be reported~~

## Author's Checklist

N/A

## How to test this PR locally
N/A

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseeds #123
-->
- Closes #950

## Use cases

<!-- Recommended
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.

If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->
