### PR TITLE
Added messages to assertions in MetricsProvider tests

### DIFF
--- a/broker/src/test/java/io/moquette/metrics/MetricsTest.java
+++ b/broker/src/test/java/io/moquette/metrics/MetricsTest.java
@@ -121,12 +121,12 @@ public class MetricsTest {
     public void testMetrics() throws MqttException {
         MetricsProviderMock mp = validateMetricsProvider();
 
-        assertEquals(0, mp.getSessionCount());
-        assertEquals(0, mp.getPublishCount());
-        assertEquals(0, mp.getMessageSum());
-        assertEquals(0, mp.getSessionQueueFillSum());
-        assertEquals(0, mp.getSessionQueueFillMax());
-        assertEquals(0, mp.getSessionQueueOverrunSum());
+        assertEquals(0, mp.getSessionCount(), "Incorrect value for metric 'SessionCount'");
+        assertEquals(0, mp.getPublishCount(), "Incorrect value for metric 'PublishCount'");
+        assertEquals(0, mp.getMessageSum(), "Incorrect value for metric 'MessageSum'");
+        assertEquals(0, mp.getSessionQueueFillSum(), "Incorrect value for metric 'SessionQueueFillSum'");
+        assertEquals(0, mp.getSessionQueueFillMax(), "Incorrect value for metric 'SessionQueueFillMax'");
+        assertEquals(0, mp.getSessionQueueOverrunSum(), "Incorrect value for metric 'SessionQueueOverrunSum'");
 
         clientListener.connect();
         clientListener.subscribe("test/topic");
@@ -134,15 +134,15 @@ public class MetricsTest {
         clientPublisher.publish("test/topic", "Hello world MQTT!!".getBytes(UTF_8), 2, false);
         Awaitility.await().until(messagesCollector::isMessageReceived);
 
-        assertEquals(2, mp.getSessionCount());
-        assertEquals(1, mp.getPublishCount());
-        assertEquals(1, mp.getMessageSum());
-        assertEquals(0, mp.getMessageSum(MqttQoS.AT_MOST_ONCE.value()));
-        assertEquals(1, mp.getMessageSum(MqttQoS.AT_LEAST_ONCE.value()));
-        assertEquals(0, mp.getMessageSum(MqttQoS.EXACTLY_ONCE.value()));
-        assertEquals(0, mp.getSessionQueueFillSum());
-        assertTrue(mp.getSessionQueueFillMax() > 0);
-        assertEquals(0, mp.getSessionQueueOverrunSum());
+        assertEquals(2, mp.getSessionCount(), "Incorrect value for metric 'SessionCount'");
+        assertEquals(1, mp.getPublishCount(), "Incorrect value for metric 'PublishCount'");
+        assertEquals(1, mp.getMessageSum(), "Incorrect value for metric 'MessageSum'");
+        assertEquals(0, mp.getMessageSum(MqttQoS.AT_MOST_ONCE.value()), "Incorrect value for metric 'MessageSum, QOS 0'");
+        assertEquals(1, mp.getMessageSum(MqttQoS.AT_LEAST_ONCE.value()), "Incorrect value for metric 'MessageSum, QOS 1'");
+        assertEquals(0, mp.getMessageSum(MqttQoS.EXACTLY_ONCE.value()), "Incorrect value for metric 'MessageSum, QOS 2'");
+        assertEquals(0, mp.getSessionQueueFillSum(), "Incorrect value for metric 'SessionQueueFillSum'");
+        assertTrue(mp.getSessionQueueFillMax() > 0, "Incorrect value for metric 'SessionQueueFillMax'");
+        assertEquals(0, mp.getSessionQueueOverrunSum(), "Incorrect value for metric 'SessionQueueOverrunSum'");
         mp.clearSessionQueueFillMax();
 
         clientListener.disconnect();
@@ -153,17 +153,16 @@ public class MetricsTest {
             .atMost(Duration.ofMillis(100))
             .until(() -> mp.getSessionCount(), Is.is(0));
 
-        assertEquals(0, mp.getSessionCount());
-        assertEquals(1, mp.getPublishCount());
-        assertEquals(1, mp.getMessageSum());
-        assertEquals(0, mp.getMessageSum(MqttQoS.AT_MOST_ONCE.value()));
-        assertEquals(1, mp.getMessageSum(MqttQoS.AT_LEAST_ONCE.value()));
-        assertEquals(0, mp.getMessageSum(MqttQoS.EXACTLY_ONCE.value()));
-        assertEquals(0, mp.getSessionQueueFillSum());
-        assertTrue(mp.getSessionQueueFillMax() > 0);
-        assertEquals(0, mp.getSessionQueueOverrunSum());
+        assertEquals(0, mp.getSessionCount(), "Incorrect value for metric 'SessionCount'");
+        assertEquals(1, mp.getPublishCount(), "Incorrect value for metric 'PublishCount'");
+        assertEquals(1, mp.getMessageSum(), "Incorrect value for metric 'MessageSum'");
+        assertEquals(0, mp.getMessageSum(MqttQoS.AT_MOST_ONCE.value()), "Incorrect value for metric 'MessageSum, QOS 0'");
+        assertEquals(1, mp.getMessageSum(MqttQoS.AT_LEAST_ONCE.value()), "Incorrect value for metric 'MessageSum, QOS 1'");
+        assertEquals(0, mp.getMessageSum(MqttQoS.EXACTLY_ONCE.value()), "Incorrect value for metric 'MessageSum, QOS 2'");
+        assertEquals(0, mp.getSessionQueueFillSum(), "Incorrect value for metric 'SessionQueueFillSum'");
+        assertTrue(mp.getSessionQueueFillMax() > 0, "Incorrect value for metric 'SessionQueueFillMax'");
+        assertEquals(0, mp.getSessionQueueOverrunSum(), "Incorrect value for metric 'SessionQueueOverrunSum'");
         mp.clearSessionQueueFillMax();
-
     }
 
     /**

--- a/metrics_prometheus/src/test/java/io/moquette/metrics/prometheus/MetricsProviderPrometheusTest.java
+++ b/metrics_prometheus/src/test/java/io/moquette/metrics/prometheus/MetricsProviderPrometheusTest.java
@@ -123,15 +123,15 @@ public class MetricsProviderPrometheusTest {
         assertEquals(200, response.code, () -> "Error fetching metrics: " + metricsUrl);
         LOGGER.debug("Data: \n{}", response.response);
         Map<String, String> data = parseMetrics(response.response);
-        assertEquals("0.0", data.get(METRIC_MOQUETTE_OPEN_SESSIONS));
-        assertEquals("0.0", data.get(METRIC_MOQUETTE_PUBLISHES_TOTAL));
-        assertEquals("0.0", data.get(METRIC_MOQUETTE_SESSION_MESSAGES_TOTAL + "{QoS=\"0\",queue_name=\"queue-0\"}"));
-        assertEquals("0.0", data.get(METRIC_MOQUETTE_SESSION_MESSAGES_TOTAL + "{QoS=\"1\",queue_name=\"queue-0\"}"));
-        assertEquals("0.0", data.get(METRIC_MOQUETTE_SESSION_MESSAGES_TOTAL + "{QoS=\"2\",queue_name=\"queue-0\"}"));
-        assertEquals("0.0", data.get(METRIC_MOQUETTE_SESSION_QUEUE_FILL + "{queue_id=\"queue-0\"}"));
-        assertEquals("0.0", data.get(METRIC_MOQUETTE_SESSION_QUEUE_FILL_MAX + "{queue_id=\"queue-0\"}"));
-        assertEquals("0.0", data.get(METRIC_MOQUETTE_SESSION_QUEUE_OVERRUNS_TOTAL + "{queue_name=\"queue-0\"}"));
-        assertEquals("0.0", data.get(METRIC_MOQUETTE_SESSION_QUEUE_FILL_MAX));
+        assertMetric(data, "0.0", METRIC_MOQUETTE_OPEN_SESSIONS);
+        assertMetric(data, "0.0", METRIC_MOQUETTE_PUBLISHES_TOTAL);
+        assertMetric(data, "0.0", METRIC_MOQUETTE_SESSION_MESSAGES_TOTAL + "{QoS=\"0\",queue_name=\"queue-0\"}");
+        assertMetric(data, "0.0", METRIC_MOQUETTE_SESSION_MESSAGES_TOTAL + "{QoS=\"1\",queue_name=\"queue-0\"}");
+        assertMetric(data, "0.0", METRIC_MOQUETTE_SESSION_MESSAGES_TOTAL + "{QoS=\"2\",queue_name=\"queue-0\"}");
+        assertMetric(data, "0.0", METRIC_MOQUETTE_SESSION_QUEUE_FILL + "{queue_id=\"queue-0\"}");
+        assertMetric(data, "0.0", METRIC_MOQUETTE_SESSION_QUEUE_FILL_MAX + "{queue_id=\"queue-0\"}");
+        assertMetric(data, "0.0", METRIC_MOQUETTE_SESSION_QUEUE_OVERRUNS_TOTAL + "{queue_name=\"queue-0\"}");
+        assertMetric(data, "0.0", METRIC_MOQUETTE_SESSION_QUEUE_FILL_MAX);
 
         clientListener.connect();
         clientListener.subscribe("test/topic");
@@ -143,12 +143,12 @@ public class MetricsProviderPrometheusTest {
         assertEquals(200, response.code, () -> "Error fetching metrics: " + metricsUrl);
         LOGGER.debug("Data: \n{}", response.response);
         data = parseMetrics(response.response);
-        assertEquals("2.0", data.get(METRIC_MOQUETTE_OPEN_SESSIONS));
-        assertEquals("1.0", data.get(METRIC_MOQUETTE_PUBLISHES_TOTAL));
-        assertEquals("1.0", data.get(METRIC_MOQUETTE_SESSION_MESSAGES_TOTAL));
-        assertEquals("0.0", data.get(METRIC_MOQUETTE_SESSION_QUEUE_FILL + "{queue_id=\"queue-0\"}"));
-        assertEquals("0.0", data.get(METRIC_MOQUETTE_SESSION_QUEUE_OVERRUNS_TOTAL + "{queue_name=\"queue-0\"}"));
-        assertTrue(Double.parseDouble(data.get(METRIC_MOQUETTE_SESSION_QUEUE_FILL_MAX)) > 0.0);
+        assertMetric(data, "2.0", METRIC_MOQUETTE_OPEN_SESSIONS);
+        assertMetric(data, "1.0", METRIC_MOQUETTE_PUBLISHES_TOTAL);
+        assertMetric(data, "1.0", METRIC_MOQUETTE_SESSION_MESSAGES_TOTAL);
+        assertMetric(data, "0.0", METRIC_MOQUETTE_SESSION_QUEUE_FILL + "{queue_id=\"queue-0\"}");
+        assertMetric(data, "0.0", METRIC_MOQUETTE_SESSION_QUEUE_OVERRUNS_TOTAL + "{queue_name=\"queue-0\"}");
+        assertTrue(Double.parseDouble(data.get(METRIC_MOQUETTE_SESSION_QUEUE_FILL_MAX)) > 0.0, "Incorrect value for metric moquette_session_queue_fill_max, must be > 0.0");
 
         clientListener.disconnect();
         clientPublisher.disconnect();
@@ -157,23 +157,23 @@ public class MetricsProviderPrometheusTest {
         assertEquals(200, response.code, () -> "Error fetching metrics: " + metricsUrl);
         LOGGER.debug("Data: \n{}", response.response);
         data = parseMetrics(response.response);
-        assertEquals("0.0", data.get(METRIC_MOQUETTE_OPEN_SESSIONS));
-        assertEquals("1.0", data.get(METRIC_MOQUETTE_PUBLISHES_TOTAL));
-        assertEquals("1.0", data.get(METRIC_MOQUETTE_SESSION_MESSAGES_TOTAL));
-        assertEquals("0.0", data.get(METRIC_MOQUETTE_SESSION_QUEUE_FILL + "{queue_id=\"queue-0\"}"));
-        assertEquals("0.0", data.get(METRIC_MOQUETTE_SESSION_QUEUE_OVERRUNS_TOTAL + "{queue_name=\"queue-0\"}"));
-        assertTrue(Double.parseDouble(data.get(METRIC_MOQUETTE_SESSION_QUEUE_FILL_MAX)) > 0.0);
+        assertMetric(data, "0.0", METRIC_MOQUETTE_OPEN_SESSIONS);
+        assertMetric(data, "1.0", METRIC_MOQUETTE_PUBLISHES_TOTAL);
+        assertMetric(data, "1.0", METRIC_MOQUETTE_SESSION_MESSAGES_TOTAL);
+        assertMetric(data, "0.0", METRIC_MOQUETTE_SESSION_QUEUE_FILL + "{queue_id=\"queue-0\"}");
+        assertMetric(data, "0.0", METRIC_MOQUETTE_SESSION_QUEUE_OVERRUNS_TOTAL + "{queue_name=\"queue-0\"}");
+        assertTrue(Double.parseDouble(data.get(METRIC_MOQUETTE_SESSION_QUEUE_FILL_MAX)) > 0.0, "Incorrect value for metric moquette_session_queue_fill_max, must be > 0.0");
 
         response = HttpHelper.doGet(metricsUrl);
         assertEquals(200, response.code, () -> "Error fetching metrics: " + metricsUrl);
         LOGGER.debug("Data: \n{}", response.response);
         data = parseMetrics(response.response);
-        assertEquals("0.0", data.get(METRIC_MOQUETTE_OPEN_SESSIONS));
-        assertEquals("1.0", data.get(METRIC_MOQUETTE_PUBLISHES_TOTAL));
-        assertEquals("1.0", data.get(METRIC_MOQUETTE_SESSION_MESSAGES_TOTAL));
-        assertEquals("0.0", data.get(METRIC_MOQUETTE_SESSION_QUEUE_FILL + "{queue_id=\"queue-0\"}"));
-        assertEquals("0.0", data.get(METRIC_MOQUETTE_SESSION_QUEUE_OVERRUNS_TOTAL + "{queue_name=\"queue-0\"}"));
-        assertTrue(Double.parseDouble(data.get(METRIC_MOQUETTE_SESSION_QUEUE_FILL_MAX)) == 0.0);
+        assertMetric(data, "0.0", METRIC_MOQUETTE_OPEN_SESSIONS);
+        assertMetric(data, "1.0", METRIC_MOQUETTE_PUBLISHES_TOTAL);
+        assertMetric(data, "1.0", METRIC_MOQUETTE_SESSION_MESSAGES_TOTAL);
+        assertMetric(data, "0.0", METRIC_MOQUETTE_SESSION_QUEUE_FILL + "{queue_id=\"queue-0\"}");
+        assertMetric(data, "0.0", METRIC_MOQUETTE_SESSION_QUEUE_OVERRUNS_TOTAL + "{queue_name=\"queue-0\"}");
+        assertTrue(Double.parseDouble(data.get(METRIC_MOQUETTE_SESSION_QUEUE_FILL_MAX)) == 0.0, "Incorrect value for metric moquette_session_queue_fill_max, must be > 0.0");
     }
 
     @Test
@@ -186,8 +186,8 @@ public class MetricsProviderPrometheusTest {
         assertEquals(200, response.code, () -> "Error fetching metrics: " + metricsUrl);
         LOGGER.debug("Data: \n{}", response.response);
         Map<String, String> data = parseMetrics(response.response);
-        assertEquals("0.0", data.get(METRIC_MOQUETTE_OPEN_SESSIONS));
-        assertEquals("0.0", data.get(METRIC_MOQUETTE_PUBLISHES_TOTAL));
+        assertMetric(data, "0.0", METRIC_MOQUETTE_OPEN_SESSIONS);
+        assertMetric(data, "0.0", METRIC_MOQUETTE_PUBLISHES_TOTAL);
 
         // Connect two clients, one with clean session, one with non-clean session.
         final MqttConnectOptions listenerOptions = new MqttConnectOptions();
@@ -205,8 +205,8 @@ public class MetricsProviderPrometheusTest {
         assertEquals(200, response.code, () -> "Error fetching metrics: " + metricsUrl);
         LOGGER.debug("Data: \n{}", response.response);
         data = parseMetrics(response.response);
-        assertEquals("2.0", data.get(METRIC_MOQUETTE_OPEN_SESSIONS));
-        assertEquals("1.0", data.get(METRIC_MOQUETTE_PUBLISHES_TOTAL));
+        assertMetric(data, "2.0", METRIC_MOQUETTE_OPEN_SESSIONS);
+        assertMetric(data, "1.0", METRIC_MOQUETTE_PUBLISHES_TOTAL);
 
         // Disconnect the clients, this should leave the non-clean session open.
         clientListener.disconnect();
@@ -217,8 +217,8 @@ public class MetricsProviderPrometheusTest {
         assertEquals(200, response.code, () -> "Error fetching metrics: " + metricsUrl);
         LOGGER.debug("Data: \n{}", response.response);
         data = parseMetrics(response.response);
-        assertEquals("1.0", data.get(METRIC_MOQUETTE_OPEN_SESSIONS));
-        assertEquals("1.0", data.get(METRIC_MOQUETTE_PUBLISHES_TOTAL));
+        assertMetric(data, "1.0", METRIC_MOQUETTE_OPEN_SESSIONS);
+        assertMetric(data, "1.0", METRIC_MOQUETTE_PUBLISHES_TOTAL);
 
         // Re-open both sessions, but now both set to clean.
         listenerOptions.setCleanSession(true);
@@ -235,8 +235,8 @@ public class MetricsProviderPrometheusTest {
         assertEquals(200, response.code, () -> "Error fetching metrics: " + metricsUrl);
         LOGGER.debug("Data: \n{}", response.response);
         data = parseMetrics(response.response);
-        assertEquals("2.0", data.get(METRIC_MOQUETTE_OPEN_SESSIONS));
-        assertEquals("2.0", data.get(METRIC_MOQUETTE_PUBLISHES_TOTAL));
+        assertMetric(data, "2.0", METRIC_MOQUETTE_OPEN_SESSIONS);
+        assertMetric(data, "2.0", METRIC_MOQUETTE_PUBLISHES_TOTAL);
 
         // disconnect both sessions, this should leave 0 sessions open.
         clientListener.disconnect();
@@ -247,11 +247,15 @@ public class MetricsProviderPrometheusTest {
         assertEquals(200, response.code, () -> "Error fetching metrics: " + metricsUrl);
         LOGGER.debug("Data: \n{}", response.response);
         data = parseMetrics(response.response);
-        assertEquals("0.0", data.get(METRIC_MOQUETTE_OPEN_SESSIONS));
-        assertEquals("2.0", data.get(METRIC_MOQUETTE_PUBLISHES_TOTAL));
+        assertMetric(data, "0.0", METRIC_MOQUETTE_OPEN_SESSIONS);
+        assertMetric(data, "2.0", METRIC_MOQUETTE_PUBLISHES_TOTAL);
     }
 
-    private Map<String, String> parseMetrics(String response) {
+    private static void assertMetric(Map<String, String> data, String expected, String metric) {
+        assertEquals(expected, data.get(metric), "Incorrect value for metric " + metric);
+    }
+
+    private static Map<String, String> parseMetrics(String response) {
         Map<String, String> data = new HashMap<>();
         data.put(METRIC_MOQUETTE_SESSION_QUEUE_FILL_MAX, "0.0");
         data.put(METRIC_MOQUETTE_SESSION_MESSAGES_TOTAL, "0.0");


### PR DESCRIPTION
## What does this PR do?

Since the automatic build of a recent PR failed with a less-than-helpful message, this PR adds messages to the assertions of the metrics tests.

No functional changes were made.