### PR TITLE
Added optional, configurable timeout to session queue offers

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.19-SNAPSHOT
+   Added optional, configurable timeout to session queue offers. (#953)
    [fix] Fixed SessionCount metric miscounting when non-clean session are replaced with clean sessions. (#940)
    [Cleanup] Cleaned up subscription handling. (#931)
    [feature] Added metrics framework and Prometheus implementation.

--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -259,7 +259,8 @@ public class Server {
         }
 
         final int sessionQueueSize = config.intProp(IConfig.SESSION_QUEUE_SIZE, 1024);
-        final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(interceptor, sessionQueueSize, metricsProvider);
+        final int offerTimeoutMs = config.intProp(IConfig.SESSION_QUEUE_OFFER_TIMEOUT_MS, 1000);
+        final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(interceptor, sessionQueueSize, offerTimeoutMs, metricsProvider);
         sessions = new SessionRegistry(subscriptions, sessionsRepository, queueRepository, authorizator, scheduler,
             clock, globalSessionExpiry, loopsGroup, metricsProvider);
 

--- a/broker/src/main/java/io/moquette/broker/Server.java
+++ b/broker/src/main/java/io/moquette/broker/Server.java
@@ -259,7 +259,7 @@ public class Server {
         }
 
         final int sessionQueueSize = config.intProp(IConfig.SESSION_QUEUE_SIZE, 1024);
-        final int offerTimeoutMs = config.intProp(IConfig.SESSION_QUEUE_OFFER_TIMEOUT_MS, 1000);
+        final int offerTimeoutMs = config.intProp(IConfig.SESSION_QUEUE_OFFER_TIMEOUT_MS, 0);
         final SessionEventLoopGroup loopsGroup = new SessionEventLoopGroup(interceptor, sessionQueueSize, offerTimeoutMs, metricsProvider);
         sessions = new SessionRegistry(subscriptions, sessionsRepository, queueRepository, authorizator, scheduler,
             clock, globalSessionExpiry, loopsGroup, metricsProvider);

--- a/broker/src/main/java/io/moquette/broker/SessionEventLoop.java
+++ b/broker/src/main/java/io/moquette/broker/SessionEventLoop.java
@@ -1,12 +1,13 @@
 package io.moquette.broker;
 
-import io.moquette.metrics.MetricsManager;
 import io.moquette.metrics.MetricsProvider;
+import java.util.concurrent.ArrayBlockingQueue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
 
 final class SessionEventLoop extends Thread {
 
@@ -16,24 +17,59 @@ final class SessionEventLoop extends Thread {
     private final boolean flushOnExit;
     private final int queueId;
     private final MetricsProvider metricsProvider;
+    private final int offerTimeoutMs;
+    private final boolean timeoutUsed;
     /**
      * Allows a task to fetch the id of the session queue that is executing it.
      */
     private static final ThreadLocal<Integer> threadQueueId = new ThreadLocal<>();
 
-    public SessionEventLoop(BlockingQueue<FutureTask<String>> taskQueue, int queueId, MetricsProvider metricsProvider) {
-        this(taskQueue, queueId, true, metricsProvider);
+    public SessionEventLoop(int queueSize, int queueId, int offerTimeoutMs, MetricsProvider metricsProvider) {
+        this(new ArrayBlockingQueue<>(queueSize), queueId, offerTimeoutMs, true, metricsProvider);
     }
 
     /**
      * @param flushOnExit consume the commands queue before exit.
      *
      */
-    public SessionEventLoop(BlockingQueue<FutureTask<String>> taskQueue, int queueId, boolean flushOnExit, MetricsProvider metricsProvider) {
+    public SessionEventLoop(BlockingQueue<FutureTask<String>> taskQueue, int queueId, int offerTimeoutMs, boolean flushOnExit, MetricsProvider metricsProvider) {
         this.taskQueue = taskQueue;
         this.queueId = queueId;
+        this.offerTimeoutMs = offerTimeoutMs;
         this.flushOnExit = flushOnExit;
         this.metricsProvider = metricsProvider;
+        this.timeoutUsed = offerTimeoutMs > 0;
+    }
+
+    public PostOffice.RouteResult addTask(String clientId, String actionDescription, SessionCommand cmd) {
+        final FutureTask<String> task = new FutureTask<>(() -> {
+            cmd.execute();
+            cmd.complete();
+            return cmd.getSessionId();
+        });
+        if (Thread.currentThread() == this) {
+            SessionEventLoop.executeTask(task);
+            return PostOffice.RouteResult.success(clientId, cmd.completableFuture());
+        }
+        if (taskQueue.offer(task)) {
+            metricsProvider.sessionQueueInc(queueId);
+            return PostOffice.RouteResult.success(clientId, cmd.completableFuture());
+        } else {
+            if (timeoutUsed) {
+                LOG.warn("Session command queue {} is full executing action {}, retrying for max {}ms", queueId, actionDescription, offerTimeoutMs);
+                try {
+                    if (taskQueue.offer(task, offerTimeoutMs, TimeUnit.MILLISECONDS)) {
+                        metricsProvider.sessionQueueInc(queueId);
+                        return PostOffice.RouteResult.success(clientId, cmd.completableFuture());
+                    }
+                } catch (InterruptedException ex) {
+                    LOG.warn("Interrupted waiting too queue task");
+                }
+            }
+            LOG.error("Session command queue {} is full executing action {}, queue failed", queueId, actionDescription);
+            metricsProvider.addSessionQueueOverrun(queueId);
+            return PostOffice.RouteResult.failed(clientId);
+        }
     }
 
     @Override

--- a/broker/src/main/java/io/moquette/broker/SessionEventLoopGroup.java
+++ b/broker/src/main/java/io/moquette/broker/SessionEventLoopGroup.java
@@ -16,24 +16,22 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.FutureTask;
 
 class SessionEventLoopGroup {
+
     private static final Logger LOG = LoggerFactory.getLogger(SessionEventLoopGroup.class);
 
     private final SessionEventLoop[] sessionExecutors;
-    private final BlockingQueue<FutureTask<String>>[] sessionQueues;
     private final int eventLoops = Runtime.getRuntime().availableProcessors();
     private final ConcurrentMap<String, Throwable> loopThrownExceptions = new ConcurrentHashMap<>();
-    private final MetricsProvider metricsProvider;
 
     SessionEventLoopGroup(BrokerInterceptor interceptor, int sessionQueueSize, MetricsProvider metricsProvider) {
-        this.metricsProvider = metricsProvider;
-        this.sessionQueues = new BlockingQueue[eventLoops];
+        this(interceptor, sessionQueueSize, 0, metricsProvider);
+    }
+
+    SessionEventLoopGroup(BrokerInterceptor interceptor, int sessionQueueSize, int offerTimeoutMs, MetricsProvider metricsProvider) {
         metricsProvider.initSessionQueues(eventLoops, sessionQueueSize);
-        for (int i = 0; i < eventLoops; i++) {
-            this.sessionQueues[i] = new ArrayBlockingQueue<>(sessionQueueSize);
-        }
         this.sessionExecutors = new SessionEventLoop[eventLoops];
         for (int i = 0; i < eventLoops; i++) {
-            SessionEventLoop newLoop = new SessionEventLoop(this.sessionQueues[i], i, metricsProvider);
+            SessionEventLoop newLoop = new SessionEventLoop(sessionQueueSize, i, offerTimeoutMs, metricsProvider);
             newLoop.setName(sessionLoopName(i));
             newLoop.setUncaughtExceptionHandler((loopThread, ex) -> {
                 // executed in session loop thread
@@ -74,24 +72,8 @@ class SessionEventLoopGroup {
 
         final int targetQueueId = targetQueueOrdinal(cmd.getSessionId());
         LOG.debug("Routing cmd [{}] for session [{}] to event processor {}", actionDescription, cmd.getSessionId(), targetQueueId);
-        final FutureTask<String> task = new FutureTask<>(() -> {
-            cmd.execute();
-            cmd.complete();
-            return cmd.getSessionId();
-        });
-        if (Thread.currentThread() == sessionExecutors[targetQueueId]) {
-            SessionEventLoop.executeTask(task);
-            return PostOffice.RouteResult.success(clientId, cmd.completableFuture());
-        }
-        final BlockingQueue<FutureTask<String>> targetQueue = this.sessionQueues[targetQueueId];
-        if (targetQueue.offer(task)) {
-            metricsProvider.sessionQueueInc(targetQueueId);
-            return PostOffice.RouteResult.success(clientId, cmd.completableFuture());
-        } else {
-            LOG.warn("Session command queue {} is full executing action {}", targetQueueId, actionDescription);
-            metricsProvider.addSessionQueueOverrun(targetQueueId);
-            return PostOffice.RouteResult.failed(clientId);
-        }
+        final SessionEventLoop sessionExecutor = sessionExecutors[targetQueueId];
+        return sessionExecutor.addTask(clientId, actionDescription, cmd);
     }
 
     public void terminate() {

--- a/broker/src/main/java/io/moquette/broker/config/IConfig.java
+++ b/broker/src/main/java/io/moquette/broker/config/IConfig.java
@@ -50,6 +50,7 @@ public abstract class IConfig {
     public static final String ACL_FILE_PROPERTY_NAME = "acl_file";
     public static final String PERSISTENT_CLIENT_EXPIRATION_PROPERTY_NAME = "persistent_client_expiration";
     public static final String SESSION_QUEUE_SIZE = "session_queue_size";
+    public static final String SESSION_QUEUE_OFFER_TIMEOUT_MS = "session_queue_offer_timeout_millis";
     public static final String ENABLE_TELEMETRY_NAME = "telemetry_enabled";
     public static final String RECEIVE_MAXIMUM = "receive_maximum";
     /**


### PR DESCRIPTION
- enhancement

Since failing to add a task to the session queue is usually fatal to the stability and consistency of the broker, instead of directly failing on a full queue, a retry is made with a configurable timeout. Since the thread doing the offer is never the queue worker thread itself, this may give the queue worker thread some time to clear the queue, while at the same time delaying the offering thread, hopefully reducing the load.


- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files (and/or docker env variables)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the Changelog if it's a feature or a fix that has to be reported

Related to #953.