### PR TITLE
Updated Unsubscribe notification mirror subscribe notification

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,7 @@
 Version 0.19-SNAPSHOT
+   [feature] InterceptUnsubscribeMessage now has the entire Subscription and the notification hook has changed
+     from `notifyTopicUnsubscribed(String topic, String clientID, String username)`
+     to `notifyTopicUnsubscribed(Subscription sub, String username)`
    [feature] Added topic rewriting, allowing the internally used topic to be different from the topic the client used. (#932)
      All methods dealing with topic filters are renamed and duplicated into:
      - topicFilterClient: The topic filter as it was set by the client.

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -618,7 +618,7 @@ class PostOffice {
             session.removeSubscription(topic);
 
             String username = NettyUtils.userName(mqttConnection.channel);
-            interceptor.notifyTopicUnsubscribed(topic.toString(), clientID, username);
+            interceptor.notifyTopicUnsubscribed(subscription, username);
         }
 
         // ack the client

--- a/broker/src/main/java/io/moquette/interception/BrokerInterceptor.java
+++ b/broker/src/main/java/io/moquette/interception/BrokerInterceptor.java
@@ -153,7 +153,7 @@ public final class BrokerInterceptor implements Interceptor {
     public void notifyTopicUnsubscribed(final Subscription sub, final String username) {
         for (final InterceptHandler handler : this.handlers.get(InterceptUnsubscribeMessage.class)) {
             LOG.debug("Notifying MQTT UNSUBSCRIBE message to interceptor. CId={}, topic={}, interceptorId={}", sub.getClientId(),
-                sub.getTopicFilter(), handler.getID());
+                sub.getTopicFilterRewritten(), handler.getID());
             executor.execute(() -> handler.onUnsubscribe(new InterceptUnsubscribeMessage(sub, username)));
         }
     }

--- a/broker/src/main/java/io/moquette/interception/BrokerInterceptor.java
+++ b/broker/src/main/java/io/moquette/interception/BrokerInterceptor.java
@@ -150,11 +150,11 @@ public final class BrokerInterceptor implements Interceptor {
     }
 
     @Override
-    public void notifyTopicUnsubscribed(final String topic, final String clientID, final String username) {
+    public void notifyTopicUnsubscribed(final Subscription sub, final String username) {
         for (final InterceptHandler handler : this.handlers.get(InterceptUnsubscribeMessage.class)) {
-            LOG.debug("Notifying MQTT UNSUBSCRIBE message to interceptor. CId={}, topic={}, interceptorId={}", clientID,
-                topic, handler.getID());
-            executor.execute(() -> handler.onUnsubscribe(new InterceptUnsubscribeMessage(topic, clientID, username)));
+            LOG.debug("Notifying MQTT UNSUBSCRIBE message to interceptor. CId={}, topic={}, interceptorId={}", sub.getClientId(),
+                sub.getTopicFilter(), handler.getID());
+            executor.execute(() -> handler.onUnsubscribe(new InterceptUnsubscribeMessage(sub, username)));
         }
     }
 

--- a/broker/src/main/java/io/moquette/interception/Interceptor.java
+++ b/broker/src/main/java/io/moquette/interception/Interceptor.java
@@ -44,7 +44,7 @@ public interface Interceptor {
 
     void notifyTopicSubscribed(Subscription sub, String username);
 
-    void notifyTopicUnsubscribed(String topic, String clientID, String username);
+    void notifyTopicUnsubscribed(Subscription sub, String username);
 
     void notifyMessageAcknowledged(InterceptAcknowledgedMessage msg);
 

--- a/broker/src/main/java/io/moquette/interception/messages/InterceptUnsubscribeMessage.java
+++ b/broker/src/main/java/io/moquette/interception/messages/InterceptUnsubscribeMessage.java
@@ -42,11 +42,11 @@ public class InterceptUnsubscribeMessage implements InterceptMessage {
     }
 
     public String getTopicFilterClient() {
-        return subscription.getTopicFilter().toString();
+        return subscription.getTopicFilterClient().toString();
     }
 
-    public String getTopicFilterInternal() {
-        return subscription.getTopicFilter().toString();
+    public String getTopicFilterRewritten() {
+        return subscription.getTopicFilterRewritten().toString();
     }
 
     public String getUsername() {

--- a/broker/src/main/java/io/moquette/interception/messages/InterceptUnsubscribeMessage.java
+++ b/broker/src/main/java/io/moquette/interception/messages/InterceptUnsubscribeMessage.java
@@ -13,27 +13,40 @@
  *
  * You may elect to redistribute this code under either of these licenses.
  */
-
 package io.moquette.interception.messages;
+
+import io.moquette.broker.subscriptions.Subscription;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import io.netty.handler.codec.mqtt.MqttSubscriptionOption;
 
 public class InterceptUnsubscribeMessage implements InterceptMessage {
 
-    private final String topicFilter;
-    private final String clientID;
+    private final Subscription subscription;
     private final String username;
 
-    public InterceptUnsubscribeMessage(String topicFilter, String clientID, String username) {
-        this.topicFilter = topicFilter;
-        this.clientID = clientID;
+    public InterceptUnsubscribeMessage(Subscription subscription, String username) {
+        this.subscription = subscription;
         this.username = username;
     }
 
-    public String getTopicFilter() {
-        return topicFilter;
+    public String getClientID() {
+        return subscription.getClientId();
     }
 
-    public String getClientID() {
-        return clientID;
+    public MqttQoS getRequestedQos() {
+        return subscription.getOption().qos();
+    }
+
+    public MqttSubscriptionOption getOption() {
+        return subscription.getOption();
+    }
+
+    public String getTopicFilterClient() {
+        return subscription.getTopicFilter().toString();
+    }
+
+    public String getTopicFilterInternal() {
+        return subscription.getTopicFilter().toString();
     }
 
     public String getUsername() {

--- a/broker/src/test/java/io/moquette/interception/BrokerInterceptorTest.java
+++ b/broker/src/test/java/io/moquette/interception/BrokerInterceptorTest.java
@@ -153,7 +153,7 @@ public class BrokerInterceptorTest {
 
     @Test
     public void testNotifyTopicUnsubscribed() throws Exception {
-        interceptor.notifyTopicUnsubscribed("o2", "cli1234", "cli1234");
+        interceptor.notifyTopicUnsubscribed(new Subscription("cli1234", new Topic("o2"), null), "cli1234");
         interval();
         assertEquals(80, n.get());
     }


### PR DESCRIPTION
Currently, the InterceptSubscribeMessage gets the subscription and the username, but the InterceptUnsubscribeMessage only gets topic, clientId and username. Probably because before the subscription cleanup the Subscription was not available at the point where the intercept message was sent.

Since unsubscribe now works on the Subscription, the InterceptUnsubscribeMessage can mirror the Subscribe equivalent, and have the full Subscription instead of just the topic, username and clientID.

- enhancement
