### PR TITLE
Fix/response topic readability

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.19-SNAPSHOT
+   [fix] Fixed wildcard subscriptions returning responses to requests. (#893-4)
    [Cleanup] Moved MQTT-5 response base topic to a constant.
    [fix] Fixed SessionCount metric miscounting when non-clean session are replaced with clean sessions. (#940)
    [Cleanup] Cleaned up subscription handling. (#931)

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.19-SNAPSHOT
+   [Cleanup] Moved MQTT-5 response base topic to a constant.
    [fix] Fixed SessionCount metric miscounting when non-clean session are replaced with clean sessions. (#940)
    [Cleanup] Cleaned up subscription handling. (#931)
    [feature] Added metrics framework and Prometheus implementation.

--- a/broker/src/main/java/io/moquette/BrokerConstants.java
+++ b/broker/src/main/java/io/moquette/BrokerConstants.java
@@ -126,6 +126,8 @@ public final class BrokerConstants {
 
     public static final int DISABLED_TOPIC_ALIAS = 0;
 
+    public static final String RESPONSE_TOPIC_BASE = "reqresp/response/";
+
     private BrokerConstants() {
     }
 }

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -351,7 +351,7 @@ final class MQTTConnection {
             if (isNeedResponseInformation(msg)) {
                 // the responder and requested access to the topic are already configured during session creation
                 // in SessionRegistry
-                connAckPropertiesBuilder.responseInformation("/reqresp/response/" + clientId);
+                connAckPropertiesBuilder.responseInformation(BrokerConstants.RESPONSE_TOPIC_BASE + clientId);
             }
 
             if (receivedQuota.hasLimit()) {

--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -15,6 +15,7 @@
  */
 package io.moquette.broker;
 
+import io.moquette.BrokerConstants;
 import io.moquette.broker.scheduler.Expirable;
 import io.moquette.broker.scheduler.ScheduledExpirationService;
 import io.moquette.broker.subscriptions.ISubscriptionsDirectory;
@@ -57,7 +58,6 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static io.moquette.broker.Utils.messageId;
-import io.moquette.metrics.MetricsManager;
 import io.moquette.metrics.MetricsProvider;
 import static io.netty.handler.codec.mqtt.MqttMessageIdVariableHeader.from;
 import static io.netty.handler.codec.mqtt.MqttQoS.AT_MOST_ONCE;
@@ -774,6 +774,17 @@ class PostOffice {
     private RoutingResults publish2Subscribers(String publisherClientId,
                                                Instant messageExpiry,
                                                MqttPublishMessage msg) {
+        final String topicName = msg.variableHeader().topicName();
+        if (topicName.startsWith(BrokerConstants.RESPONSE_TOPIC_BASE)) {
+            final int startIdx = BrokerConstants.RESPONSE_TOPIC_BASE.length();
+            final Set<String> filter = new HashSet<>(1);
+            int endIdx = topicName.indexOf('/', startIdx);
+            if (endIdx < startIdx) {
+                endIdx = topicName.length();
+            }
+            filter.add(topicName.substring(startIdx, endIdx));
+            return publish2Subscribers(publisherClientId, filter, messageExpiry, msg);
+        }
         return publish2Subscribers(publisherClientId, NO_FILTER, messageExpiry, msg);
     }
 

--- a/broker/src/main/java/io/moquette/broker/SessionRegistry.java
+++ b/broker/src/main/java/io/moquette/broker/SessionRegistry.java
@@ -15,6 +15,7 @@
  */
 package io.moquette.broker;
 
+import io.moquette.BrokerConstants;
 import io.moquette.broker.Session.SessionStatus;
 import io.moquette.broker.scheduler.ScheduledExpirationService;
 import io.moquette.broker.subscriptions.ISubscriptionsDirectory;
@@ -419,8 +420,8 @@ public class SessionRegistry {
         if (MQTTConnection.isNeedResponseInformation(msg)) {
             // the responder client must have write access to this topic
             // the requester client must have read access on this topic
-            authorizator.forceReadAccess(Topic.asTopic("/reqresp/response/" + clientId), clientId);
-            authorizator.forceWriteToAll(Topic.asTopic("/reqresp/response/" + clientId));
+            authorizator.forceReadAccess(Topic.asTopic(BrokerConstants.RESPONSE_TOPIC_BASE + clientId), clientId);
+            authorizator.forceWriteToAll(Topic.asTopic(BrokerConstants.RESPONSE_TOPIC_BASE + clientId));
         }
         return newSession;
     }

--- a/broker/src/test/java/io/moquette/integration/mqtt5/AbstractServerIntegrationWithoutClientFixture.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/AbstractServerIntegrationWithoutClientFixture.java
@@ -30,6 +30,7 @@ import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5PublishResult;
 import com.hivemq.client.mqtt.mqtt5.message.publish.puback.Mqtt5PubAckReasonCode;
 import com.hivemq.client.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAck;
 import com.hivemq.client.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAckReasonCode;
+import io.moquette.BrokerConstants;
 import io.moquette.broker.Server;
 import io.moquette.broker.config.IConfig;
 import io.moquette.broker.config.MemoryConfig;
@@ -141,7 +142,7 @@ public class AbstractServerIntegrationWithoutClientFixture {
         assertEquals(Mqtt5ConnAckReasonCode.SUCCESS, connAck.getReasonCode(), clientId + " connected");
         assertTrue(connAck.getResponseInformation().isPresent(), "ConnACK must contain response topic assigned by the broker");
         String responseTopic = connAck.getResponseInformation().get().toString();
-        assertEquals(responseTopic, "/reqresp/response/" + clientId, "Response topic pattern MUST we respected");
+        assertEquals(responseTopic, BrokerConstants.RESPONSE_TOPIC_BASE + clientId, "Response topic pattern MUST we respected");
         return client;
     }
 

--- a/broker/src/test/java/io/moquette/integration/mqtt5/RequestResponseTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/RequestResponseTest.java
@@ -27,6 +27,7 @@ import com.hivemq.client.mqtt.mqtt5.message.publish.puback.Mqtt5PubAckReasonCode
 import com.hivemq.client.mqtt.mqtt5.message.subscribe.Mqtt5Subscribe;
 import com.hivemq.client.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAck;
 import com.hivemq.client.mqtt.mqtt5.message.subscribe.suback.Mqtt5SubAckReasonCode;
+import io.moquette.BrokerConstants;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
@@ -166,7 +167,7 @@ public class RequestResponseTest extends AbstractServerIntegrationWithoutClientF
     @Test
     public void givenRequestResponseProtocolAndClientIsConnectedWhenRequestIsIssueThenTheResponderReply() throws InterruptedException {
         final Mqtt5BlockingClient requester = createHiveBlockingClientWithResponseProtocol("requester");
-        final String responseTopic = "/reqresp/response/requester";
+        final String responseTopic = BrokerConstants.RESPONSE_TOPIC_BASE + "requester";
         subscribeToResponseTopic(requester, responseTopic);
 
         final Mqtt5BlockingClient responder = createHiveBlockingClient("responder");

--- a/broker/src/test/java/io/moquette/integration/mqtt5/RequestResponseTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/RequestResponseTest.java
@@ -15,7 +15,6 @@
  *  * You may elect to redistribute this code under either of these licenses.
  *
  */
-
 package io.moquette.integration.mqtt5;
 
 import com.hivemq.client.mqtt.MqttGlobalPublishFilter;
@@ -33,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -180,6 +180,40 @@ public class RequestResponseTest extends AbstractServerIntegrationWithoutClientF
                 String payload = new String(msgPub.getPayloadAsBytes(), StandardCharsets.UTF_8);
                 assertEquals("OK", payload);
             });
+        }
+    }
+
+    @Test
+    public void givenRequestResponseProtocolClientTwoCanNotSeeResponseForClientOne() throws InterruptedException {
+        final Mqtt5BlockingClient snooper = createHiveBlockingClientWithResponseProtocol("snooper");
+        subscribeToAtQos1(snooper, "reqresp/#");
+        subscribeToAtQos1(snooper, "reqresp/response/+");
+
+        final Mqtt5BlockingClient requester = createHiveBlockingClientWithResponseProtocol("requester");
+        final String responseTopic = BrokerConstants.RESPONSE_TOPIC_BASE + "requester";
+        subscribeToResponseTopic(requester, responseTopic);
+
+        final Mqtt5BlockingClient responder = createHiveBlockingClient("responder");
+
+        try (Mqtt5BlockingClient.Mqtt5Publishes snooped = snooper.publishes(MqttGlobalPublishFilter.ALL)) {
+            try (Mqtt5BlockingClient.Mqtt5Publishes publishes = requester.publishes(MqttGlobalPublishFilter.ALL)) {
+                // First ensure requester receives the message
+                responderRepliesToRequesterPublish(responder, requester, responseTopic);
+
+                verifyPublishMessage(publishes, msgPub -> {
+                    assertTrue(msgPub.getPayload().isPresent(), "Response payload MUST be present");
+                    String payload = new String(msgPub.getPayloadAsBytes(), StandardCharsets.UTF_8);
+                    assertEquals("OK", payload);
+                });
+            }
+            // Then check if snooper also received any messages.
+            int snoopedCount = 0;
+            Optional<Mqtt5Publish> messageOpt = snooped.receive(1, TimeUnit.SECONDS);
+            while (messageOpt.isPresent()) {
+                snoopedCount++;
+                messageOpt = snooped.receive(1, TimeUnit.SECONDS);
+            }
+            assertEquals(0, snoopedCount, "Snooper should not have received any messages");
         }
     }
 }


### PR DESCRIPTION
- bug

## What does this PR do?

Fixes one of the issues in #893.
When using the MQTT-5 request-response pattern, response are sent to the topics `reqresp/response/<clientid>`. Only the requesting client can set subscriptions on this topic, but everyone can set wild-card subscriptions on higher topics, including the top-level `#` topic.

Possible solutions:
1. Disallow wildcard subscriptions that cover these (including the top-level `#`)
2. Only allow the client with the correct clientId to receive messages sent to topics starting with `reqresp/response/<clientid>`.

This PR implements the more precise second solution in three commits:
1. Move the string `reqresp/response/` to a constant,
2. Add a test demonstrating the problem,
3. Solve the problem.

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have made corresponding change to the default configuration files (and/or docker env variables)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have updated the Changelog if it's a feature or a fix that has to be reported

## Further discussion

Although this solution works, we may actually want to make it more generic, and disallow messages going to certain sub-trees from matching wildcard topics. That would also solve the same problem that exists on the request side of the request-response pattern. The request side is harder to solve, since request topics are not limited to a server-defined subtree, and request topics are likely to have shared subscriptions, meaning we can't do a client-id check to see of a client may receive a message.
