### PR TITLE
Keep the session event loop alive when a command throws (remote DoS)

### DIFF
--- a/broker/src/main/java/io/moquette/broker/SessionEventLoop.java
+++ b/broker/src/main/java/io/moquette/broker/SessionEventLoop.java
@@ -49,11 +49,8 @@ final class SessionEventLoop extends Thread {
                 LOG.info("SessionEventLoop {} interrupted", Thread.currentThread().getName());
                 Thread.currentThread().interrupt();
             } catch (Throwable th) {
-                // A single failing command must never terminate the shared session loop: the FutureTask
-                // has already captured the failure for its submitter. Log and keep serving the other
-                // sessions bound to this loop. Previously the RuntimeException rethrown by executeTask
-                // propagated out of run() and killed the thread, wedging every co-located client (a
-                // malformed packet on one session became a partitioned, broker-wide denial of service).
+                // Keep the shared loop alive on a failing command; the FutureTask already captured the
+                // failure for its submitter, so co-located sessions must not be taken down with it.
                 LOG.error("SessionEventLoop {} caught an unhandled error while processing a command; "
                         + "the loop continues", Thread.currentThread().getName(), th);
             }

--- a/broker/src/main/java/io/moquette/broker/SessionEventLoop.java
+++ b/broker/src/main/java/io/moquette/broker/SessionEventLoop.java
@@ -48,6 +48,14 @@ final class SessionEventLoop extends Thread {
             } catch (InterruptedException e) {
                 LOG.info("SessionEventLoop {} interrupted", Thread.currentThread().getName());
                 Thread.currentThread().interrupt();
+            } catch (Throwable th) {
+                // A single failing command must never terminate the shared session loop: the FutureTask
+                // has already captured the failure for its submitter. Log and keep serving the other
+                // sessions bound to this loop. Previously the RuntimeException rethrown by executeTask
+                // propagated out of run() and killed the thread, wedging every co-located client (a
+                // malformed packet on one session became a partitioned, broker-wide denial of service).
+                LOG.error("SessionEventLoop {} caught an unhandled error while processing a command; "
+                        + "the loop continues", Thread.currentThread().getName(), th);
             }
         }
         LOG.info("SessionEventLoop {} exit", Thread.currentThread().getName());

--- a/broker/src/test/java/io/moquette/broker/SessionEventLoopTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionEventLoopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 The original author or authors
+ * Copyright (c) 2012-2026 The original author or authors
  * ------------------------------------------------------
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -17,24 +17,24 @@
 package io.moquette.broker;
 
 import io.moquette.metrics.MetricsProviderNull;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 class SessionEventLoopTest {
 
     @Test
-    public void aCommandThatThrowsMustNotTerminateTheSharedSessionLoop() throws InterruptedException {
+    public void givenACommandThatThrowsWhenProcessedThenTheSharedSessionLoopKeepsRunning() {
         final BlockingQueue<FutureTask<String>> queue = new LinkedBlockingQueue<>();
-        final SessionEventLoop loop = new SessionEventLoop(queue, 0, new MetricsProviderNull());
-        loop.setDaemon(true);
-        loop.start();
+        final SessionEventLoop sut = new SessionEventLoop(queue, 0, new MetricsProviderNull());
+        sut.setDaemon(true);
+        sut.start();
         try {
             // A command that throws (as a malformed packet's handler could).
             queue.add(new FutureTask<>(() -> {
@@ -42,17 +42,22 @@ class SessionEventLoopTest {
             }));
 
             // A subsequent command bound to the SAME loop must still be executed.
-            final CountDownLatch executed = new CountDownLatch(1);
+            final AtomicBoolean executed = new AtomicBoolean(false);
             queue.add(new FutureTask<>(() -> {
-                executed.countDown();
+                executed.set(true);
                 return "ok";
             }));
 
-            assertTrue(executed.await(5, TimeUnit.SECONDS),
-                "the session loop must keep processing commands after one of them throws");
+            Awaitility.await("the session loop keeps processing commands after one of them throws")
+                .atMost(Duration.ofSeconds(5))
+                .untilTrue(executed);
         } finally {
-            loop.interrupt();
-            loop.join(TimeUnit.SECONDS.toMillis(2));
+            sut.interrupt();
+            try {
+                sut.join(TimeUnit.SECONDS.toMillis(2));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 }

--- a/broker/src/test/java/io/moquette/broker/SessionEventLoopTest.java
+++ b/broker/src/test/java/io/moquette/broker/SessionEventLoopTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2012-2018 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.moquette.broker;
+
+import io.moquette.metrics.MetricsProviderNull;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SessionEventLoopTest {
+
+    @Test
+    public void aCommandThatThrowsMustNotTerminateTheSharedSessionLoop() throws InterruptedException {
+        final BlockingQueue<FutureTask<String>> queue = new LinkedBlockingQueue<>();
+        final SessionEventLoop loop = new SessionEventLoop(queue, 0, new MetricsProviderNull());
+        loop.setDaemon(true);
+        loop.start();
+        try {
+            // A command that throws (as a malformed packet's handler could).
+            queue.add(new FutureTask<>(() -> {
+                throw new RuntimeException("boom");
+            }));
+
+            // A subsequent command bound to the SAME loop must still be executed.
+            final CountDownLatch executed = new CountDownLatch(1);
+            queue.add(new FutureTask<>(() -> {
+                executed.countDown();
+                return "ok";
+            }));
+
+            assertTrue(executed.await(5, TimeUnit.SECONDS),
+                "the session loop must keep processing commands after one of them throws");
+        } finally {
+            loop.interrupt();
+            loop.join(TimeUnit.SECONDS.toMillis(2));
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?
Makes `SessionEventLoop.run()` catch `Throwable` per command and continue, instead of letting the `RuntimeException` rethrown by `executeTask()` propagate out of `run()` and terminate the thread.

## Why is it important?
Each session loop is shared by all client ids that hash to its ordinal (`abs(clientId.hashCode()) % availableProcessors`). Today a single command that throws (e.g. an uncaught exception while handling a malformed packet) kills the whole loop and it is never restarted, so every other client bound to that loop can no longer have its PUBLISH/SUBSCRIBE/PUBACK/... commands processed. An attacker can spread client ids across all loops and take down session processing for the entire broker. The `FutureTask` already captures the failure for its submitter, so the shared loop should not die with it.

This is the structural containment for a whole class of per-command crashes (malformed `$share` filter, deeply nested topic, null-field NPEs), mirroring the containment `NewNettyMQTTHandler.channelRead` already applies on the Netty thread (close only the offending channel).

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective (`SessionEventLoopTest`)

## How to test this PR locally
`mvn -pl broker -Dtest=SessionEventLoopTest test` - the test submits a throwing command then a normal one and asserts the loop still executes the latter.

Reported privately via the repository Security Advisory; opening this DoS-hardening fix as a public PR per the maintainer. cc @andsel