### PR TITLE
Reject a malformed $share subscription before parsing it (remote DoS)

### DIFF
--- a/broker/src/main/java/io/moquette/broker/PostOffice.java
+++ b/broker/src/main/java/io/moquette/broker/PostOffice.java
@@ -389,21 +389,26 @@ class PostOffice {
                 return;
             }
 
+            // Validate the shared-subscription format BEFORE parsing it. A filter such as "$share/grp"
+            // (a share name with no "/{topicFilter}" part) would make extractShareName() evaluate
+            // substring(7, -1) and throw StringIndexOutOfBoundsException while building the subscription.
+            // MQTT-4.13.1-1 / MQTT-4.8.2: disconnect on a malformed shared subscription instead.
+            Optional<MqttTopicSubscription> invalidSharedSubscription = ackingSubsriptions.stream()
+                .filter(PostOffice::isNoFailure)
+                .filter(SharedSubscriptionUtils::isSharedSubscription)
+                .filter(s -> !SharedSubscriptionUtils.isValidSharedSubscription(s.topicFilter()))
+                .findFirst();
+            if (invalidSharedSubscription.isPresent()) {
+                LOG.info("{} used a malformed shared subscription {}, disconnecting", clientID, invalidSharedSubscription.get().topicFilter());
+                session.disconnectFromBroker();
+                return;
+            }
+
             List<Subscription> sharedSubscriptions = ackingSubsriptions.stream()
                 .filter(PostOffice::isNoFailure)
                 .filter(SharedSubscriptionUtils::isSharedSubscription)
                 .map(s -> buildSharedSubscriptionFrom(s, clientID, subscriptionIdOpt))
                 .collect(Collectors.toList());
-
-            Optional<Subscription> invalidSharedSubscription = sharedSubscriptions.stream()
-                .filter(sub -> !SharedSubscriptionUtils.validateShareName(sub.getShareName().getShareName()))
-                .findFirst();
-            if (invalidSharedSubscription.isPresent()) {
-                // this is a malformed packet, MQTT-4.13.1-1, disconnect it
-                LOG.info("{} used an invalid shared subscription name {}, disconnecting", clientID, invalidSharedSubscription.get().getShareName());
-                session.disconnectFromBroker();
-                return;
-            }
             for (Subscription sub : sharedSubscriptions) {
                 subscriptions.addShared(sub);
                 session.addSubscription(sub);

--- a/broker/src/main/java/io/moquette/broker/SharedSubscriptionUtils.java
+++ b/broker/src/main/java/io/moquette/broker/SharedSubscriptionUtils.java
@@ -67,4 +67,31 @@ class SharedSubscriptionUtils {
         Objects.requireNonNull(shareName);
         return shareName.length() > 0 && !shareName.contains("+") && !shareName.contains("#");
     }
+
+    /**
+     * Validate the WHOLE shared-subscription filter ($share/{shareName}/{topicFilter}) before it is
+     * parsed. A filter such as "$share/grp" (a share name with no "/{topicFilter}" part) has no '/'
+     * after the share name, which would make {@link #extractShareName(String)} evaluate
+     * substring(7, -1) and throw. Returns true only when the share name and the topic-filter part are
+     * both present and the share name is well-formed.
+     *
+     * @return true if topicFilter is a well-formed shared subscription
+     * */
+    protected static boolean isValidSharedSubscription(String topicFilter) {
+        Objects.requireNonNull(topicFilter, "topicFilter can't be null");
+        if (!isSharedSubscription(topicFilter)) {
+            return false;
+        }
+        final int afterShare = "$share/".length();
+        final int endOfShareName = topicFilter.indexOf('/', afterShare);
+        if (endOfShareName < 0) {
+            // no "/{topicFilter}" part after the share name
+            return false;
+        }
+        if (!validateShareName(topicFilter.substring(afterShare, endOfShareName))) {
+            return false;
+        }
+        // the topic-filter part must be present (non-empty)
+        return endOfShareName + 1 < topicFilter.length();
+    }
 }

--- a/broker/src/test/java/io/moquette/broker/SharedSubscriptionUtilsTest.java
+++ b/broker/src/test/java/io/moquette/broker/SharedSubscriptionUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 The original author or authors
+ * Copyright (c) 2012-2026 The original author or authors
  * ------------------------------------------------------
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -24,14 +24,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class SharedSubscriptionUtilsTest {
 
     @Test
-    public void wellFormedSharedSubscriptionIsValid() {
+    public void givenWellFormedSharedSubscriptionWhenValidatedThenGetPositiveAnswer() {
         assertTrue(SharedSubscriptionUtils.isValidSharedSubscription("$share/grp/sensors/#"));
         assertTrue(SharedSubscriptionUtils.isValidSharedSubscription("$share/grp/a/b"));
         assertTrue(SharedSubscriptionUtils.isValidSharedSubscription("$share/grp/+"));
     }
 
     @Test
-    public void aShareNameWithNoTopicFilterPartIsRejected() {
+    public void givenSharedSubscriptionWithNoTopicFilterPartWhenValidatedThenIsRejected() {
         // "$share/grp" has no "/{topicFilter}" part: extractShareName() would have evaluated
         // substring(7, -1) and thrown StringIndexOutOfBoundsException while building the subscription.
         assertFalse(SharedSubscriptionUtils.isValidSharedSubscription("$share/grp"));
@@ -39,14 +39,14 @@ class SharedSubscriptionUtilsTest {
     }
 
     @Test
-    public void anEmptyOrWildcardShareNameIsRejected() {
+    public void givenSharedSubscriptionWithEmptyOrWildcardShareNameWhenValidatedThenIsRejected() {
         assertFalse(SharedSubscriptionUtils.isValidSharedSubscription("$share//sensors"));
         assertFalse(SharedSubscriptionUtils.isValidSharedSubscription("$share/gr+p/sensors"));
         assertFalse(SharedSubscriptionUtils.isValidSharedSubscription("$share/gr#p/sensors"));
     }
 
     @Test
-    public void aNonSharedFilterIsNotAValidSharedSubscription() {
+    public void givenNonSharedFilterWhenValidatedThenIsNotAValidSharedSubscription() {
         assertFalse(SharedSubscriptionUtils.isValidSharedSubscription("sensors/#"));
     }
 }

--- a/broker/src/test/java/io/moquette/broker/SharedSubscriptionUtilsTest.java
+++ b/broker/src/test/java/io/moquette/broker/SharedSubscriptionUtilsTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2012-2023 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.moquette.broker;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SharedSubscriptionUtilsTest {
+
+    @Test
+    public void wellFormedSharedSubscriptionIsValid() {
+        assertTrue(SharedSubscriptionUtils.isValidSharedSubscription("$share/grp/sensors/#"));
+        assertTrue(SharedSubscriptionUtils.isValidSharedSubscription("$share/grp/a/b"));
+        assertTrue(SharedSubscriptionUtils.isValidSharedSubscription("$share/grp/+"));
+    }
+
+    @Test
+    public void aShareNameWithNoTopicFilterPartIsRejected() {
+        // "$share/grp" has no "/{topicFilter}" part: extractShareName() would have evaluated
+        // substring(7, -1) and thrown StringIndexOutOfBoundsException while building the subscription.
+        assertFalse(SharedSubscriptionUtils.isValidSharedSubscription("$share/grp"));
+        assertFalse(SharedSubscriptionUtils.isValidSharedSubscription("$share/grp/"));
+    }
+
+    @Test
+    public void anEmptyOrWildcardShareNameIsRejected() {
+        assertFalse(SharedSubscriptionUtils.isValidSharedSubscription("$share//sensors"));
+        assertFalse(SharedSubscriptionUtils.isValidSharedSubscription("$share/gr+p/sensors"));
+        assertFalse(SharedSubscriptionUtils.isValidSharedSubscription("$share/gr#p/sensors"));
+    }
+
+    @Test
+    public void aNonSharedFilterIsNotAValidSharedSubscription() {
+        assertFalse(SharedSubscriptionUtils.isValidSharedSubscription("sensors/#"));
+    }
+}

--- a/broker/src/test/java/io/moquette/integration/mqtt5/SharedSubscriptionTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/SharedSubscriptionTest.java
@@ -53,6 +53,20 @@ public class SharedSubscriptionTest extends AbstractSubscriptionIntegrationTest 
     }
 
     @Test
+    public void givenAClientSendingSharedSubscriptionWithNoTopicFilterPartThenItIsDisconnectedInsteadOfCrashing() throws InterruptedException {
+        // "$share/grp" has a share name but no "/{topicFilter}" part. Before the fix this reached
+        // extractShareName() -> substring(7, -1) and threw StringIndexOutOfBoundsException inside the
+        // session event loop; the broker must instead reject it as a malformed packet.
+        connectLowLevel();
+
+        MqttMessage received = lowLevelClient.subscribeWithError("$share/grp", MqttQoS.AT_LEAST_ONCE);
+
+        verifyOfType(received, MqttMessageType.DISCONNECT);
+        MqttReasonCodeAndPropertiesVariableHeader disconnectHeader = (MqttReasonCodeAndPropertiesVariableHeader) received.variableHeader();
+        assertEquals(MqttReasonCodes.Disconnect.MALFORMED_PACKET.byteValue(), disconnectHeader.reasonCode());
+    }
+
+    @Test
     public void givenClientSubscribingToSharedTopicThenReceiveTheExpectedSubscriptionACK() throws InterruptedException {
         connectLowLevel();
 

--- a/broker/src/test/java/io/moquette/integration/mqtt5/SharedSubscriptionTest.java
+++ b/broker/src/test/java/io/moquette/integration/mqtt5/SharedSubscriptionTest.java
@@ -53,10 +53,7 @@ public class SharedSubscriptionTest extends AbstractSubscriptionIntegrationTest 
     }
 
     @Test
-    public void givenAClientSendingSharedSubscriptionWithNoTopicFilterPartThenItIsDisconnectedInsteadOfCrashing() throws InterruptedException {
-        // "$share/grp" has a share name but no "/{topicFilter}" part. Before the fix this reached
-        // extractShareName() -> substring(7, -1) and threw StringIndexOutOfBoundsException inside the
-        // session event loop; the broker must instead reject it as a malformed packet.
+    public void givenClientSendingSharedSubscriptionWithNoTopicFilterPartThenItIsDisconnectedInsteadOfCrashing() throws InterruptedException {
         connectLowLevel();
 
         MqttMessage received = lowLevelClient.subscribeWithError("$share/grp", MqttQoS.AT_LEAST_ONCE);


### PR DESCRIPTION
## What does this PR do?
Validates a shared-subscription filter `$share/{shareName}/{topicFilter}` up front in `PostOffice.subscribe()` and disconnects the client (MQTT-4.13.1-1) if it is malformed, instead of throwing while parsing it. Adds `SharedSubscriptionUtils.isValidSharedSubscription(topicFilter)` and a unit test.

## Why is it important?
A filter of the form `$share/grp` (a share name with no `/{topicFilter}` part) has no `/` after the share name, so `SharedSubscriptionUtils.extractShareName()` evaluated `substring(7, -1)` and threw `StringIndexOutOfBoundsException`. That parsing runs inside the `buildSharedSubscriptionFrom` `map()` in `subscribe()` - BEFORE the existing share-name validation - so a single crafted SUBSCRIBE crashed the command handling on the shared session event loop.

(#957 makes that loop resilient to such throws in general; this PR removes the specific illegal input at the source and returns the correct protocol behavior.)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective (`SharedSubscriptionUtilsTest`)

## How to test this PR locally
`mvn -pl broker -Dtest=SharedSubscriptionUtilsTest test`. (The existing `SharedSubscriptionTest` integration tests still pass on Linux CI; on Windows they report an unrelated pre-existing `@TempDir` cleanup error on the mmap-ed H2 store.)

Reported privately via the repository Security Advisory; opening this DoS-hardening fix as a public PR per the maintainer. cc @andsel