### PR TITLE
Guard the periodic expiration task so one failing entity can't disable all expirations

### DIFF
--- a/broker/src/main/java/io/moquette/broker/scheduler/ScheduledExpirationService.java
+++ b/broker/src/main/java/io/moquette/broker/scheduler/ScheduledExpirationService.java
@@ -38,14 +38,26 @@ public class ScheduledExpirationService<T extends Expirable> {
             TimeUnit.SECONDS);
     }
 
-    private void checkExpiredEntities() {
-        List<ExpirableTracker<T>> expiredEntities = new ArrayList<>();
-        int drainedEntities = expiringEntities.drainTo(expiredEntities);
-        LOG.debug("Retrieved {} expired entity on {}", drainedEntities, expiringEntities.size());
+    // Package-private for testing. Runs from scheduleWithFixedDelay: if an exception escapes, the
+    // executor silently stops rescheduling and NO further expirations ever fire again. Never let one
+    // throw out, and never let one failing entity skip the rest of the batch.
+    void checkExpiredEntities() {
+        try {
+            List<ExpirableTracker<T>> expiredEntities = new ArrayList<>();
+            int drainedEntities = expiringEntities.drainTo(expiredEntities);
+            LOG.debug("Retrieved {} expired entity on {}", drainedEntities, expiringEntities.size());
 
-        expiredEntities.stream()
-            .map(ExpirableTracker::expirable)
-            .forEach(action);
+            for (ExpirableTracker<T> tracker : expiredEntities) {
+                try {
+                    action.accept(tracker.expirable());
+                } catch (Throwable th) {
+                    LOG.warn("Expiration action failed for an entity; continuing with the remaining ones", th);
+                }
+            }
+        } catch (Throwable th) {
+            // Guarantee the periodic firer keeps running regardless.
+            LOG.error("Unexpected error while checking expired entities; the periodic task continues", th);
+        }
     }
 
     public void track(String entityId, T entity) {

--- a/broker/src/main/java/io/moquette/broker/scheduler/ScheduledExpirationService.java
+++ b/broker/src/main/java/io/moquette/broker/scheduler/ScheduledExpirationService.java
@@ -31,7 +31,7 @@ public class ScheduledExpirationService<T extends Expirable> {
 
     public ScheduledExpirationService(Clock clock, Consumer<T> action) {
         this.clock = clock;
-        this.action = guarded(action);
+        this.action = exceptionSafeWrapper(action);
         this.actionsExecutor = Executors.newSingleThreadScheduledExecutor();
         this.expiredEntityTask = actionsExecutor.scheduleWithFixedDelay(this::checkExpiredEntities,
             FIRER_TASK_INTERVAL.getSeconds(), FIRER_TASK_INTERVAL.getSeconds(),
@@ -41,7 +41,7 @@ public class ScheduledExpirationService<T extends Expirable> {
     // The action runs from a scheduleWithFixedDelay task: if it throws, the executor silently stops
     // rescheduling and no further expirations ever fire. Decorate it so a failing entity is logged and
     // the batch continues, instead of letting the exception escape into the scheduler.
-    private Consumer<T> guarded(Consumer<T> delegate) {
+    private Consumer<T> exceptionSafeWrapper(Consumer<T> delegate) {
         return entity -> {
             try {
                 delegate.accept(entity);
@@ -57,9 +57,9 @@ public class ScheduledExpirationService<T extends Expirable> {
         int drainedEntities = expiringEntities.drainTo(expiredEntities);
         LOG.debug("Retrieved {} expired entity on {}", drainedEntities, expiringEntities.size());
 
-        for (ExpirableTracker<T> tracker : expiredEntities) {
-            action.accept(tracker.expirable());
-        }
+        expiredEntities.stream()
+            .map(ExpirableTracker::expirable)
+            .forEach(action);
     }
 
     public void track(String entityId, T entity) {

--- a/broker/src/main/java/io/moquette/broker/scheduler/ScheduledExpirationService.java
+++ b/broker/src/main/java/io/moquette/broker/scheduler/ScheduledExpirationService.java
@@ -31,32 +31,34 @@ public class ScheduledExpirationService<T extends Expirable> {
 
     public ScheduledExpirationService(Clock clock, Consumer<T> action) {
         this.clock = clock;
-        this.action = action;
+        this.action = guarded(action);
         this.actionsExecutor = Executors.newSingleThreadScheduledExecutor();
         this.expiredEntityTask = actionsExecutor.scheduleWithFixedDelay(this::checkExpiredEntities,
             FIRER_TASK_INTERVAL.getSeconds(), FIRER_TASK_INTERVAL.getSeconds(),
             TimeUnit.SECONDS);
     }
 
-    // Package-private for testing. Runs from scheduleWithFixedDelay: if an exception escapes, the
-    // executor silently stops rescheduling and NO further expirations ever fire again. Never let one
-    // throw out, and never let one failing entity skip the rest of the batch.
-    void checkExpiredEntities() {
-        try {
-            List<ExpirableTracker<T>> expiredEntities = new ArrayList<>();
-            int drainedEntities = expiringEntities.drainTo(expiredEntities);
-            LOG.debug("Retrieved {} expired entity on {}", drainedEntities, expiringEntities.size());
-
-            for (ExpirableTracker<T> tracker : expiredEntities) {
-                try {
-                    action.accept(tracker.expirable());
-                } catch (Throwable th) {
-                    LOG.warn("Expiration action failed for an entity; continuing with the remaining ones", th);
-                }
+    // The action runs from a scheduleWithFixedDelay task: if it throws, the executor silently stops
+    // rescheduling and no further expirations ever fire. Decorate it so a failing entity is logged and
+    // the batch continues, instead of letting the exception escape into the scheduler.
+    private Consumer<T> guarded(Consumer<T> delegate) {
+        return entity -> {
+            try {
+                delegate.accept(entity);
+            } catch (Throwable th) {
+                LOG.warn("Expiration action failed for an entity; continuing with the remaining ones", th);
             }
-        } catch (Throwable th) {
-            // Guarantee the periodic firer keeps running regardless.
-            LOG.error("Unexpected error while checking expired entities; the periodic task continues", th);
+        };
+    }
+
+    // Package-private so the test can trigger one cycle directly.
+    void checkExpiredEntities() {
+        List<ExpirableTracker<T>> expiredEntities = new ArrayList<>();
+        int drainedEntities = expiringEntities.drainTo(expiredEntities);
+        LOG.debug("Retrieved {} expired entity on {}", drainedEntities, expiringEntities.size());
+
+        for (ExpirableTracker<T> tracker : expiredEntities) {
+            action.accept(tracker.expirable());
         }
     }
 

--- a/broker/src/test/java/io/moquette/broker/scheduler/ScheduledExpirationServiceTest.java
+++ b/broker/src/test/java/io/moquette/broker/scheduler/ScheduledExpirationServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2023 The original author or authors
+ * Copyright (c) 2012-2026 The original author or authors
  * ------------------------------------------------------
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/src/test/java/io/moquette/broker/scheduler/ScheduledExpirationServiceTest.java
+++ b/broker/src/test/java/io/moquette/broker/scheduler/ScheduledExpirationServiceTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2012-2023 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.moquette.broker.scheduler;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ScheduledExpirationServiceTest {
+
+    private static final class Entity implements Expirable {
+        private final String id;
+        private final Instant expireAt;
+
+        private Entity(String id, Instant expireAt) {
+            this.id = id;
+            this.expireAt = expireAt;
+        }
+
+        @Override
+        public Optional<Instant> expireAt() {
+            return Optional.of(expireAt);
+        }
+    }
+
+    @Test
+    public void aThrowingExpirationActionMustNotStopThePeriodicService() {
+        final Clock clock = Clock.fixed(Instant.ofEpochMilli(10_000), ZoneOffset.UTC);
+        final Set<String> processed = new HashSet<>();
+        final Consumer<Entity> action = e -> {
+            if ("boom".equals(e.id)) {
+                throw new RuntimeException("boom");
+            }
+            processed.add(e.id);
+        };
+
+        final ScheduledExpirationService<Entity> service = new ScheduledExpirationService<>(clock, action);
+        try {
+            final Instant alreadyExpired = Instant.ofEpochMilli(9_000); // < clock -> ready to be drained
+            service.track("boom", new Entity("boom", alreadyExpired));
+            service.track("good", new Entity("good", alreadyExpired));
+
+            // Running the periodic check must not propagate the action's exception (which would make
+            // scheduleWithFixedDelay stop firing forever)...
+            assertDoesNotThrow(service::checkExpiredEntities);
+            // ...and the non-throwing entity must still have been processed in the same batch.
+            assertTrue(processed.contains("good"),
+                "a failing expiration action must not skip the other expired entities");
+        } finally {
+            service.shutdown();
+        }
+    }
+}

--- a/broker/src/test/java/io/moquette/broker/scheduler/ScheduledExpirationServiceTest.java
+++ b/broker/src/test/java/io/moquette/broker/scheduler/ScheduledExpirationServiceTest.java
@@ -26,8 +26,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ScheduledExpirationServiceTest {
 
@@ -47,7 +47,7 @@ class ScheduledExpirationServiceTest {
     }
 
     @Test
-    public void aThrowingExpirationActionMustNotStopThePeriodicService() {
+    public void givenAnActionThatThrowsAnErrorWhenExecutedThenDoesntStopExecutingNextScheduledActions() {
         final Clock clock = Clock.fixed(Instant.ofEpochMilli(10_000), ZoneOffset.UTC);
         final Set<String> processed = new HashSet<>();
         final Consumer<Entity> action = e -> {
@@ -59,16 +59,12 @@ class ScheduledExpirationServiceTest {
 
         final ScheduledExpirationService<Entity> service = new ScheduledExpirationService<>(clock, action);
         try {
-            final Instant alreadyExpired = Instant.ofEpochMilli(9_000); // < clock -> ready to be drained
+            final Instant alreadyExpired = Instant.ofEpochMilli(9_000);
             service.track("boom", new Entity("boom", alreadyExpired));
             service.track("good", new Entity("good", alreadyExpired));
 
-            // Running the periodic check must not propagate the action's exception (which would make
-            // scheduleWithFixedDelay stop firing forever)...
             assertDoesNotThrow(service::checkExpiredEntities);
-            // ...and the non-throwing entity must still have been processed in the same batch.
-            assertTrue(processed.contains("good"),
-                "a failing expiration action must not skip the other expired entities");
+            assertThat(processed).contains("good");
         } finally {
             service.shutdown();
         }


### PR DESCRIPTION
## What does this PR do?
Wraps `ScheduledExpirationService.checkExpiredEntities()` so an exception from the expiration action can never escape the periodic task, and iterates the drained entities one by one so a single failing action does not skip the rest of the batch. Adds a test.

## Why is it important?
The task is scheduled with `scheduleWithFixedDelay`. Per its contract, if a run throws, the executor stops rescheduling it - permanently. So a single throwing expiration action silently disables ALL future expirations: delayed Wills never fire, retained messages and sessions never expire, and that state accumulates without bound until the broker restarts. Three services share this pattern (Will/retained expiry, session expiry, and the check loop).

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective (`ScheduledExpirationServiceTest`)

## How to test this PR locally
`mvn -pl broker -Dtest=ScheduledExpirationServiceTest test` - tracks two already-expired entities whose action throws for one of them, runs the check, and asserts it does not throw and still processes the other.

Reported privately via the repository Security Advisory; opening this hardening fix as a public PR per the maintainer. cc @andsel