### PR TITLE
Guard pattern ACL substitution against a null username (remote DoS)

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.19-SNAPSHOT
+   [fix] Guarded pattern ACL substitution against a null username to prevent a remote DoS. (#963)
    [feature] InterceptUnsubscribeMessage now has the entire Subscription and the notification hook has changed
      from `notifyTopicUnsubscribed(String topic, String clientID, String username)`
      to `notifyTopicUnsubscribed(Subscription sub, String username)`

--- a/broker/src/main/java/io/moquette/broker/security/AuthorizationsCollector.java
+++ b/broker/src/main/java/io/moquette/broker/security/AuthorizationsCollector.java
@@ -134,8 +134,13 @@ class AuthorizationsCollector implements IAuthorizatorPolicy {
                     "wildcards ('+' or '#') and can't be safely substituted into a pattern filter " +
                     "(client: {}, username: {})", client, username);
             } else {
+                // A missing identity (an anonymous client has a null username) must not reach
+                // String.replace(), which NPEs on a null replacement; treat it as empty so the
+                // substituted filter simply does not match.
+                final String clientValue = client == null ? "" : client;
+                final String usernameValue = username == null ? "" : username;
                 for (Authorization auth : m_patternAuthorizations) {
-                    Topic substitutedTopic = new Topic(auth.topic.toString().replace("%c", client).replace("%u", username));
+                    Topic substitutedTopic = new Topic(auth.topic.toString().replace("%c", clientValue).replace("%u", usernameValue));
                     if (auth.grant(permission)) {
                         if (topic.match(substitutedTopic)) {
                             return true;

--- a/broker/src/test/java/io/moquette/broker/security/AuthorizationsCollectorTest.java
+++ b/broker/src/test/java/io/moquette/broker/security/AuthorizationsCollectorTest.java
@@ -188,4 +188,18 @@ public class AuthorizationsCollectorTest {
         assertDoesNotThrow(() -> authorizator.canRead(new Topic("/weather/italy/victim/inner"), "", "#"));
         assertFalse(authorizator.canRead(new Topic("/weather/italy/victim/inner"), "", "#"));
     }
+
+    @Test
+    public void givenPatternACLWhenUsernameIsNullThenSubstitutesSafelyWithoutThrowing() throws ParseException {
+        // An anonymous client presents a null username; substituting it into a pattern rule
+        // previously reached String.replace() with a null, which NPEd and killed the session loop.
+        authorizator.parse("pattern read /weather/italy/%c");
+        authorizator.parse("pattern read /weather/%u/data");
+
+        // A %c rule still grants for a null-username client (matched on the client id).
+        assertTrue(authorizator.canRead(new Topic("/weather/italy/anemometer1"), null, "anemometer1"));
+        // A %u rule cannot match a null username, but must fail closed instead of throwing.
+        assertDoesNotThrow(() -> authorizator.canRead(new Topic("/weather/rome/data"), null, "anemometer1"));
+        assertFalse(authorizator.canRead(new Topic("/weather/rome/data"), null, "anemometer1"));
+    }
 }


### PR DESCRIPTION
## What does this PR do?
Makes the pattern-ACL branch of `AuthorizationsCollector.canDoOperation()` treat a missing (`null`) client id / username as an empty string before substituting it into the rule, instead of passing `null` into `String.replace()`.

## Why is it important?
An anonymous client has a `null` username (`login()` returns `true` without calling `NettyUtils.userName`). When a `pattern` ACL rule is configured, the first authorization check substitutes the identity into the rule via `auth.topic.toString().replace("%c", client).replace("%u", username)`. `String.replace(CharSequence, CharSequence)` calls `replacement.toString()` eagerly, so a `null` username throws `NullPointerException` regardless of whether `%u` appears in the rule. That check runs on the session event loop, so the unchecked exception kills the worker thread and every co-located session stops being served (the same broker-wide DoS amplifier as #957). Substituting an empty string fails closed: a `%u` rule simply does not match an anonymous client, while `%c` rules keep working.

(The sibling wildcard-in-identity case is already handled by the `hasTopicWildcard` guard; this PR closes the remaining `null`-identity path.)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective (`AuthorizationsCollectorTest#givenPatternACLWhenUsernameIsNullThenSubstitutesSafelyWithoutThrowing`)

## How to test this PR locally
`mvn -pl broker -Dtest=AuthorizationsCollectorTest test`

Reported privately via the repository Security Advisory; opening this DoS-hardening fix as a public PR per the maintainer. cc @andsel
