### PR TITLE
Namespace the H2 queue metadata map to prevent a client-id collision (durable corruption)

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.19-SNAPSHOT
+   [fix] Namespaced the H2 queue metadata map to prevent a client-id collision that could corrupt a durable queue. (#964)
    [fix] Check Last Will topic for writability rights before publish.
    [fix] Reject a malformed $share subscription before parsing it (remote DoS). (#958)
    [fix] Keep the session event loop alive when a command throws (remote DoS). (#957)

--- a/broker/src/main/java/io/moquette/persistence/H2PersistentQueue.java
+++ b/broker/src/main/java/io/moquette/persistence/H2PersistentQueue.java
@@ -25,6 +25,15 @@ import java.util.concurrent.atomic.AtomicLong;
 
 class H2PersistentQueue extends AbstractSessionMessageQueue<SessionRegistry.EnqueuedMessage> {
 
+    // The message map and the metadata map must live in disjoint name spaces. The queue name is a raw
+    // client id, so deriving both names from a shared "queue_" prefix let a client id ending in "_meta"
+    // make its message map ("queue_" + "victim_meta") collide with another client's metadata map
+    // ("queue_" + "victim" + "_meta") -> durable cross-session corruption. The metadata prefix now differs
+    // from the message prefix at a fixed position, so no queue name can make the two names collide.
+    private static final String MESSAGES_MAP_PREFIX = "queue_";
+    private static final String METADATA_MAP_PREFIX = "queuemeta_";
+    private static final String LEGACY_METADATA_MAP_SUFFIX = "_meta";
+
     private final MVMap<Long, SessionRegistry.EnqueuedMessage> queueMap;
     private final MVMap<String, Long> metadataMap;
     private final AtomicLong head;
@@ -42,8 +51,9 @@ class H2PersistentQueue extends AbstractSessionMessageQueue<SessionRegistry.Enqu
 
         this.store = store;
         this.queueName = queueName;
-        this.queueMap = this.store.openMap("queue_" + this.queueName, messageTypeBuilder);
-        this.metadataMap = store.openMap("queue_" + queueName + "_meta");
+        this.queueMap = this.store.openMap(MESSAGES_MAP_PREFIX + this.queueName, messageTypeBuilder);
+        this.metadataMap = store.openMap(METADATA_MAP_PREFIX + queueName);
+        migrateLegacyMetadata(store, queueName, this.metadataMap);
 
         //setup head index
         long headIdx = 0L;
@@ -98,8 +108,30 @@ class H2PersistentQueue extends AbstractSessionMessageQueue<SessionRegistry.Enqu
     }
 
     private void dropQueue(String queueName) {
-        store.removeMap(store.openMap("queue_" + queueName));
-        store.removeMap(store.openMap("queue_" + queueName + "_meta"));
+        store.removeMap(store.openMap(MESSAGES_MAP_PREFIX + queueName));
+        store.removeMap(store.openMap(METADATA_MAP_PREFIX + queueName));
+        final String legacyMetadata = MESSAGES_MAP_PREFIX + queueName + LEGACY_METADATA_MAP_SUFFIX;
+        if (store.hasMap(legacyMetadata)) {
+            store.removeMap(store.openMap(legacyMetadata));
+        }
+    }
+
+    // Stores written before the rename kept the head/tail under MESSAGES_MAP_PREFIX + queueName + "_meta".
+    // Move them into the new, collision-free map once and drop the legacy one, so a client id ending in
+    // "_meta" can no longer reopen it as its own message map.
+    private static void migrateLegacyMetadata(MVStore store, String queueName, MVMap<String, Long> metadataMap) {
+        final String legacyName = MESSAGES_MAP_PREFIX + queueName + LEGACY_METADATA_MAP_SUFFIX;
+        if (!metadataMap.isEmpty() || !store.hasMap(legacyName)) {
+            return;
+        }
+        final MVMap<String, Long> legacy = store.openMap(legacyName);
+        if (legacy.containsKey("head")) {
+            metadataMap.put("head", legacy.get("head"));
+        }
+        if (legacy.containsKey("tail")) {
+            metadataMap.put("tail", legacy.get("tail"));
+        }
+        store.removeMap(legacy);
     }
 
 }

--- a/broker/src/main/java/io/moquette/persistence/H2PersistentQueue.java
+++ b/broker/src/main/java/io/moquette/persistence/H2PersistentQueue.java
@@ -121,16 +121,20 @@ class H2PersistentQueue extends AbstractSessionMessageQueue<SessionRegistry.Enqu
     // "_meta" can no longer reopen it as its own message map.
     private static void migrateLegacyMetadata(MVStore store, String queueName, MVMap<String, Long> metadataMap) {
         final String legacyName = MESSAGES_MAP_PREFIX + queueName + LEGACY_METADATA_MAP_SUFFIX;
-        if (!metadataMap.isEmpty() || !store.hasMap(legacyName)) {
+        if (!store.hasMap(legacyName)) {
             return;
         }
+
         final MVMap<String, Long> legacy = store.openMap(legacyName);
-        if (legacy.containsKey("head")) {
+
+        // Copy only if missing to keep the migration idempotent across restarts.
+        if (!metadataMap.containsKey("head") && legacy.containsKey("head")) {
             metadataMap.put("head", legacy.get("head"));
         }
-        if (legacy.containsKey("tail")) {
+        if (!metadataMap.containsKey("tail") && legacy.containsKey("tail")) {
             metadataMap.put("tail", legacy.get("tail"));
         }
+
         store.removeMap(legacy);
     }
 

--- a/broker/src/test/java/io/moquette/persistence/H2PersistentQueueTest.java
+++ b/broker/src/test/java/io/moquette/persistence/H2PersistentQueueTest.java
@@ -21,6 +21,7 @@ import io.moquette.broker.subscriptions.Topic;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.handler.codec.mqtt.MqttQoS;
+import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -99,5 +100,43 @@ public class H2PersistentQueueTest extends H2BaseTest {
         assertEquals("crazy", ((SessionRegistry.PublishedMessage) after.dequeue()).getTopic().toString());
         assertEquals("world", ((SessionRegistry.PublishedMessage) after.dequeue()).getTopic().toString());
         assertTrue(after.isEmpty(), "should be empty");
+    }
+
+    @Test
+    public void givenAClientIdEndingInMetaWhenBothClientsUseDurableQueuesThenTheirMapsDoNotCollide() {
+        // "sensor_meta"'s message map ("queue_sensor_meta") previously aliased "sensor"'s metadata map,
+        // corrupting both durable queues. Each queue must now keep only its own messages.
+        H2PersistentQueue victim = new H2PersistentQueue(this.mvStore, "sensor");
+        H2PersistentQueue attacker = new H2PersistentQueue(this.mvStore, "sensor_meta");
+
+        victim.enqueue(createMessage("victim-message"));
+        attacker.enqueue(createMessage("attacker-message"));
+
+        assertEquals("victim-message", ((SessionRegistry.PublishedMessage) victim.dequeue()).getTopic().toString());
+        assertTrue(victim.isEmpty(), "victim queue must be unaffected by the other client");
+        assertEquals("attacker-message", ((SessionRegistry.PublishedMessage) attacker.dequeue()).getTopic().toString());
+        assertTrue(attacker.isEmpty(), "attacker queue must hold only its own message");
+    }
+
+    @Test
+    public void givenALegacyMetadataMapWhenTheQueueIsOpenedThenHeadAndTailAreMigratedAndTheLegacyMapRemoved() {
+        // Reproduce a pre-rename store: messages under "queue_test" and head/tail under "queue_test_meta".
+        final MVMap.Builder<Long, SessionRegistry.EnqueuedMessage> messageTypeBuilder =
+            new MVMap.Builder<Long, SessionRegistry.EnqueuedMessage>().valueType(new EnqueuedMessageValueType());
+        MVMap<Long, SessionRegistry.EnqueuedMessage> legacyMessages = this.mvStore.openMap("queue_test", messageTypeBuilder);
+        legacyMessages.put(0L, createMessage("Hello"));
+        legacyMessages.put(1L, createMessage("crazy"));
+        legacyMessages.put(2L, createMessage("world"));
+        MVMap<String, Long> legacyMetadata = this.mvStore.openMap("queue_test_meta");
+        legacyMetadata.put("head", 3L);
+        legacyMetadata.put("tail", 1L);
+
+        H2PersistentQueue sut = new H2PersistentQueue(this.mvStore, "test");
+
+        // tail was migrated as 1, so the already-dequeued "Hello" is not replayed.
+        assertEquals("crazy", ((SessionRegistry.PublishedMessage) sut.dequeue()).getTopic().toString());
+        assertEquals("world", ((SessionRegistry.PublishedMessage) sut.dequeue()).getTopic().toString());
+        assertTrue(sut.isEmpty(), "should be empty after draining the migrated queue");
+        assertFalse(this.mvStore.hasMap("queue_test_meta"), "the legacy metadata map must be removed");
     }
 }


### PR DESCRIPTION
## What does this PR do?
Gives the H2 persistent-queue **message** map and **metadata** map disjoint name spaces so no client id can make one client's map collide with another's. The metadata map moves from `queue_<id>_meta` to `queuemeta_<id>`; the message map name (`queue_<id>`) is unchanged, and a one-time migration copies the head/tail pointers out of any legacy `queue_<id>_meta` map and drops it.

## Why is it important?
`H2QueueRepository.getOrCreateQueue(clientId)` uses the raw client id as the queue name, and `H2PersistentQueue` built both map names by suffixing a shared `queue_` prefix:

```
messageMap  = "queue_" + queueName            // Long -> EnqueuedMessage
metadataMap = "queue_" + queueName + "_meta"   // String -> Long (head/tail)
```

Because the names are plain concatenations, `"queue_" + "sensor_meta"` is byte-identical to `"queue_" + "sensor" + "_meta"`. A client that connects with a durable (non-clean) session and client id `sensor_meta` therefore opens, as its **message** map, the exact MVStore map that client `sensor` uses as its **metadata** map — two sessions reading/writing the same map with incompatible value types. The result is durable cross-session corruption of client `sensor`'s queue (message loss, misdelivery, or a failed reload), and a crafted collision can expose the victim's queued content. Client ids are never validated, so only knowing/guessing a victim id is required.

`queuemeta_` differs from `queue_` at a fixed position (index 5: `'m'` vs `'_'`), so a message map name can never equal a metadata map name for any queue name — the collision is impossible by construction rather than by input validation.

**Upgrade / compatibility:** message maps keep their names, so durable messages are preserved. On first open of an existing queue, `migrateLegacyMetadata` copies `head`/`tail` from the old `queue_<id>_meta` map into the new one and removes the legacy map (removal is required so a later `<id>_meta` client can't reopen the leftover as its message map). Stores with no durable queues are unaffected.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective (`H2PersistentQueueTest`: a `sensor` / `sensor_meta` non-collision test and a legacy-metadata migration test)

## How to test this PR locally
`mvn -pl broker -Dtest=H2PersistentQueueTest test`. (On Windows the unrelated `SegmentPersistentQueueTest` reports a pre-existing `@TempDir` cleanup error on the mmap-ed store; it is not touched by this change.)

Reported privately via the repository Security Advisory; opening this hardening fix as a public PR per the maintainer. cc @andsel
