### PR TITLE
Double CONNECT must close the connection as protocol error

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.19-SNAPSHOT
+   [fix] A second connect message sent on an already connected client must close the connection as a protocol error. (#969)
    [fix] Add a length max to the session queues, this avoids that a slow ACK-ing subscriber consumes too much resources if a fast publisher is sending to same topic.
    [fix] Add a guard for topic depth against static max value. It checks on PUB and SUB message receive and also at SubscriptionDirectory level.
    [fix] Guarded pattern ACL substitution against a null username to prevent a remote DoS. (#963)

--- a/broker/src/main/java/io/moquette/broker/MQTTConnection.java
+++ b/broker/src/main/java/io/moquette/broker/MQTTConnection.java
@@ -210,6 +210,21 @@ final class MQTTConnection {
             abortConnection(CONNECTION_REFUSED_UNACCEPTABLE_PROTOCOL_VERSION);
             return PostOffice.RouteResult.failed(clientId);
         }
+        
+        if (connected) {
+            // processing a CONNECT on an already connected channel
+            //[MQTT-3.1.0-2] a second CONNECT is a protocol violation
+            if (isMqtt3xProtocol(msg)) {
+                channel.close().addListener(CLOSE_ON_FAILURE);
+            } else {
+                // it an MQTT 5 CONNECT
+                final ConnAckPropertiesBuilder builder = prepareConnAckPropertiesBuilder(false, clientId);
+                builder.reasonString("Received second CONNECT on already connected channel");
+                abortConnectionV5(CONNECTION_REFUSED_PROTOCOL_ERROR, builder);
+            }
+            return PostOffice.RouteResult.failed(clientId);
+        }
+        
         boolean cleanSession = msg.variableHeader().isCleanSession();
         final boolean serverGeneratedClientId;
         if (clientId == null || clientId.isEmpty()) {
@@ -285,7 +300,7 @@ final class MQTTConnection {
     }
 
     // only for test
-    protected void assignSendQuota(Quota quota) {
+    void assignSendQuota(Quota quota) {
         this.sendQuota = quota;
     }
 
@@ -506,6 +521,11 @@ final class MQTTConnection {
 
     private boolean isProtocolVersion(MqttVersion version) {
         return protocolVersion == version.protocolLevel();
+    }
+    
+    private boolean isMqtt3xProtocol(MqttConnectMessage connectMessage) {
+        return isProtocolVersion(connectMessage, MqttVersion.MQTT_3_1) ||
+            isProtocolVersion(connectMessage, MqttVersion.MQTT_3_1_1);
     }
 
     private void abortConnection(MqttConnectReturnCode returnCode) {

--- a/broker/src/test/java/io/moquette/integration/DoubleConnectOnSameChannelTest.java
+++ b/broker/src/test/java/io/moquette/integration/DoubleConnectOnSameChannelTest.java
@@ -1,0 +1,132 @@
+package io.moquette.integration;
+
+import io.moquette.broker.Server;
+import io.moquette.broker.config.IConfig;
+import io.moquette.broker.config.MemoryConfig;
+import io.moquette.testclient.Client;
+import io.netty.handler.codec.mqtt.*;
+import org.awaitility.Awaitility;
+import org.awaitility.Durations;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies broker behaviour when a second CONNECT is sent on an already-established channel.
+ *
+ * MQTT 3.1.1 §3.1 [MQTT-3.1.0-2]: the server MUST treat it as a protocol violation and disconnect the client.
+ * MQTT 5.0   §3.1.4 [MQTT-3.1.0-2]: it is a Protocol Error; the broker must send DISCONNECT (0x82) then close.
+ */
+public class DoubleConnectOnSameChannelTest {
+
+    Server broker;
+    Client lowLevelClient;
+    IConfig config;
+
+    @TempDir
+    Path tempFolder;
+
+    @BeforeAll
+    public static void beforeTests() {
+        Awaitility.setDefaultTimeout(Durations.TWO_SECONDS);
+    }
+
+    @BeforeEach
+    public void setUp() throws IOException {
+        String dbPath = IntegrationUtils.tempH2Path(tempFolder);
+        broker = new Server();
+        final Properties configProps = IntegrationUtils.prepareTestProperties(dbPath);
+        config = new MemoryConfig(configProps);
+        broker.startServer(config);
+        lowLevelClient = new Client("localhost");
+    }
+
+    @AfterEach
+    public void tearDown() throws InterruptedException {
+        lowLevelClient.shutdownConnection();
+        Thread.sleep(300);
+        broker.stopServer();
+    }
+
+    // [MQTT-3.1.0-2] MQTT 3.1.1 §3.1
+    @Test
+    public void givenConnectedMqtt311ClientWhenASecondConnectIsSentOnSameChannelThenChannelIsForciblyClose()
+        throws InterruptedException {
+        lowLevelClient.sendMessage(buildConnect311("client1"));
+
+        MqttMessage firstResponse = lowLevelClient.receiveNextMessage(Duration.ofSeconds(2));
+        assertNotNull(firstResponse, "First CONNECT must receive a CONNACK");
+        assertTrue(firstResponse instanceof MqttConnAckMessage, "Response to first CONNECT must be CONNACK");
+        assertEquals(MqttConnectReturnCode.CONNECTION_ACCEPTED,
+            ((MqttConnAckMessage) firstResponse).variableHeader().connectReturnCode(),
+            "First CONNECT must be accepted");
+
+        // second CONNECT on the same already-connected channel
+        lowLevelClient.sendMessage(buildConnect311("client2"));
+
+        Awaitility.await("Channel must be closed after second CONNECT [MQTT-3.1.0-2]")
+            .atMost(2, TimeUnit.SECONDS)
+            .until(lowLevelClient::isConnectionLost);
+    }
+
+    // [MQTT-3.1.0-2] MQTT 5.0 §3.1.4
+    @Test
+    public void givenConnectedMqtt5ClientWhenASecondConnectIsSentOnSameChannelThenBrokerSendsDisconnectProtocolErrorAndClosesChannel()
+        throws InterruptedException {
+        lowLevelClient.sendMessage(buildConnect5("client1"));
+
+        MqttMessage firstResponse = lowLevelClient.receiveNextMessage(Duration.ofSeconds(2));
+        assertNotNull(firstResponse, "First CONNECT must receive a CONNACK");
+        assertTrue(firstResponse instanceof MqttConnAckMessage, "Response to first CONNECT must be CONNACK");
+        assertEquals(MqttConnectReturnCode.CONNECTION_ACCEPTED,
+            ((MqttConnAckMessage) firstResponse).variableHeader().connectReturnCode(),
+            "First CONNECT must be accepted");
+
+        // second CONNECT on the same already-connected channel
+        lowLevelClient.sendMessage(buildConnect5("client2"));
+
+        // broker must send DISCONNECT with reason code Protocol Error (0x82) before closing
+        MqttMessage brokerResponse = lowLevelClient.receiveNextMessage(Duration.ofSeconds(2));
+        assertNotNull(brokerResponse, "Broker must send CONNACK after second CONNECT with specific error code");
+        assertEquals(MqttMessageType.CONNACK, brokerResponse.fixedHeader().messageType(),
+            "Broker response to second CONNECT must be CONNACK");
+        MqttConnAckVariableHeader connAckHeader =
+            (MqttConnAckVariableHeader) brokerResponse.variableHeader();
+        assertEquals(MqttConnectReturnCode.CONNECTION_REFUSED_PROTOCOL_ERROR, connAckHeader.connectReturnCode(),
+            "CONNACK reason code must be Protocol Error (0x82)");
+
+        Awaitility.await("Channel must be closed after CONNACK [MQTT-3.1.0-2]")
+            .atMost(2, TimeUnit.SECONDS)
+            .until(lowLevelClient::isConnectionLost);
+    }
+
+    private static MqttConnectMessage buildConnect311(String clientId) {
+        MqttFixedHeader fixedHeader = new MqttFixedHeader(
+            MqttMessageType.CONNECT, false, MqttQoS.AT_MOST_ONCE, false, 0);
+        MqttConnectVariableHeader varHeader = new MqttConnectVariableHeader(
+            MqttVersion.MQTT_3_1_1.protocolName(), MqttVersion.MQTT_3_1_1.protocolLevel(),
+            false, false, false, 0, false, true, 60);
+        MqttConnectPayload payload = new MqttConnectPayload(clientId, null, null, null, (byte[]) null);
+        return new MqttConnectMessage(fixedHeader, varHeader, payload);
+    }
+
+    private static MqttConnectMessage buildConnect5(String clientId) {
+        return MqttMessageBuilders.connect()
+            .protocolVersion(MqttVersion.MQTT_5)
+            .clientId(clientId)
+            .keepAlive(60)
+            .build();
+    }
+}


### PR DESCRIPTION
## Release notes
Fix CONNECT processing to close as protocol error a channel on which a second CONNECT is sent.


## What does this PR do?

Updates the `processConnect` to error the connection and close channel as soon as possible when a second CONNECT is received on an already connected channel.

## Why is it important/What is the impact to the user?

Respect the MQTT protocol specification MQTT-3.1.0-2.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have made corresponding changes to the documentation~~
- ~~[ ] I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the Changelog if it's a feature or a fix that has to be reported
