### PR TITLE
Expose MQTT properties on InterceptPublishMessage

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,4 +1,5 @@
 Version 0.19-SNAPSHOT
+   [feature] InterceptPublishMessage exposes the MQTT properties of the intercepted PUBLISH message. (#918)
    [feature] Pass remote address of a client when notify to interceptor handlers, adding it into InterceptConnectMessage. (#946)
    [fix] A second connect message sent on an already connected client must close the connection as a protocol error. (#969)
    [fix] Add a length max to the session queues, this avoids that a slow ACK-ing subscriber consumes too much resources if a fast publisher is sending to same topic.

--- a/broker/src/main/java/io/moquette/interception/messages/InterceptPublishMessage.java
+++ b/broker/src/main/java/io/moquette/interception/messages/InterceptPublishMessage.java
@@ -17,6 +17,7 @@
 package io.moquette.interception.messages;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.mqtt.MqttProperties;
 import io.netty.handler.codec.mqtt.MqttPublishMessage;
 
 public class InterceptPublishMessage extends InterceptAbstractMessage {
@@ -38,6 +39,10 @@ public class InterceptPublishMessage extends InterceptAbstractMessage {
 
     public ByteBuf getPayload() {
         return msg.payload();
+    }
+
+    public MqttProperties getProperties() {
+        return msg.variableHeader().properties();
     }
 
     public String getClientID() {

--- a/broker/src/test/java/io/moquette/interception/messages/InterceptPublishMessageTest.java
+++ b/broker/src/test/java/io/moquette/interception/messages/InterceptPublishMessageTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2012-2026 The original author or authors
+ * ------------------------------------------------------
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ *
+ * The Eclipse Public License is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * The Apache License v2.0 is available at
+ * http://www.opensource.org/licenses/apache2.0.php
+ *
+ * You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.moquette.interception.messages;
+
+import io.moquette.broker.Utils;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.mqtt.MqttMessageBuilders;
+import io.netty.handler.codec.mqtt.MqttProperties;
+import io.netty.handler.codec.mqtt.MqttPublishMessage;
+import io.netty.handler.codec.mqtt.MqttQoS;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class InterceptPublishMessageTest {
+
+    @Test
+    public void exposesMqttPropertiesOfTheInterceptedPublish() {
+        MqttPublishMessage publish = publishWithProperties();
+
+        InterceptPublishMessage intercepted = new InterceptPublishMessage(publish, "cli1234", "usr1234");
+
+        verifyProperties(intercepted.getProperties());
+        publish.release();
+    }
+
+    @Test
+    public void exposesMqttPropertiesOnTheDuplicatePassedToEachHandler() {
+        MqttPublishMessage publish = publishWithProperties();
+
+        MqttPublishMessage duplicate = (MqttPublishMessage) Utils.retainDuplicate(publish, "test");
+        InterceptPublishMessage intercepted = new InterceptPublishMessage(duplicate, "cli1234", "usr1234");
+
+        verifyProperties(intercepted.getProperties());
+        duplicate.release();
+        publish.release();
+    }
+
+    private MqttPublishMessage publishWithProperties() {
+        MqttProperties properties = new MqttProperties();
+        properties.add(new MqttProperties.StringProperty(
+            MqttProperties.MqttPropertyType.CONTENT_TYPE.value(), "application/json"));
+        properties.add(new MqttProperties.StringProperty(
+            MqttProperties.MqttPropertyType.RESPONSE_TOPIC.value(), "response/topic"));
+        properties.add(new MqttProperties.UserProperty("origin", "sensor-42"));
+
+        return MqttMessageBuilders.publish()
+            .topicName("telemetry/temperature")
+            .qos(MqttQoS.AT_MOST_ONCE)
+            .payload(Unpooled.copiedBuffer("{\"celsius\":21}", StandardCharsets.UTF_8))
+            .properties(properties)
+            .build();
+    }
+
+    private void verifyProperties(MqttProperties exposed) {
+        MqttProperties.MqttProperty contentType =
+            exposed.getProperty(MqttProperties.MqttPropertyType.CONTENT_TYPE.value());
+        assertEquals("application/json", ((MqttProperties.StringProperty) contentType).value());
+
+        MqttProperties.MqttProperty responseTopic =
+            exposed.getProperty(MqttProperties.MqttPropertyType.RESPONSE_TOPIC.value());
+        assertEquals("response/topic", ((MqttProperties.StringProperty) responseTopic).value());
+
+        List<? extends MqttProperties.MqttProperty> userProperties =
+            exposed.getProperties(MqttProperties.MqttPropertyType.USER_PROPERTY.value());
+        assertEquals(1, userProperties.size());
+        MqttProperties.UserProperty userProperty = (MqttProperties.UserProperty) userProperties.get(0);
+        assertEquals("origin", userProperty.value().key);
+        assertEquals("sensor-42", userProperty.value().value);
+    }
+}


### PR DESCRIPTION
## Release notes

InterceptPublishMessage exposes the MQTT properties of the intercepted PUBLISH message.

## What does this PR do?

Adds `getProperties()` to `InterceptPublishMessage`, returning the `MqttProperties` of the
intercepted PUBLISH. The properties survive the `retainedDuplicate()` that
`BrokerInterceptor.notifyTopicPublished` makes for each handler, because the duplicate shares the
variable header.

## Why is it important/What is the impact to the user?

An intercept handler can read only the topic, payload, client id and username. Everything else the
publisher attached to an MQTT 5 PUBLISH is lost on the way to the handler: user properties, content
type, response topic, correlation data, payload format indicator and message expiry interval. The
broker forwards all of them to subscribers, so the interception API is the only place where this
metadata disappears.

With the accessor an embedder can:

- read the content type the publisher declared and parse the payload accordingly, instead of
  guessing or agreeing on a format out of band
- read the user properties the publisher set, and use them for routing, filtering, tracing or
  tenant tagging without adding its own header inside the payload
- take part in request and response flows, because the response topic and the correlation data are
  now visible to the handler
- honour the message expiry interval when it stores or forwards the message

Today the only way to reach these values is to stop using the interception API and add a Netty
handler or a custom pipeline, which means giving up the hook the broker offers for exactly this
purpose.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the Changelog if it's a feature or a fix that has to be reported

## How to test this PR locally

    ./mvnw -pl broker test -Dtest=InterceptPublishMessageTest

The two tests read the properties back from a PUBLISH built with them, once directly and once
through the retained duplicate that `BrokerInterceptor` makes for each handler.

## Related issues

- Closes #918

## Use cases

- An embedder bridges MQTT traffic to another system, for example Kafka or an HTTP endpoint, and
  carries the publisher user properties over as message headers instead of dropping them.
- An audit or archive handler stores the content type and the correlation data next to the payload,
  so a later reader can decode the payload and match a reply to its request.
- A handler that observes a request and response flow reads the response topic to know where the
  answer is expected, without parsing the payload.
- A handler that reads no properties keeps working unchanged, because the accessor only adds a
  method.
